### PR TITLE
Add sample JS Trace Id Emitter app

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}

--- a/sample-apps/js-sdk-aws-XRay/.gitignore
+++ b/sample-apps/js-sdk-aws-XRay/.gitignore
@@ -1,0 +1,3 @@
+# lock files
+node_modules/
+package-lock.json

--- a/sample-apps/js-sdk-aws-XRay/Dockerfile
+++ b/sample-apps/js-sdk-aws-XRay/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:14
+
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+
+RUN npm install
+
+COPY . .
+
+EXPOSE 8080
+
+CMD [ "node", "server.js" ]

--- a/sample-apps/js-sdk-aws-XRay/Dockerfile
+++ b/sample-apps/js-sdk-aws-XRay/Dockerfile
@@ -8,6 +8,4 @@ RUN npm install
 
 COPY . .
 
-EXPOSE 8080
-
 CMD [ "node", "server.js" ]

--- a/sample-apps/js-sdk-aws-XRay/client.js
+++ b/sample-apps/js-sdk-aws-XRay/client.js
@@ -24,19 +24,12 @@ function makeRequest() {
       });
     });
   });
-  returnTraceId(span);
 
   // The process must live for at least the interval past any traces that
   // must be exported, or some risk being lost if they are recorded after the
   // last export.
   console.log('Sleeping 5 seconds before shutdown to ensure all records are flushed.');
   setTimeout(() => { console.log('Completed.'); }, 5000);
-}
-
-function returnTraceId(span) {
-  const traceId = span.context().traceId.toString();
-  const xrayTraceId = "1-" + traceId.substring(0, 8) + "-" + traceId.substring(8);
-  return xrayTraceId;
 }
 
 makeRequest();

--- a/sample-apps/js-sdk-aws-XRay/client.js
+++ b/sample-apps/js-sdk-aws-XRay/client.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const tracer = require('./tracer')('example-http-client');
+// eslint-disable-next-line import/order
+const http = require('http');
+
+/** A function which makes requests and handles response. */
+function makeRequest() {
+  // span corresponds to outgoing requests. Here, we have manually created
+  // the span, which is created to track work that happens outside of the
+  // request lifecycle entirely.
+  const span = tracer.startSpan('makeRequest');
+  tracer.withSpan(span, () => {
+    http.get({
+      host: 'localhost',
+      port: 8080,
+      path: '/helloworld',
+    }, (response) => {
+      const body = [];
+      response.on('data', (chunk) => body.push(chunk));
+      response.on('end', () => {
+        console.log(body.toString());
+        span.end();
+      });
+    });
+  });
+  returnTraceId(span);
+
+  // The process must live for at least the interval past any traces that
+  // must be exported, or some risk being lost if they are recorded after the
+  // last export.
+  console.log('Sleeping 5 seconds before shutdown to ensure all records are flushed.');
+  setTimeout(() => { console.log('Completed.'); }, 5000);
+}
+
+function returnTraceId(span) {
+  const traceId = span.context().traceId.toString();
+  const xrayTraceId = "1-" + traceId.substring(0, 8) + "-" + traceId.substring(8);
+  return xrayTraceId;
+}
+
+makeRequest();

--- a/sample-apps/js-sdk-aws-XRay/package.json
+++ b/sample-apps/js-sdk-aws-XRay/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "sample-app",
+  "version": "0.11.0",
+  "description": "Sample Instrumentation of X-Ray",
+  "main": "index.js",
+  "scripts": {
+    "zipkin:server": "cross-env EXPORTER=zipkin node ./server.js",
+    "zipkin:client": "cross-env EXPORTER=zipkin node ./client.js",
+    "jaeger:server": "cross-env EXPORTER=jaeger node ./server.js",
+    "jaeger:client": "cross-env EXPORTER=jaeger node ./client.js"
+  },
+  "keywords": [
+    "opentelemetry",
+    "http",
+    "tracing"
+  ],
+  "engines": {
+    "node": ">=8"
+  },
+  "dependencies": {
+    "@lerna/link": "^3.21.0",
+    "@opentelemetry/api": "^0.11.0",
+    "@opentelemetry/context-base": "^0.11.0",
+    "@opentelemetry/core": "^0.11.0",
+    "@opentelemetry/exporter-collector": "^0.11.0",
+    "@opentelemetry/node": "^0.11.0",
+    "@opentelemetry/plugin-http": "^0.11.0",
+    "@opentelemetry/propagator-jaeger": "^0.9.0",
+    "@opentelemetry/resource-detector-aws": "^0.10.3-alpha.28",
+    "@opentelemetry/resource-detector-gcp": "^0.10.3-alpha.28",
+    "@opentelemetry/resources": "^0.11.0",
+    "@opentelemetry/sdk-node": "^0.11.0",
+    "@opentelemetry/tracing": "^0.11.0",
+    "kelvin-id-generator-aws-xray": "^0.1.0",
+    "kelvin-propagator-aws-xray": "^0.1.0"
+  },
+  "devDependencies": {
+    "cross-env": "^6.0.0"
+  }
+}

--- a/sample-apps/js-sdk-aws-XRay/package.json
+++ b/sample-apps/js-sdk-aws-XRay/package.json
@@ -4,10 +4,7 @@
   "description": "Sample Instrumentation of X-Ray",
   "main": "index.js",
   "scripts": {
-    "zipkin:server": "cross-env EXPORTER=zipkin node ./server.js",
-    "zipkin:client": "cross-env EXPORTER=zipkin node ./client.js",
-    "jaeger:server": "cross-env EXPORTER=jaeger node ./server.js",
-    "jaeger:client": "cross-env EXPORTER=jaeger node ./client.js"
+    "install" : "npm install git+https://github.com/aws-observability/aws-otel-js/tree/master/packages/opentelemetry-id-generator-aws-xray.git"
   },
   "keywords": [
     "opentelemetry",
@@ -31,8 +28,6 @@
     "@opentelemetry/resources": "^0.11.0",
     "@opentelemetry/sdk-node": "^0.11.0",
     "@opentelemetry/tracing": "^0.11.0",
-    "kelvin-id-generator-aws-xray": "^0.1.0",
-    "kelvin-propagator-aws-xray": "^0.1.0"
   },
   "devDependencies": {
     "cross-env": "^6.0.0"

--- a/sample-apps/js-sdk-aws-XRay/server.js
+++ b/sample-apps/js-sdk-aws-XRay/server.js
@@ -33,17 +33,26 @@ function handleRequest(request, response) {
     const body = [];
     request.on('error', (err) => console.log(err));
     request.on('data', (chunk) => body.push(chunk));
+    // const traceIdJson = returnTraceIdJson(span);
     request.on('end', () => {
       // deliberately sleeping to mock some action.
       setTimeout(() => {
         span.end();
-        response.end('hello world!');
+        response.end(JSON.stringify(returnTraceIdJson(span)));
       }, 2000);
     });
   } catch (err) {
     console.error(err);
     span.end();
   }
+
+  function returnTraceIdJson(span) {
+    const traceId = span.context().traceId.toString();
+    const xrayTraceId = "1-" + traceId.substring(0, 8) + "-" + traceId.substring(8);
+    const traceIdJson = { "traceId" : xrayTraceId }
+    return traceIdJson;
+  }
+  
 }
 
-startServer(8080);
+startServer(process.env.LISTEN_ADDRESS);

--- a/sample-apps/js-sdk-aws-XRay/server.js
+++ b/sample-apps/js-sdk-aws-XRay/server.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const tracer = require('./tracer')('example-http-server');
+// eslint-disable-next-line import/order
+const http = require('http');
+
+/** Starts a HTTP server that receives requests on sample server port. */
+function startServer(port) {
+  // Creates a server
+  const server = http.createServer(handleRequest);
+  // Starts the server
+  server.listen(port, (err) => {
+    if (err) {
+      throw err;
+    }
+    console.log(`Node HTTP listening on ${port}`);
+  });
+}
+
+/** A function which handles requests and send response. */
+function handleRequest(request, response) {
+  const currentSpan = tracer.getCurrentSpan();
+  // display traceid in the terminal
+  console.log(`traceid: ${currentSpan.context().traceId}`);
+  const span = tracer.startSpan('handleRequest', {
+    parent: currentSpan,
+    kind: 1, // server
+    attributes: { key: 'value' },
+  });
+  // Annotate our span to capture metadata about the operation
+  span.addEvent('invoking handleRequest');
+  try {
+    const body = [];
+    request.on('error', (err) => console.log(err));
+    request.on('data', (chunk) => body.push(chunk));
+    request.on('end', () => {
+      // deliberately sleeping to mock some action.
+      setTimeout(() => {
+        span.end();
+        response.end('hello world!');
+      }, 2000);
+    });
+  } catch (err) {
+    console.error(err);
+    span.end();
+  }
+}
+
+startServer(8080);

--- a/sample-apps/js-sdk-aws-XRay/tracer.js
+++ b/sample-apps/js-sdk-aws-XRay/tracer.js
@@ -1,0 +1,46 @@
+'use strict'
+
+const { BasicTracerProvider, SimpleSpanProcessor, ConsoleSpanExporter } = require("@opentelemetry/tracing");
+const { NodeTracerProvider } = require('@opentelemetry/node');
+const { CollectorTraceExporter } = require('@opentelemetry/exporter-collector');
+
+const { AWSXRayPropagator } = require('kelvin-propagator-aws-xray');
+const { AwsXRayIdGenerator } = require('kelvin-id-generator-aws-xray');
+
+const { context, propagation, trace } = require("@opentelemetry/api");
+const { awsEc2Detector } = require('@opentelemetry/resource-detector-aws');
+const { detectResources } = require('@opentelemetry/resources/build/src/platform/node/detect-resources');
+
+module.exports = (serviceName) => {
+  // set global propagator
+  propagation.setGlobalPropagator(new AWSXRayPropagator());
+  
+  var resources;
+  detectResources({ detectors: [awsEc2Detector] })
+  .then((res) => {
+    resources = res;
+    console.log("detected resource: " + JSON.stringify(resources));
+  })
+    .catch((e) => {console.log(e);});
+
+  // create a provider for activating and tracking with AWS IdGenerator
+  const tracerConfig = {
+    idGenerator: new AwsXRayIdGenerator(),
+    resources: resources
+  };
+  const tracerProvider = new NodeTracerProvider(tracerConfig);
+
+  // add OTLP exporter
+  const otlpExporter = new CollectorTraceExporter({
+    serviceName: serviceName,
+    protocolNode: 2,
+  });
+  tracerProvider.addSpanProcessor(new SimpleSpanProcessor(otlpExporter));
+  tracerProvider.addSpanProcessor(new SimpleSpanProcessor(new ConsoleSpanExporter()));
+
+  // Register the tracer
+  tracerProvider.register();
+
+  // Return an tracer instance
+  return trace.getTracer("awsxray-tests");
+}


### PR DESCRIPTION
**What is the point of this pull request?**
This pull request adds a sample JavaScript app which is able to emit trace Ids in order to run in the testing framework to validate traceIds to AWS X-Ray. 