### PR TITLE
Add test cases for Datadog exporter

### DIFF
--- a/terraform/testcases/datadog_exporter_metric_mock/otconfig.tpl
+++ b/terraform/testcases/datadog_exporter_metric_mock/otconfig.tpl
@@ -1,0 +1,25 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:${grpc_port}
+
+processors:
+  batch:
+    timeout: 10s
+
+exporters:
+  logging:
+    loglevel: debug
+  datadog:
+    api:
+      key: testapikey
+    metrics:
+      endpoint: "https://${mock_endpoint}"
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [datadog]

--- a/terraform/testcases/datadog_exporter_metric_mock/parameters.tfvars
+++ b/terraform/testcases/datadog_exporter_metric_mock/parameters.tfvars
@@ -1,0 +1,2 @@
+# data type will be emitted. Possible values: metric or trace
+soaking_data_mode = "metric"

--- a/terraform/testcases/datadog_exporter_trace_mock/otconfig.tpl
+++ b/terraform/testcases/datadog_exporter_trace_mock/otconfig.tpl
@@ -1,0 +1,27 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:${grpc_port}
+
+processors:
+  batch:
+    timeout: 10s
+
+exporters:
+  logging:
+    loglevel: debug
+  datadog:
+    api:
+      key: testapikey
+    metrics:
+      endpoint: "https://${mock_endpoint}"
+    traces:
+      endpoint: "https://${mock_endpoint}"
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [datadog]

--- a/terraform/testcases/datadog_exporter_trace_mock/parameters.tfvars
+++ b/terraform/testcases/datadog_exporter_trace_mock/parameters.tfvars
@@ -1,0 +1,2 @@
+# data type will be emitted. Possible values: metric or trace
+soaking_data_mode = "trace"


### PR DESCRIPTION
**Description:**

Add integration testing for metrics and traces for the Datadog exporter﻿

**Testing:**

Ran it locally with
```
cd terraform/mock; terraform init && terraform apply -var="testcase=../testcases/datadog_exporter_metric_mock"
cd terraform/mock; terraform init && terraform apply -var="testcase=../testcases/datadog_exporter_trace_mock"
```

checked that the changes made sense