### PR TITLE
Enable otlp http exporter integration test cases for all the testing platforms

### DIFF
--- a/terraform/testcases/otlp_http_exporter_metric_mock/otconfig.tpl
+++ b/terraform/testcases/otlp_http_exporter_metric_mock/otconfig.tpl
@@ -1,0 +1,22 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:${grpc_port}
+
+processors:
+  batch/metrics:
+    timeout: 60s
+
+exporters:
+  logging:
+    loglevel: debug
+  otlphttp:
+    metrics_endpoint: "https://${mock_endpoint}"
+    insecure: true
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      exporters: [otlphttp]

--- a/terraform/testcases/otlp_http_exporter_metric_mock/parameters.tfvars
+++ b/terraform/testcases/otlp_http_exporter_metric_mock/parameters.tfvars
@@ -1,0 +1,2 @@
+# data type will be emitted. Possible values: metric or trace
+soaking_data_mode = "metric"

--- a/terraform/testcases/otlp_http_exporter_trace_mock/otconfig.tpl
+++ b/terraform/testcases/otlp_http_exporter_trace_mock/otconfig.tpl
@@ -1,0 +1,22 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:${grpc_port}
+
+processors:
+  batch/metrics:
+    timeout: 60s
+
+exporters:
+  logging:
+    loglevel: debug
+  otlphttp:
+    traces_endpoint: "https://${mock_endpoint}"
+    insecure: true
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [otlphttp]

--- a/terraform/testcases/otlp_http_exporter_trace_mock/parameters.tfvars
+++ b/terraform/testcases/otlp_http_exporter_trace_mock/parameters.tfvars
@@ -1,0 +1,2 @@
+# data type will be emitted. Possible values: metric or trace
+soaking_data_mode = "trace"


### PR DESCRIPTION
Description:
Enable otlp http exporter integration test cases for all the testing platforms

Link to tracking Issue:
#104

Testing:
Tested on local with `aws-otel-test-framework`
`cd terraform/mock; terraform init && terraform apply -var="testcase=../testcases/otlp_http_exporter_trace_mock"`
`cd terraform/mock; terraform init && terraform apply -var="testcase=../testcases/otlp_http_exporter_metric_mock"`