### PR TITLE
Abstract AOC as a service

### DIFF
--- a/terraform/testcases/otlp_mock/otconfig.tpl
+++ b/terraform/testcases/otlp_mock/otconfig.tpl
@@ -2,7 +2,7 @@ receivers:
   otlp:
     protocols:
       grpc:
-        endpoint: 0.0.0.0:55680
+        endpoint: 0.0.0.0:${grpc_port}
 
 exporters:
   logging:


### PR DESCRIPTION
This PR abstracts the AOC container pod as a service to allow for future use cases that requires AOC to run as a service instead of a sidecar. We expose 2 ports (TCP/gRPC and UDP) which run in separate services, because k8s does not support a service with mixed protocols currently ([ref](https://github.com/kubernetes/kubernetes/pull/64471)).