### PR TITLE
added env vars command to canary test

### DIFF
--- a/terraform/canary/amis.tf
+++ b/terraform/canary/amis.tf
@@ -7,6 +7,7 @@ variable "ami_family" {
       otconfig_destination = "/tmp/ot-default.yml"
       download_command_pattern = "wget %s"
       install_command = "sudo rpm -Uvh aws-otel-collector.rpm"
+      set_env_var_command = "sudo chmod 777 /opt/aws/aws-otel-collector/etc/.env && sudo echo 'SAMPLE_APP_HOST=%s' >> /opt/aws/aws-otel-collector/etc/.env && sudo echo 'SAMPLE_APP_PORT=%s' >> /opt/aws/aws-otel-collector/etc/.env"
       start_command = "sudo /opt/aws/aws-otel-collector/bin/aws-otel-collector-ctl -c /tmp/ot-default.yml -a start"
       connection_type = "ssh"
       user_data = ""
@@ -18,6 +19,7 @@ variable "ami_family" {
       otconfig_destination = "C:\\ot-default.yml"
       download_command_pattern = "powershell -command \"Invoke-WebRequest -Uri %s -OutFile C:\\aws-otel-collector.msi\""
       install_command = "msiexec /i C:\\aws-otel-collector.msi"
+      set_env_var_command = "powershell \"[System.Environment]::SetEnvironmentVariable('SAMPLE_APP_HOST', '%s', [System.EnvironmentVariableTarget]::Machine); [System.Environment]::SetEnvironmentVariable('SAMPLE_APP_PORT', '%s', [System.EnvironmentVariableTarget]::Machine)\""
       start_command = "powershell \"& 'C:\\Program Files\\Amazon\\AwsOtelCollector\\aws-otel-collector-ctl.ps1' -ConfigLocation C:\\ot-default.yml -Action start\""
       connection_type = "winrm"
       user_data = <<EOF


### PR DESCRIPTION
`set_env_var_command ` is a new ami field introduced in a recent PR (https://github.com/aws-observability/aws-otel-test-framework/pull/144) to support Prometheus pull based testing. This also needs to be added to the canary test amis and should fix the current failing canary tests