### PR TITLE
Add Testcases for Prometheus Pipeline

### DIFF
--- a/terraform/basic_components/main.tf
+++ b/terraform/basic_components/main.tf
@@ -73,6 +73,10 @@ data "template_file" "otconfig" {
     testing_id = var.testing_id
     grpc_port = module.common.grpc_port
     udp_port = module.common.udp_port
+    cortex_instance_endpoint = module.common.cortex_instance_endpoint
+    sample_app_listen_address_ip = module.common.sample_app_listen_address_ip
+    sample_app_listen_address_port = module.common.sample_app_listen_address_port
+    sample_app_lb_port = module.common.sample_app_lb_port
 
     mock_endpoint = var.mocked_endpoint
   }

--- a/terraform/basic_components/main.tf
+++ b/terraform/basic_components/main.tf
@@ -73,7 +73,7 @@ data "template_file" "otconfig" {
     testing_id = var.testing_id
     grpc_port = module.common.grpc_port
     udp_port = module.common.udp_port
-    cortex_instance_endpoint = module.common.cortex_instance_endpoint
+    cortex_instance_endpoint = var.cortex_instance_endpoint
     sample_app_listen_address_ip = module.common.sample_app_listen_address_ip
     sample_app_listen_address_port = module.common.sample_app_listen_address_port
     sample_app_lb_port = module.common.sample_app_lb_port

--- a/terraform/basic_components/main.tf
+++ b/terraform/basic_components/main.tf
@@ -74,10 +74,7 @@ data "template_file" "otconfig" {
     grpc_port = module.common.grpc_port
     udp_port = module.common.udp_port
     cortex_instance_endpoint = var.cortex_instance_endpoint
-    sample_app_listen_address_ip = module.common.sample_app_listen_address_ip
-    sample_app_listen_address_port = module.common.sample_app_listen_address_port
-    sample_app_lb_port = module.common.sample_app_lb_port
-
+    
     mock_endpoint = var.mocked_endpoint
   }
 }

--- a/terraform/basic_components/variables.tf
+++ b/terraform/basic_components/variables.tf
@@ -29,3 +29,6 @@ variable "mocked_endpoint" {
 variable "sample_app" {
 }
 
+variable "cortex_instance_endpoint" {
+
+}

--- a/terraform/common.tf
+++ b/terraform/common.tf
@@ -54,3 +54,7 @@ variable "debug" {
 variable "soaking_data_mode" {
   default = "metric"
 }
+
+variable "sample_app_mode" {
+  default = "push"
+}

--- a/terraform/common/outputs.tf
+++ b/terraform/common/outputs.tf
@@ -105,3 +105,8 @@ output "sample_app_ecr_repo_name" {
 output "mocked_server_ecr_repo_name" {
   value = "otel-test/mocked-server"
 }
+
+output "cortex_instance_endpoint" {
+  # change to your cortex endpoint
+  value = ""
+}

--- a/terraform/common/outputs.tf
+++ b/terraform/common/outputs.tf
@@ -105,8 +105,3 @@ output "sample_app_ecr_repo_name" {
 output "mocked_server_ecr_repo_name" {
   value = "otel-test/mocked-server"
 }
-
-output "cortex_instance_endpoint" {
-  # change to your cortex endpoint
-  value = ""
-}

--- a/terraform/ec2/main.tf
+++ b/terraform/ec2/main.tf
@@ -31,6 +31,8 @@ module "basic_components" {
   mocked_endpoint = var.mock_endpoint
 
   sample_app = var.sample_app
+
+  cortex_instance_endpoint = var.cortex_instance_endpoint
 }
 
 provider "aws" {

--- a/terraform/ec2/variables.tf
+++ b/terraform/ec2/variables.tf
@@ -98,3 +98,8 @@ variable "testing_type" {
 variable "canary" {
   default = false
 }
+
+variable "cortex_instance_endpoint" {
+  # change to your cortex endpoint
+  default = ""
+}

--- a/terraform/ecs/main.tf
+++ b/terraform/ecs/main.tf
@@ -32,6 +32,8 @@ module "basic_components" {
   mocked_endpoint = "localhost/put-data"
 
   sample_app = var.sample_app
+
+  cortex_instance_endpoint = var.cortex_instance_endpoint
 }
 
 locals {

--- a/terraform/ecs/variables.tf
+++ b/terraform/ecs/variables.tf
@@ -21,3 +21,7 @@ variable "sample_app_callable" {
   default = true
 }
 
+variable "cortex_instance_endpoint" {
+  # change to your cortex endpoint
+  default = ""
+}

--- a/terraform/eks/main.tf
+++ b/terraform/eks/main.tf
@@ -36,6 +36,8 @@ module "basic_components" {
   mocked_endpoint = "localhost/put-data"
 
   sample_app = var.sample_app
+
+  cortex_instance_endpoint = var.cortex_instance_endpoint
 }
 
 locals {
@@ -140,7 +142,7 @@ resource "kubernetes_cluster_role_binding" "aoc-role-binding" {
 
 # deploy aoc and mocked server
 resource "kubernetes_deployment" "aoc_deployment" {
-  count = var.sample_app_mode == "pull" ? 0 : 1
+  count = var.sample_app_mode == "push" ? 1 : 0
 
   metadata {
     name = "aoc"
@@ -184,13 +186,6 @@ resource "kubernetes_deployment" "aoc_deployment" {
           }
         }
 
-        volume {
-          name = kubernetes_service_account.aoc-role.default_secret_name
-          secret {
-            secret_name = kubernetes_service_account.aoc-role.default_secret_name
-          }
-        }
-
         container {
           name = "mocked-server"
           image = local.mocked_server_image
@@ -220,12 +215,6 @@ resource "kubernetes_deployment" "aoc_deployment" {
           }
 
           volume_mount {
-            mount_path = "/var/run/secrets/kubernetes.io/serviceaccount"
-            name = kubernetes_service_account.aoc-role.default_secret_name
-            read_only = true
-          }
-
-          volume_mount {
             mount_path = "/aoc"
             name = "otel-config"
           }
@@ -240,33 +229,11 @@ resource "kubernetes_deployment" "aoc_deployment" {
   }
 }
 
-# create service upon the mocked server
-resource "kubernetes_service" "mocked_server_service" {
-  count = var.sample_app_mode == "pull" ? 0 : 1
-  
-  metadata {
-    name = "mocked-server"
-    namespace = kubernetes_namespace.aoc_ns.metadata[0].name
-  }
-  spec {
-    selector = {
-      app = kubernetes_deployment.aoc_deployment[0].metadata[0].labels.app
-    }
-
-    type = "LoadBalancer"
-
-    port {
-      port = 80
-      target_port = 8080
-    }
-  }
-}
-
 # create service upon AOC (GRPC port)
 # NOTE: we have to create a service for each port protocol type because
 # Kubernetes does not support mixed protocols: https://github.com/kubernetes/kubernetes/pull/64471.
 resource "kubernetes_service" "aoc_grpc_service" {
-  count = var.sample_app_mode == "pull" ? 0 : 1
+  count = var.sample_app_mode == "push" ? 1 : 0
   
   metadata {
     name = "aoc-grpc"
@@ -287,7 +254,7 @@ resource "kubernetes_service" "aoc_grpc_service" {
 
 # create service upon AOC (UDP port)
 resource "kubernetes_service" "aoc_udp_service" {
-  count = var.sample_app_mode == "pull" ? 0 : 1
+  count = var.sample_app_mode == "push" ? 1 : 0
   
   metadata {
     name = "aoc-udp"
@@ -308,7 +275,7 @@ resource "kubernetes_service" "aoc_udp_service" {
 
 # deploy sample app
 resource "kubernetes_deployment" "sample_app_deployment" {
-  count = var.sample_app_mode == "pull" ? 0 : 1
+  count = var.sample_app_mode == "push" ? 1 : 0
   
   metadata {
     name = "sample-app"
@@ -396,155 +363,19 @@ resource "kubernetes_deployment" "sample_app_deployment" {
   }
 }
 
-# create service upon the sample app
-resource "kubernetes_service" "sample_app_service" {
-  count = var.sample_app_mode == "pull" ? 0 : 1
-  
-  metadata {
-    name = "sample-app"
-    namespace = kubernetes_namespace.aoc_ns.metadata[0].name
-  }
-  spec {
-    selector = {
-      app = kubernetes_deployment.sample_app_deployment[0].metadata[0].labels.app
-    }
-
-    type = "LoadBalancer"
-
-    port {
-      port = module.common.sample_app_lb_port
-      target_port = module.common.sample_app_listen_address_port
-    }
-  }
-}
-
 ##########################################
-# Pull mode deployments
+# Common components for both push and pull modes
 ##########################################
-
-# deploy aoc and mocked server
-resource "kubernetes_deployment" "pull_mode_aoc_deployment" {
-  count = var.sample_app_mode == "pull" ? 1 : 0
-
-  metadata {
-    name = "aoc"
-    namespace = kubernetes_namespace.aoc_ns.metadata[0].name
-    labels = {
-      app = "aoc"
-    }
-  }
-
-  spec {
-    replicas = 1
-
-    selector {
-      match_labels = {
-        app = "aoc"
-      }
-    }
-
-    template {
-      metadata {
-        labels = {
-          app = "aoc"
-        }
-      }
-
-      spec {
-        service_account_name = "aoc-role"
-
-        volume {
-          name = "otel-config"
-          config_map {
-            name = kubernetes_config_map.aoc_config_map.metadata[0].name
-          }
-        }
-
-        volume {
-          name = "mocked-server-cert"
-          config_map {
-            name = kubernetes_config_map.mocked_server_cert.metadata[0].name
-          }
-        }
-
-        volume {
-          name = kubernetes_service_account.aoc-role.default_secret_name
-          secret {
-            secret_name = kubernetes_service_account.aoc-role.default_secret_name
-          }
-        }
-
-        container {
-          name = "mocked-server"
-          image = local.mocked_server_image
-
-          readiness_probe {
-            http_get {
-              path = "/"
-              port = 8080
-            }
-            initial_delay_seconds = 10
-            period_seconds = 5
-          }
-        }
-
-        # aoc
-        container {
-          name = "aoc"
-          image = module.common.aoc_image
-          image_pull_policy = "Always"
-          args = [
-            "--config=/aoc/aoc-config.yml"]
-
-          env {
-            name = "SAMPLE_APP_HOST"
-            value = kubernetes_service.pull_mode_sample_app_service[0].load_balancer_ingress.0.hostname
-          }
-
-          env {
-            name = "SAMPLE_APP_PORT"
-            value = module.common.sample_app_lb_port
-          }
-
-          resources {
-            requests {
-              cpu = "0.2"
-              memory = "256Mi"
-            }
-          }
-
-          volume_mount {
-            mount_path = "/var/run/secrets/kubernetes.io/serviceaccount"
-            name = kubernetes_service_account.aoc-role.default_secret_name
-            read_only = true
-          }
-
-          volume_mount {
-            mount_path = "/aoc"
-            name = "otel-config"
-          }
-
-          volume_mount {
-            mount_path = "/etc/pki/tls/certs"
-            name = "mocked-server-cert"
-          }
-        }
-      }
-    }
-  }
-}
 
 # create service upon the mocked server
-resource "kubernetes_service" "pull_mode_mocked_server_service" {
-  count = var.sample_app_mode == "pull" ? 1 : 0
-
+resource "kubernetes_service" "mocked_server_service" {
   metadata {
     name = "mocked-server"
     namespace = kubernetes_namespace.aoc_ns.metadata[0].name
   }
   spec {
     selector = {
-      app = kubernetes_deployment.pull_mode_aoc_deployment[0].metadata[0].labels.app
+      app = var.sample_app_mode == "push" ? kubernetes_deployment.aoc_deployment[0].metadata[0].labels.app : kubernetes_deployment.pull_mode_aoc_deployment[0].metadata[0].labels.app
     }
 
     type = "LoadBalancer"
@@ -556,91 +387,15 @@ resource "kubernetes_service" "pull_mode_mocked_server_service" {
   }
 }
 
-# deploy sample app
-resource "kubernetes_deployment" "pull_mode_sample_app_deployment" {
-  count = var.sample_app_mode == "pull" ? 1 : 0
-
-  metadata {
-    name = "sample-app"
-    namespace = kubernetes_namespace.aoc_ns.metadata[0].name
-    labels = {
-      app = "sample-app"
-    }
-  }
-
-  spec {
-    replicas = 1
-
-    selector {
-      match_labels = {
-        app = "sample-app"
-      }
-    }
-
-    template {
-      metadata {
-        labels = {
-          app = "sample-app"
-        }
-      }
-
-      spec {
-        # sample app
-        container {
-          name = "sample-app"
-          image= local.eks_pod_config["image"]
-          image_pull_policy = "Always"
-          command = length(local.eks_pod_config["command"]) != 0 ? local.eks_pod_config["command"] : null
-          args = length(local.eks_pod_config["args"]) != 0 ? local.eks_pod_config["args"] : null
-
-          env {
-            name = "AWS_REGION"
-            value = var.region
-          }
-
-          env {
-            name = "INSTANCE_ID"
-            value = module.common.testing_id
-          }
-
-          env {
-            name = "LISTEN_ADDRESS"
-            value = "${module.common.sample_app_listen_address_ip}:${module.common.sample_app_listen_address_port}"
-          }
-
-          resources {
-            requests {
-              cpu = "0.2"
-              memory = "256Mi"
-            }
-
-          }
-
-          readiness_probe {
-            http_get {
-              path = "/"
-              port = module.common.sample_app_listen_address_port
-            }
-            initial_delay_seconds = 10
-            period_seconds = 5
-          }
-        }
-      }
-    }
-  }
-}
-
 # create service upon the sample app
-resource "kubernetes_service" "pull_mode_sample_app_service" {
-  count = var.sample_app_mode == "pull" ? 1 : 0
-
+resource "kubernetes_service" "sample_app_service" {
   metadata {
     name = "sample-app"
     namespace = kubernetes_namespace.aoc_ns.metadata[0].name
   }
   spec {
     selector = {
-      app = kubernetes_deployment.pull_mode_sample_app_deployment[0].metadata[0].labels.app
+      app = var.sample_app_mode == "push" ? kubernetes_deployment.sample_app_deployment[0].metadata[0].labels.app : kubernetes_deployment.pull_mode_sample_app_deployment[0].metadata[0].labels.app
     }
 
     type = "LoadBalancer"
@@ -662,10 +417,10 @@ module "validator" {
   region = var.region
   testing_id = module.common.testing_id
   metric_namespace = "${module.common.otel_service_namespace}/${module.common.otel_service_name}"
-  sample_app_endpoint = var.sample_app_mode == "pull" ? "http://${kubernetes_service.pull_mode_sample_app_service[0].load_balancer_ingress.0.hostname}:${module.common.sample_app_lb_port}" : "http://${kubernetes_service.sample_app_service[0].load_balancer_ingress.0.hostname}:${module.common.sample_app_lb_port}"
-  mocked_server_validating_url = var.sample_app_mode == "pull" ? "http://${kubernetes_service.pull_mode_mocked_server_service[0].load_balancer_ingress.0.hostname}/check-data" : "http://${kubernetes_service.mocked_server_service[0].load_balancer_ingress.0.hostname}/check-data"
+  sample_app_endpoint = "http://${kubernetes_service.sample_app_service.load_balancer_ingress.0.hostname}:${module.common.sample_app_lb_port}"
+  mocked_server_validating_url = "http://${kubernetes_service.mocked_server_service.load_balancer_ingress.0.hostname}/check-data"
 
-  cortex_instance_endpoint = module.common.cortex_instance_endpoint
+  cortex_instance_endpoint = var.cortex_instance_endpoint
 
   aws_access_key_id = var.aws_access_key_id
   aws_secret_access_key = var.aws_secret_access_key

--- a/terraform/eks/pull_mode_deployment.tf
+++ b/terraform/eks/pull_mode_deployment.tf
@@ -1,0 +1,189 @@
+##########################################
+# Pull mode deployments
+##########################################
+
+# deploy aoc and mocked server
+resource "kubernetes_deployment" "pull_mode_aoc_deployment" {
+  count = var.sample_app_mode == "pull" ? 1 : 0
+
+  metadata {
+    name = "aoc"
+    namespace = kubernetes_namespace.aoc_ns.metadata[0].name
+    labels = {
+      app = "aoc"
+    }
+  }
+
+  spec {
+    replicas = 1
+
+    selector {
+      match_labels = {
+        app = "aoc"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          app = "aoc"
+        }
+      }
+
+      spec {
+        service_account_name = "aoc-role"
+
+        volume {
+          name = "otel-config"
+          config_map {
+            name = kubernetes_config_map.aoc_config_map.metadata[0].name
+          }
+        }
+
+        volume {
+          name = "mocked-server-cert"
+          config_map {
+            name = kubernetes_config_map.mocked_server_cert.metadata[0].name
+          }
+        }
+
+        volume {
+          name = kubernetes_service_account.aoc-role.default_secret_name
+          secret {
+            secret_name = kubernetes_service_account.aoc-role.default_secret_name
+          }
+        }
+
+        container {
+          name = "mocked-server"
+          image = local.mocked_server_image
+
+          readiness_probe {
+            http_get {
+              path = "/"
+              port = 8080
+            }
+            initial_delay_seconds = 10
+            period_seconds = 5
+          }
+        }
+
+        # aoc
+        container {
+          name = "aoc"
+          image = module.common.aoc_image
+          image_pull_policy = "Always"
+          args = [
+            "--config=/aoc/aoc-config.yml"]
+
+          env {
+            name = "SAMPLE_APP_HOST"
+            value = kubernetes_service.sample_app_service.load_balancer_ingress.0.hostname
+          }
+
+          env {
+            name = "SAMPLE_APP_PORT"
+            value = module.common.sample_app_lb_port
+          }
+
+          resources {
+            requests {
+              cpu = "0.2"
+              memory = "256Mi"
+            }
+          }
+
+          volume_mount {
+            mount_path = "/var/run/secrets/kubernetes.io/serviceaccount"
+            name = kubernetes_service_account.aoc-role.default_secret_name
+            read_only = true
+          }
+
+          volume_mount {
+            mount_path = "/aoc"
+            name = "otel-config"
+          }
+
+          volume_mount {
+            mount_path = "/etc/pki/tls/certs"
+            name = "mocked-server-cert"
+          }
+        }
+      }
+    }
+  }
+}
+
+# deploy sample app
+resource "kubernetes_deployment" "pull_mode_sample_app_deployment" {
+  count = var.sample_app_mode == "pull" ? 1 : 0
+
+  metadata {
+    name = "sample-app"
+    namespace = kubernetes_namespace.aoc_ns.metadata[0].name
+    labels = {
+      app = "sample-app"
+    }
+  }
+
+  spec {
+    replicas = 1
+
+    selector {
+      match_labels = {
+        app = "sample-app"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          app = "sample-app"
+        }
+      }
+
+      spec {
+        # sample app
+        container {
+          name = "sample-app"
+          image= local.eks_pod_config["image"]
+          image_pull_policy = "Always"
+          command = length(local.eks_pod_config["command"]) != 0 ? local.eks_pod_config["command"] : null
+          args = length(local.eks_pod_config["args"]) != 0 ? local.eks_pod_config["args"] : null
+
+          env {
+            name = "AWS_REGION"
+            value = var.region
+          }
+
+          env {
+            name = "INSTANCE_ID"
+            value = module.common.testing_id
+          }
+
+          env {
+            name = "LISTEN_ADDRESS"
+            value = "${module.common.sample_app_listen_address_ip}:${module.common.sample_app_listen_address_port}"
+          }
+
+          resources {
+            requests {
+              cpu = "0.2"
+              memory = "256Mi"
+            }
+
+          }
+
+          readiness_probe {
+            http_get {
+              path = "/"
+              port = module.common.sample_app_listen_address_port
+            }
+            initial_delay_seconds = 10
+            period_seconds = 5
+          }
+        }
+      }
+    }
+  }
+}

--- a/terraform/eks/variables.tf
+++ b/terraform/eks/variables.tf
@@ -17,7 +17,7 @@ variable "eks_cluster_name" {
   default = "aoc-test-eks-ec2"
 }
 
-variable "sample_app_mode" {
-  default = "push"
+variable "cortex_instance_endpoint" {
+  # change to your cortex endpoint
+  default = ""
 }
-

--- a/terraform/eks/variables.tf
+++ b/terraform/eks/variables.tf
@@ -17,4 +17,7 @@ variable "eks_cluster_name" {
   default = "aoc-test-eks-ec2"
 }
 
+variable "sample_app_mode" {
+  default = "push"
+}
 

--- a/terraform/templates/defaults/validator_docker_compose.tpl
+++ b/terraform/templates/defaults/validator_docker_compose.tpl
@@ -29,4 +29,5 @@ services:
       - "--alarm-names=${cpu_alarm}"
       - "--alarm-names=${mem_alarm}"
       - "--alarm-names=${incoming_packets_alarm}"
+      - "--cortex-instance-endpoint=${cortex_instance_endpoint}"
 

--- a/terraform/testcases/prometheus_sd/otconfig.tpl
+++ b/terraform/testcases/prometheus_sd/otconfig.tpl
@@ -1,0 +1,28 @@
+receivers:
+  prometheus:
+    config:
+      scrape_configs:
+      - job_name: 'kubernetes-service-endpoints'
+        kubernetes_sd_configs:
+        - role: endpoints
+        relabel_configs:
+        - source_labels: [ __meta_kubernetes_namespace ]
+          action: keep
+          regex: "aoc-ns-${testing_id}"
+        - source_labels: [ __meta_kubernetes_pod_label_app ]
+          action: keep
+          regex: "sample-app"
+exporters:
+  awsprometheusremotewrite:
+    endpoint: ${cortex_instance_endpoint}/api/v1/remote_write
+    aws_auth:
+      region: ${region}
+      service: "aps"
+    timeout: 10s
+  logging:
+    loglevel: debug
+service:
+  pipelines:
+    metrics:
+     receivers: [prometheus]
+     exporters: [awsprometheusremotewrite, logging]

--- a/terraform/testcases/prometheus_sd/parameters.tfvars
+++ b/terraform/testcases/prometheus_sd/parameters.tfvars
@@ -1,7 +1,7 @@
 # this file is defined in validator/src/main/resources/validations
 validation_config="prometheus-sd-validation.yml"
 
-sample_app="prometheus""
+sample_app="prometheus"
 
 # change to your cortex endpoint
 cortex_instance_endpoint=""

--- a/terraform/testcases/prometheus_sd/parameters.tfvars
+++ b/terraform/testcases/prometheus_sd/parameters.tfvars
@@ -1,0 +1,9 @@
+# this file is defined in validator/src/main/resources/validations
+validation_config="prometheus-sd-validation.yml"
+
+sample_app="prometheus""
+
+# change to your cortex endpoint
+cortex_instance_endpoint=""
+
+sample_app_mode="pull"

--- a/terraform/testcases/prometheus_static/otconfig.tpl
+++ b/terraform/testcases/prometheus_static/otconfig.tpl
@@ -1,0 +1,23 @@
+receivers:
+  prometheus:
+    config:
+      global:
+        scrape_interval: 15s
+      scrape_configs:
+      - job_name: "test-prometheus-sample-app"
+        static_configs:
+        - targets: [ $SAMPLE_APP_HOST:$SAMPLE_APP_PORT ]
+exporters:
+  awsprometheusremotewrite:
+    endpoint: ${cortex_instance_endpoint}/api/v1/remote_write
+    aws_auth:
+      region: ${region}
+      service: "aps"
+    timeout: 10s
+  logging:
+    loglevel: debug
+service:
+  pipelines:
+    metrics:
+     receivers: [prometheus]
+     exporters: [awsprometheusremotewrite, logging]

--- a/terraform/testcases/prometheus_static/parameters.tfvars
+++ b/terraform/testcases/prometheus_static/parameters.tfvars
@@ -1,0 +1,9 @@
+# this file is defined in validator/src/main/resources/validations
+validation_config="prometheus-metric-validation.yml"
+
+sample_app="prometheus""
+
+# change to your cortex endpoint
+cortex_instance_endpoint=""
+
+sample_app_mode="pull"

--- a/terraform/testcases/prometheus_static/parameters.tfvars
+++ b/terraform/testcases/prometheus_static/parameters.tfvars
@@ -1,7 +1,7 @@
 # this file is defined in validator/src/main/resources/validations
 validation_config="prometheus-metric-validation.yml"
 
-sample_app="prometheus""
+sample_app="prometheus"
 
 # change to your cortex endpoint
 cortex_instance_endpoint=""

--- a/terraform/validation/main.tf
+++ b/terraform/validation/main.tf
@@ -46,7 +46,7 @@ data "template_file" "docker_compose" {
     mem_alarm = var.mem_alarm
     incoming_packets_alarm = var.incoming_packets_alarm
 
-
+    cortex_instance_endpoint = var.cortex_instance_endpoint
   }
 
 }

--- a/terraform/validation/variables.tf
+++ b/terraform/validation/variables.tf
@@ -77,3 +77,7 @@ variable "aws_access_key_id" {
 variable "aws_secret_access_key" {
   default = ""
 }
+
+variable "cortex_instance_endpoint" {
+  default = ""
+}

--- a/validator/src/main/resources/validations/prometheus-metric-validation.yml
+++ b/validator/src/main/resources/validations/prometheus-metric-validation.yml
@@ -1,0 +1,3 @@
+-
+  validationType: "prom-metric-scraping"
+  expectedResultPath: "/expected_metrics"

--- a/validator/src/main/resources/validations/prometheus-metric-validation.yml
+++ b/validator/src/main/resources/validations/prometheus-metric-validation.yml
@@ -1,3 +1,4 @@
 -
-  validationType: "prom-metric-scraping"
+  validationType: "prom-metric"
+  shouldValidateMetricValue: true
   expectedResultPath: "/expected_metrics"

--- a/validator/src/main/resources/validations/prometheus-sd-validation.yml
+++ b/validator/src/main/resources/validations/prometheus-sd-validation.yml
@@ -1,0 +1,3 @@
+-
+  validationType: "prom-metric-sd"
+  expectedResultPath: "/expected_metrics"

--- a/validator/src/main/resources/validations/prometheus-sd-validation.yml
+++ b/validator/src/main/resources/validations/prometheus-sd-validation.yml
@@ -1,3 +1,4 @@
 -
-  validationType: "prom-metric-sd"
+  validationType: "prom-metric"
+  shouldValidateMetricValue: false
   expectedResultPath: "/expected_metrics"


### PR DESCRIPTION
We want to verify that the Prometheus OTel pipeline and the Prometheus server have complete parity.

Related PRs:
* PR for sample app: [Link](https://github.com/aws-observability/aws-otel-test-framework/pull/131)
* PR for validator: [Link](https://github.com/aws-observability/aws-otel-test-framework/pull/129)

PR 3/3:

In this PR, we add the parameter and AOC configuration files to run the metric scraping and service discovery testcases.