### PR TITLE
Add test case for Dynatrace metric exporter

### DIFF
--- a/terraform/testcases/dynatrace_exporter_metric_mock/otconfig.tpl
+++ b/terraform/testcases/dynatrace_exporter_metric_mock/otconfig.tpl
@@ -1,0 +1,24 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:${grpc_port}
+
+processors:
+  batch:
+    timeout: 10s
+
+exporters:
+  logging:
+    loglevel: debug
+  dynatrace:
+    api_token: mytoken
+    endpoint: "https://${mock_endpoint}"
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [dynatrace]
+

--- a/terraform/testcases/dynatrace_exporter_metric_mock/parameters.tfvars
+++ b/terraform/testcases/dynatrace_exporter_metric_mock/parameters.tfvars
@@ -1,0 +1,3 @@
+# data type will be emitted. Possible values: metric or trace
+soaking_data_mode = "metric"
+


### PR DESCRIPTION
Description:

Add integration testing for metrics for the Dynatrace exporter﻿

Testing:

Ran tests locally using `terraform apply -var="testcase=../testcases/dynatrace_exporter_metric_mock"`

/cc @arminru