### PR TITLE
Fix configuration of SignalFx metric exporter

### DIFF
--- a/terraform/testcases/signalfx_exporter_metric_mock/otconfig.tpl
+++ b/terraform/testcases/signalfx_exporter_metric_mock/otconfig.tpl
@@ -15,7 +15,9 @@ exporters:
   logging:
     loglevel: debug
   signalfx:
-    endpoint: "https://${mock_endpoint}"
+    access_token: dummytoken
+    ingest_url: "https://${mock_endpoint}"
+    api_url: "http://localhost/dummy_url"
 
 service:
   pipelines:


### PR DESCRIPTION
The configuration was missing the required options. Presumably this is the reason why
the build of https://github.com/aws-observability/aws-otel-collector/pull/181 failed.