### PR TITLE
made cluster role binding and service account unique, and added delay…

### DIFF
--- a/terraform/eks/main.tf
+++ b/terraform/eks/main.tf
@@ -113,7 +113,7 @@ locals {
 
 resource "kubernetes_service_account" "aoc-role" {
   metadata {
-    name = "aoc-role"
+    name = "aoc-role-${module.common.testing_id}"
     namespace = kubernetes_namespace.aoc_ns.metadata[0].name
   }
 
@@ -122,7 +122,7 @@ resource "kubernetes_service_account" "aoc-role" {
 
 resource "kubernetes_cluster_role_binding" "aoc-role-binding" {
   metadata {
-    name = "aoc-role-binding"
+    name = "aoc-role-binding-${module.common.testing_id}"
   }
   role_ref {
     api_group = "rbac.authorization.k8s.io"
@@ -131,7 +131,7 @@ resource "kubernetes_cluster_role_binding" "aoc-role-binding" {
   }
   subject {
     kind      = "ServiceAccount"
-    name      = "aoc-role"
+    name      = "aoc-role-${module.common.testing_id}"
     namespace = kubernetes_namespace.aoc_ns.metadata[0].name
   }
 }
@@ -170,7 +170,7 @@ resource "kubernetes_deployment" "aoc_deployment" {
 
 
       spec {
-        service_account_name = "aoc-role"
+        service_account_name = "aoc-role-${module.common.testing_id}"
 
         volume {
           name = "otel-config"

--- a/terraform/eks/pull_mode_deployment.tf
+++ b/terraform/eks/pull_mode_deployment.tf
@@ -2,9 +2,15 @@
 # Pull mode deployments
 ##########################################
 
+resource "time_sleep" "wait_until_sample_app_produces_metrics" {
+  create_duration = "30s"
+  depends_on = [kubernetes_service.sample_app_service]
+}
+
 # deploy aoc and mocked server
 resource "kubernetes_deployment" "pull_mode_aoc_deployment" {
   count = var.sample_app_mode == "pull" ? 1 : 0
+  depends_on = [time_sleep.wait_until_sample_app_produces_metrics]
 
   metadata {
     name = "aoc"
@@ -31,7 +37,7 @@ resource "kubernetes_deployment" "pull_mode_aoc_deployment" {
       }
 
       spec {
-        service_account_name = "aoc-role"
+        service_account_name = "aoc-role-${module.common.testing_id}"
 
         volume {
           name = "otel-config"


### PR DESCRIPTION
… to pull mode aoc deployment

Hopefully this fixes the issue with the other tests. 

I also added in a delay for the pull mode AOC deployment since it depends on the sample app, and previously some scrapes failed because sample app was not ready but AOC was. 