### PR TITLE
Sleep 30s before starting docker compose on sample app

### DIFF
--- a/terraform/ec2/main.tf
+++ b/terraform/ec2/main.tf
@@ -278,6 +278,7 @@ resource "null_resource" "setup_sample_app_and_mock_server" {
       "sudo chmod +x /usr/local/bin/docker-compose",
       "sudo systemctl start docker",
       "sudo `aws ecr get-login --no-include-email --region ${var.region}`",
+      "sleep 30", // sleep 30s to wait until dockerd is totally set up
       "sudo /usr/local/bin/docker-compose -f /tmp/docker-compose.yml up -d"
     ]
 


### PR DESCRIPTION
in case the dockerd service is not totally set up. 

saw some errors while running ec2 test

```
ERROR: for tmp_sample_app_1  Cannot start service sample_app: unable to remount dir as readonly: mount tmpfs:/var/lib/docker/containers/4098d40e33e4f505bc8717f182237fe5505f33104511aaf39b9f755d577e425a/mounts/secrets, flags: 0x21, data: uid=0,gid=0: device or resource busy
```