### PR TITLE
ecscontainermetrics: update otconfig, expected metrics, and Validator logic

### DIFF
--- a/terraform/template/otconfig/ecscontainermetric_otconfig.tpl
+++ b/terraform/template/otconfig/ecscontainermetric_otconfig.tpl
@@ -6,12 +6,40 @@ processors:
       include:
         match_type: strict
         metric_names:
+          - ecs.task.memory.reserved
           - ecs.task.memory.utilized
+          - ecs.task.cpu.reserved
+          - ecs.task.cpu.utilized
+          - ecs.task.network.rate.rx
+          - ecs.task.network.rate.tx
+          - ecs.task.storage.read_bytes
+          - ecs.task.storage.write_bytes
   metricstransform:
     transforms:
+      - metric_name: ecs.task.memory.reserved
+        action: update
+        new_name: ecs.task.memory.reserved_${testing_id}
       - metric_name: ecs.task.memory.utilized
         action: update
         new_name: ecs.task.memory.utilized_${testing_id}
+      - metric_name: ecs.task.cpu.reserved
+        action: update
+        new_name: ecs.task.cpu.reserved_${testing_id}
+      - metric_name: ecs.task.cpu.utilized
+        action: update
+        new_name: ecs.task.cpu.utilized_${testing_id}
+      - metric_name: ecs.task.network.rate.rx
+        action: update
+        new_name: ecs.task.network.rate.rx_${testing_id}
+      - metric_name: ecs.task.network.rate.tx
+        action: update
+        new_name: ecs.task.network.rate.tx_${testing_id}
+      - metric_name: ecs.task.storage.read_bytes
+        action: update
+        new_name: ecs.task.storage.read_bytes_${testing_id}
+      - metric_name: ecs.task.storage.write_bytes
+        action: update
+        new_name: ecs.task.storage.write_bytes_${testing_id}
 exporters:
   logging:
     loglevel: debug

--- a/validator/src/main/java/com/amazon/aoc/validators/MetricValidator.java
+++ b/validator/src/main/java/com/amazon/aoc/validators/MetricValidator.java
@@ -184,10 +184,16 @@ public class MetricValidator implements IValidator {
   private List<Metric> rollupMetric(List<Metric> metricList) {
     List<Metric> rollupMetricList = new ArrayList<>();
     for (Metric metric : metricList) {
-      // get otellib dimension out
-      // assuming the first dimension is otellib, if not the validation fails
-      Dimension otellibDimension = metric.getDimensions().get(0);
-      boolean otelLibDimensionExisted = otellibDimension.getName().equals(DEFAULT_DIMENSION_NAME);
+      Dimension otellibDimension = new Dimension();
+      boolean otelLibDimensionExisted = false;
+
+      if (metric.getDimensions().size() > 0){
+        // get otellib dimension out
+        // assuming the first dimension is otellib, if not the validation fails
+        otellibDimension = metric.getDimensions().get(0);
+        otelLibDimensionExisted = otellibDimension.getName().equals(DEFAULT_DIMENSION_NAME);
+      }
+      
       if (otelLibDimensionExisted) {
         metric.getDimensions().remove(0);
       }

--- a/validator/src/main/java/com/amazon/aoc/validators/MetricValidator.java
+++ b/validator/src/main/java/com/amazon/aoc/validators/MetricValidator.java
@@ -187,7 +187,7 @@ public class MetricValidator implements IValidator {
       Dimension otellibDimension = new Dimension();
       boolean otelLibDimensionExisted = false;
 
-      if (metric.getDimensions().size() > 0){
+      if (metric.getDimensions().size() > 0) {
         // get otellib dimension out
         // assuming the first dimension is otellib, if not the validation fails
         otellibDimension = metric.getDimensions().get(0);

--- a/validator/src/main/resources/expected-data-template/ecsContainerExpectedMetric.mustache
+++ b/validator/src/main/resources/expected-data-template/ecsContainerExpectedMetric.mustache
@@ -1,22 +1,32 @@
 -
+  metricName: ecs.task.memory.reserved_{{testingId}}
+  namespace: {{metricNamespace}}
+  dimensions:
+-
   metricName: ecs.task.memory.utilized_{{testingId}}
   namespace: {{metricNamespace}}
   dimensions:
-    -
-      name: ecs.cluster
-      value: "{{ecsContext.ecsClusterName}}"
-    -
-      name: ecs.service
-      value: "undefined"
-    -
-      name: ecs.task-arn
-      value: "SKIP"
-    -
-      name: ecs.task-definition-family
-      value: "{{ecsContext.ecsTaskDefFamily}}"
-    -
-      name: ecs.task-definition-version
-      value: "{{ecsContext.ecsTaskDefVersion}}"
-    -
-      name: ecs.task-id
-      value: "SKIP"
+-
+  metricName: ecs.task.cpu.reserved_{{testingId}}
+  namespace: {{metricNamespace}}
+  dimensions:
+-
+  metricName: ecs.task.cpu.utilized_{{testingId}}
+  namespace: {{metricNamespace}}
+  dimensions:
+-
+  metricName: ecs.task.network.rate.rx_{{testingId}}
+  namespace: {{metricNamespace}}
+  dimensions:
+-
+  metricName: ecs.task.network.rate.tx_{{testingId}}
+  namespace: {{metricNamespace}}
+  dimensions:
+-
+  metricName: ecs.task.storage.read_bytes_{{testingId}}
+  namespace: {{metricNamespace}}
+  dimensions:
+-
+  metricName: ecs.task.storage.write_bytes_{{testingId}}
+  namespace: {{metricNamespace}}
+  dimensions:


### PR DESCRIPTION
This change updates-
1. OT Config for ECS Container Metrics Receiver
2. Expected metrics for ECS Container Metrics Receiver
3. Validation logic for empty dimensions

Note: Once the dimensions/label settings feature is available in the exporter, we will create another PR to update our otconfig and expected metrics file.