### PR TITLE
use release S3 bucket for canary test

### DIFF
--- a/terraform/canary/main.tf
+++ b/terraform/canary/main.tf
@@ -42,6 +42,7 @@ module "ec2_setup" {
   testcase = var.testcase
   validation_config = var.validation_config
   sample_app_image = var.sample_app_image != "" ? var.sample_app_image : module.basic_components.sample_app_image
+  package_s3_bucket = "aws-otel-collector"
   skip_validation = false
   canary = true
 

--- a/terraform/canary/variables.tf
+++ b/terraform/canary/variables.tf
@@ -16,10 +16,6 @@
 ## right now there's no good way to share variables across modules,
 ## so we have to define some of the common vars like region, otconfig_path in each module
 
-variable "package_s3_bucket" {
-  default = "aws-otel-collector"
-}
-
 variable "testing_ami" {
   default = "canary_linux"
 }

--- a/terraform/canary/variables.tf
+++ b/terraform/canary/variables.tf
@@ -17,7 +17,7 @@
 ## so we have to define some of the common vars like region, otconfig_path in each module
 
 variable "package_s3_bucket" {
-  default = "aws-otel-collector-test"
+  default = "aws-otel-collector"
 }
 
 variable "testing_ami" {


### PR DESCRIPTION
**Description:**
Canary should use release S3 bucket for canary test

**Tests:**
Tested manually, e.g.
```
cd terraform/canary && terraform init && terraform apply -auto-approve -lock=false -var-file="../testcases/otlp_metric/parameters.tfvars" -var="aoc_version=latest" -var="testcase=../testcases/otlp_metric" -var="testing_ami=canary_windows"
```