### PR TITLE
Export OT components via performance.json

### DIFF
--- a/terraform/ec2/outputs.tf
+++ b/terraform/ec2/outputs.tf
@@ -21,3 +21,7 @@ output "sample_app_instance_id" {
 output "testing_id" {
   value = module.common.testing_id
 }
+
+output "otconfig_content" {
+  value = module.basic_components.otconfig_content
+}

--- a/terraform/ec2_setup/outputs.tf
+++ b/terraform/ec2_setup/outputs.tf
@@ -49,3 +49,6 @@ output "launch_date" {
   value = local.launch_date
 }
 
+output "otconfig_content" {
+  value = module.ec2_setup.otconfig_content
+}

--- a/terraform/templates/defaults/performance_validation.tpl
+++ b/terraform/templates/defaults/performance_validation.tpl
@@ -7,6 +7,9 @@
   dataType: "${dataType}"
   dataMode: "${dataMode}"
   dataRate: ${dataRate}
+  otReceivers: [${otReceivers}]
+  otProcessors: [${otProcessors}]
+  otExporters: [${otExporters}]
   testcase: "${testcase}"
   commitId: "${commitId}"
   instanceId: "${instanceId}"

--- a/validator/src/main/java/com/amazon/aoc/models/PerformanceResult.java
+++ b/validator/src/main/java/com/amazon/aoc/models/PerformanceResult.java
@@ -24,7 +24,9 @@ import java.io.Serializable;
 public class PerformanceResult implements Serializable {
   @NonNull private String testcase;
   @NonNull private String instanceType;
-  @NonNull private String testingAmi;
+  @NonNull private String[] receivers;
+  @NonNull private String[] processors;
+  @NonNull private String[] exporters;
 
   @NonNull private String dataType;
   @NonNull private String dataMode;
@@ -37,4 +39,5 @@ public class PerformanceResult implements Serializable {
   // Metadata
   @NonNull private String commitId;
   @NonNull private Integer collectionPeriod;
+  @NonNull private String testingAmi;
 }

--- a/validator/src/main/java/com/amazon/aoc/models/ValidationConfig.java
+++ b/validator/src/main/java/com/amazon/aoc/models/ValidationConfig.java
@@ -49,6 +49,9 @@ public class ValidationConfig {
   String dataType;
   String dataMode;
   Integer dataRate;
+  String[] otReceivers;
+  String[] otProcessors;
+  String[] otExporters;
 
   // Dimensions
   String testcase;

--- a/validator/src/main/java/com/amazon/aoc/validators/PerformanceValidator.java
+++ b/validator/src/main/java/com/amazon/aoc/validators/PerformanceValidator.java
@@ -110,14 +110,17 @@ public class PerformanceValidator implements IValidator {
           final PerformanceResult result = new PerformanceResult(
               validationConfig.getTestcase(),
               validationConfig.getInstanceType(),
-              validationConfig.getTestingAmi(),
+              validationConfig.getOtReceivers(),
+              validationConfig.getOtProcessors(),
+              validationConfig.getOtExporters(),
               validationConfig.getDataType(),
               validationConfig.getDataMode(),
               validationConfig.getDataRate(),
               avgCpu,
               avgMemory,
               validationConfig.getCommitId(),
-              validationConfig.getCollectionPeriod()
+              validationConfig.getCollectionPeriod(),
+              validationConfig.getTestingAmi()
           );
 
           try {


### PR DESCRIPTION
This PR exposes the OT pipeline components via `performance.json` so that we can use it in the performance report.

With this change, `performance.json` looks like:
```json
{
    "testcase": "otlp_mock",
    "instanceType": "m5.2xlarge",
    "receivers": [
        "otlp"
    ],
    "processors": [],
    "exporters": [
        "awsxray"
    ],
    "dataType": "otlp",
    "dataMode": "trace",
    "dataRate": 5000,
    "avgCpu": 780.2810735552694,
    "avgMem": 2512.0426666666667,
    "commitId": "dummy_commit",
    "collectionPeriod": 2,
    "testingAmi": "soaking_linux"
}
```