### PR TITLE
added Prometheus mock test

### DIFF
--- a/terraform/mock/main.tf
+++ b/terraform/mock/main.tf
@@ -88,6 +88,7 @@ resource "null_resource" "run_docker_compose" {
 module "validator" {
   source = "../validation"
 
+  validation_config = var.validation_config
   region = var.region
   testing_id = module.common.testing_id
   sample_app_endpoint = "http://172.17.0.1:${module.common.sample_app_listen_address_port}"

--- a/terraform/templates/local/docker_compose.tpl
+++ b/terraform/templates/local/docker_compose.tpl
@@ -26,6 +26,8 @@ services:
       - AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
       - AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
       - GODEBUG=x509ignoreCN=0
+      - SAMPLE_APP_PORT=${sample_app_external_port}
+      - SAMPLE_APP_HOST=172.17.0.1
     depends_on:
       - mocked-server
 

--- a/terraform/templates/local/docker_compose_from_source.tpl
+++ b/terraform/templates/local/docker_compose_from_source.tpl
@@ -26,6 +26,8 @@ services:
       - AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
       - AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
       - GODEBUG=x509ignoreCN=0
+      - SAMPLE_APP_PORT=${sample_app_external_port}
+      - SAMPLE_APP_HOST=172.17.0.1
     depends_on:
       - mocked-server
 

--- a/terraform/testcases/prometheus_mock/otconfig.tpl
+++ b/terraform/testcases/prometheus_mock/otconfig.tpl
@@ -1,0 +1,17 @@
+receivers:
+  prometheus:
+    config:
+      global:
+        scrape_interval: 15s
+      scrape_configs:
+      - job_name: "test-pipeline-job"
+        static_configs:
+        - targets: [ $SAMPLE_APP_HOST:$SAMPLE_APP_PORT ]
+exporters:
+  awsprometheusremotewrite:
+    endpoint: "https://${mock_endpoint}"
+service:
+  pipelines:
+    metrics:
+     receivers: [prometheus]
+     exporters: [awsprometheusremotewrite]

--- a/terraform/testcases/prometheus_mock/parameters.tfvars
+++ b/terraform/testcases/prometheus_mock/parameters.tfvars
@@ -1,0 +1,3 @@
+validation_config="default-mocked-server-prometheus-validation.yml"
+
+sample_app="prometheus"

--- a/validator/src/main/java/com/amazon/aoc/validators/MockedServerValidator.java
+++ b/validator/src/main/java/com/amazon/aoc/validators/MockedServerValidator.java
@@ -30,8 +30,10 @@ public class MockedServerValidator implements IValidator {
 
   @Override
   public void validate() throws Exception {
-    // hit the endpoint to generate data
-    caller.callSampleApp();
+    // hit the endpoint to generate data if need be
+    if (caller != null) {
+      caller.callSampleApp();
+    }
 
     // hit the mocked server to validate to if it receives data
     callMockedServer();

--- a/validator/src/main/resources/validations/default-mocked-server-prometheus-validation.yml
+++ b/validator/src/main/resources/validations/default-mocked-server-prometheus-validation.yml
@@ -1,0 +1,4 @@
+-
+  validationType: "mocked-server"
+  # no call to prometheus sample app needed to produce metrics
+  callingType: "none" 


### PR DESCRIPTION
This is the mock test that will be run on github workflows. 

This does not depend on any of the other Prometheus-related PRs. 

Note that we do not need to make a call to the Prometheus sample app in order for it to generate data hence why some changes were required in the validator.