### PR TITLE
Update default trace template + Move Springboot

### DIFF
--- a/validator/src/main/java/com/amazon/aoc/fileconfigs/ExpectedTrace.java
+++ b/validator/src/main/java/com/amazon/aoc/fileconfigs/ExpectedTrace.java
@@ -26,7 +26,11 @@ public enum ExpectedTrace implements FileConfig {
   XRAY_SDK_HTTP_EXPECTED_TRACE("/expected-data-template/xraySDKexpectedHTTPTrace.mustache"),
   SPARK_SDK_HTTP_EXPECTED_TRACE("/expected-data-template/spark/sparkAppExpectedHTTPTrace.mustache"),
   SPARK_SDK_AWSSDK_EXPECTED_TRACE(
-          "/expected-data-template/spark/sparkAppExpectedAWSSDKTrace.mustache")
+          "/expected-data-template/spark/sparkAppExpectedAWSSDKTrace.mustache"),
+  SPRINGBOOT_SDK_HTTP_EXPECTED_TRACE(
+    "/expected-data-template/springboot/springbootAppExpectedHTTPTrace.mustache"),
+  SPRINGBOOT_SDK_AWSSDK_EXPECTED_TRACE(
+    "/expected-data-template/springboot/springbootAppExpectedAWSSDKTrace.mustache")
   ;
 
   private String path;

--- a/validator/src/main/resources/expected-data-template/otelSDKexpectedAWSSDKTrace.mustache
+++ b/validator/src/main/resources/expected-data-template/otelSDKexpectedAWSSDKTrace.mustache
@@ -1,8 +1,6 @@
 [{
-  "name": "/aws-sdk-call",
   "fault": false,
   "error": false,
-  "throttle": false,
   "http": {
     "request": {
       "url": "{{endpoint}}/aws-sdk-call",
@@ -12,47 +10,27 @@
       "status": 200
     }
   },
+  "metadata": {
+    "default": {
+      "otel.resource.telemetry.sdk.name": "opentelemetry"
+    }
+  },
   "subsegments": [
     {
+      "name": "S3",
       "fault": false,
       "error": false,
-      "throttle": false,
-      "subsegments": [
-        {
-          "name": "S3",
-          "fault": false,
-          "error": false,
-          "throttle": false,
-          "http": {
-            "request": {
-              "url": "https://s3.{{region}}.amazonaws.com/",
-              "method": "GET"
-            },
-            "response": {
-              "status": 200
-            }
-          },
-          "namespace": "aws",
-          "subsegments": [
-            {
-              "name": "s3.{{region}}.amazonaws.com",
-              "fault": false,
-              "error": false,
-              "throttle": false,
-              "http": {
-                "request": {
-                  "url": "https://s3.{{region}}.amazonaws.com/",
-                  "method": "GET"
-                },
-                "response": {
-                  "status": 200
-                }
-              },
-              "namespace": "remote"
-            }
-          ]
+      "http": {
+        "response": {
+          "status": 200
         }
-      ]
+      },
+      "metadata": {
+        "default": {
+          "aws.service": "s3"
+        }
+      },
+      "namespace": "aws"
     }
   ]
 }]

--- a/validator/src/main/resources/expected-data-template/otelSDKexpectedHTTPTrace.mustache
+++ b/validator/src/main/resources/expected-data-template/otelSDKexpectedHTTPTrace.mustache
@@ -1,8 +1,6 @@
 [{
-  "name": "/outgoing-http-call",
   "fault": false,
   "error": false,
-  "throttle": false,
   "http": {
     "request": {
       "url": "{{endpoint}}/outgoing-http-call",
@@ -12,29 +10,26 @@
       "status": 200
     }
   },
+  "metadata": {
+    "default": {
+      "otel.resource.telemetry.sdk.name": "opentelemetry"
+    }
+  },
   "subsegments": [
     {
+      "name": "HTTP GET",
       "fault": false,
       "error": false,
-      "throttle": false,
-      "subsegments": [
-        {
-          "name": "aws.amazon.com",
-          "fault": false,
-          "error": false,
-          "throttle": false,
-          "http": {
-            "request": {
-              "url": "https://aws.amazon.com/",
-              "method": "GET"
-            },
-            "response": {
-              "status": 200
-            }
-          },
-          "namespace": "remote"
+      "http": {
+        "request": {
+          "url": "https://aws.amazon.com/",
+          "method": "GET"
+        },
+        "response": {
+          "status": 200
         }
-      ]
+      },
+      "namespace": "remote"
     }
   ]
 }]

--- a/validator/src/main/resources/expected-data-template/springboot/springbootAppExpectedAWSSDKTrace.mustache
+++ b/validator/src/main/resources/expected-data-template/springboot/springbootAppExpectedAWSSDKTrace.mustache
@@ -1,0 +1,54 @@
+[{
+  "name": "/aws-sdk-call",
+  "fault": false,
+  "error": false,
+  "http": {
+    "request": {
+      "url": "{{endpoint}}/aws-sdk-call",
+      "method": "GET"
+    },
+    "response": {
+      "status": 200
+    }
+  },
+  "subsegments": [
+    {
+      "fault": false,
+      "error": false,
+      "subsegments": [
+        {
+          "name": "S3",
+          "fault": false,
+          "error": false,
+          "http": {
+            "request": {
+              "url": "https://s3.{{region}}.amazonaws.com/",
+              "method": "GET"
+            },
+            "response": {
+              "status": 200
+            }
+          },
+          "namespace": "aws",
+          "subsegments": [
+            {
+              "name": "s3.{{region}}.amazonaws.com",
+              "fault": false,
+              "error": false,
+              "http": {
+                "request": {
+                  "url": "https://s3.{{region}}.amazonaws.com/",
+                  "method": "GET"
+                },
+                "response": {
+                  "status": 200
+                }
+              },
+              "namespace": "remote"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}]

--- a/validator/src/main/resources/expected-data-template/springboot/springbootAppExpectedHTTPTrace.mustache
+++ b/validator/src/main/resources/expected-data-template/springboot/springbootAppExpectedHTTPTrace.mustache
@@ -1,0 +1,37 @@
+[{
+  "name": "/outgoing-http-call",
+  "fault": false,
+  "error": false,
+  "http": {
+    "request": {
+      "url": "{{endpoint}}/outgoing-http-call",
+      "method": "GET"
+    },
+    "response": {
+      "status": 200
+    }
+  },
+  "subsegments": [
+    {
+      "fault": false,
+      "error": false,
+      "subsegments": [
+        {
+          "name": "aws.amazon.com",
+          "fault": false,
+          "error": false,
+          "http": {
+            "request": {
+              "url": "https://aws.amazon.com/",
+              "method": "GET"
+            },
+            "response": {
+              "status": 200
+            }
+          },
+          "namespace": "remote"
+        }
+      ]
+    }
+  ]
+}]

--- a/validator/src/main/resources/validations/springboot-otel-trace-metric-validation.yml
+++ b/validator/src/main/resources/validations/springboot-otel-trace-metric-validation.yml
@@ -1,0 +1,19 @@
+-
+  validationType: "metric"
+  httpPath: "/outgoing-http-call"
+  httpMethod: "get"
+  callingType: "http"
+  expectedMetricTemplate: "DEFAULT_EXPECTED_METRIC"
+-
+  validationType: "trace"
+  httpPath: "/outgoing-http-call"
+  httpMethod: "get"
+  callingType: "http"
+  expectedTraceTemplate: "SPRINGBOOT_SDK_HTTP_EXPECTED_TRACE"
+-
+  validationType: "trace"
+  httpPath: "/aws-sdk-call"
+  httpMethod: "get"
+  callingType: "http"
+  expectedTraceTemplate: "SPRINGBOOT_SDK_AWSSDK_EXPECTED_TRACE"
+  

--- a/validator/src/main/resources/validations/springboot-otel-trace-validation.yml
+++ b/validator/src/main/resources/validations/springboot-otel-trace-validation.yml
@@ -1,0 +1,12 @@
+-
+  validationType: "trace"
+  httpPath: "/outgoing-http-call"
+  httpMethod: "get"
+  callingType: "http"
+  expectedTraceTemplate: "SPRINGBOOT_SDK_HTTP_EXPECTED_TRACE"
+-
+  validationType: "trace"
+  httpPath: "/aws-sdk-call"
+  httpMethod: "get"
+  callingType: "http"
+  expectedTraceTemplate: "SPRINGBOOT_SDK_AWSSDK_EXPECTED_TRACE"


### PR DESCRIPTION
### Description

Makes the template for sample app spans more general to acommodate the discrepancies between the SDKs. These simpler template should help enforce certain fields to show up in AWS X-Ray and allow others to be included by the language SDK without causing the test to fail.