### PR TITLE
Add test case for New Relic metric exporter.

### DIFF
--- a/terraform/testcases/newrelic_exporter_metric_mock/otconfig.tpl
+++ b/terraform/testcases/newrelic_exporter_metric_mock/otconfig.tpl
@@ -1,0 +1,23 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:${grpc_port}
+
+processors:
+  batch/metrics:
+    timeout: 60s
+
+exporters:
+  logging:
+    loglevel: debug
+  newrelic:
+    apikey: super-secret-api-key
+    metrics_url_override: "https://${mock_endpoint}"
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [batch/metrics]
+      exporters: [logging, newrelic]

--- a/terraform/testcases/newrelic_exporter_metric_mock/parameters.tfvars
+++ b/terraform/testcases/newrelic_exporter_metric_mock/parameters.tfvars
@@ -1,0 +1,2 @@
+# data type will be emitted. Possible values: metric or trace
+soaking_data_mode = "metric"


### PR DESCRIPTION
**Description:**
Add integration testing for traces for the New Relic exporter

**Testing:**
Verified output/ changes after running the tests locally using the following commands:

```
cd aws-otel-test-framework/terraform/mock
terraform init
terraform apply -var="testcase=../testcases/newrelic_exporter_metric_mock" 
terraform destroy
```