### PR TITLE
Add data mode to performance.json

### DIFF
--- a/validator/src/main/java/com/amazon/aoc/models/PerformanceResult.java
+++ b/validator/src/main/java/com/amazon/aoc/models/PerformanceResult.java
@@ -27,6 +27,7 @@ public class PerformanceResult implements Serializable {
   @NonNull private String testingAmi;
 
   @NonNull private String dataType;
+  @NonNull private String dataMode;
   @NonNull private Integer dataRate;
 
   // Calculated average statistics

--- a/validator/src/main/java/com/amazon/aoc/validators/PerformanceValidator.java
+++ b/validator/src/main/java/com/amazon/aoc/validators/PerformanceValidator.java
@@ -112,6 +112,7 @@ public class PerformanceValidator implements IValidator {
               validationConfig.getInstanceType(),
               validationConfig.getTestingAmi(),
               validationConfig.getDataType(),
+              validationConfig.getDataMode(),
               validationConfig.getDataRate(),
               avgCpu,
               avgMemory,


### PR DESCRIPTION
This PR adds the `dataMode` attribute to `performance.json` so that we can split up the Performance Report tables by metrics and traces.

I've tested this locally and a sample output is:
```json
{
    "testcase": "otlp_metric",
    "instanceType": "m5.2xlarge",
    "testingAmi": "soaking_linux",
    "dataType": "otlp",
    "dataMode": "metric",
    "dataRate": 5000,
    "avgCpu": 0.03332926669302766,
    "avgMem": 56.79377066666667,
    "commitId": "dummy_commit",
    "collectionPeriod": 2
}
```