### PR TITLE
use privileged: true in docker compose 

### DIFF
--- a/terraform/templates/defaults/docker_compose.tpl
+++ b/terraform/templates/defaults/docker_compose.tpl
@@ -6,6 +6,7 @@ services:
       - "80:8080"
       - "443:443"
   sample_app:
+    privileged: true
     image: ${sample_app_image}
     ports:
       - "${sample_app_external_port}:${sample_app_listen_address_port}"


### PR DESCRIPTION
to try to fix the issue in workflow: https://github.com/aws-observability/aws-otel-collector/runs/1498931966?check_suite_focus=true

error
```
ERROR: for tmp_sample_app_1  Cannot start service sample_app: unable to remount dir as readonly: mount tmpfs:/var/lib/docker/containers/c9f117c92c3ed3cc0919310eb57a0451a11501ff15dc223229e28a476f947004/mounts/secrets, flags: 0x21, data: uid=0,gid=0: device or resource busy
```

possible solution: https://github.com/moby/moby/issues/5691