### PR TITLE
Add validation templates for Go SDK

### DIFF
--- a/validator/src/main/java/com/amazon/aoc/fileconfigs/ExpectedTrace.java
+++ b/validator/src/main/java/com/amazon/aoc/fileconfigs/ExpectedTrace.java
@@ -30,7 +30,13 @@ public enum ExpectedTrace implements FileConfig {
   SPRINGBOOT_SDK_HTTP_EXPECTED_TRACE(
     "/expected-data-template/springboot/springbootAppExpectedHTTPTrace.mustache"),
   SPRINGBOOT_SDK_AWSSDK_EXPECTED_TRACE(
-    "/expected-data-template/springboot/springbootAppExpectedAWSSDKTrace.mustache")
+    "/expected-data-template/springboot/springbootAppExpectedAWSSDKTrace.mustache"),
+  GO_SDK_HTTP_EXPECTED_TRACE(
+    "/expected-data-template/go/goAppExpectedHTTPTrace.mustache"
+  ),
+  GO_SDK_AWSSDK_EXPECTED_TRACE(
+    "/expected-data-template/go/goAppExpectedAWSSDKTrace.mustache"
+  )
   ;
 
   private String path;

--- a/validator/src/main/resources/expected-data-template/go/goAppExpectedAWSSDKTrace.mustache
+++ b/validator/src/main/resources/expected-data-template/go/goAppExpectedAWSSDKTrace.mustache
@@ -1,0 +1,11 @@
+[{
+  "http": {
+    "request": {
+      "url": "{{endpoint}}/aws-sdk-call",
+      "method": "GET"
+    },
+    "response": {
+      "status": 200
+    }
+  }
+}]

--- a/validator/src/main/resources/expected-data-template/go/goAppExpectedHTTPTrace.mustache
+++ b/validator/src/main/resources/expected-data-template/go/goAppExpectedHTTPTrace.mustache
@@ -1,0 +1,23 @@
+[{
+  "http": {
+    "request": {
+      "url": "{{endpoint}}/outgoing-http-call",
+      "method": "GET"
+    },
+    "response": {
+      "status": 200
+    }
+  },
+  "subsegments": [
+    {
+      "name": "aws.amazon.com",
+      "http": {
+        "request": {
+          "url": "https://aws.amazon.com",
+          "method": "GET"
+        }
+      },
+      "namespace": "remote"
+    }
+  ]
+}]

--- a/validator/src/main/resources/validations/go-otel-trace-validation.yml
+++ b/validator/src/main/resources/validations/go-otel-trace-validation.yml
@@ -1,0 +1,12 @@
+-
+  validationType: "trace"
+  httpPath: "/outgoing-http-call"
+  httpMethod: "get"
+  callingType: "http"
+  expectedTraceTemplate: "GO_SDK_HTTP_EXPECTED_TRACE"
+-
+  validationType: "trace"
+  httpPath: "/aws-sdk-call"
+  httpMethod: "get"
+  callingType: "http"
+  expectedTraceTemplate: "GO_SDK_AWSSDK_EXPECTED_TRACE"


### PR DESCRIPTION
This pull request adds temporary validation templates for the Go SDK sample app integration test. The reason for adding these templates is because there is a `fault` thrown in AWS X-Ray even though the HTTP response is status 200. The issues have been filed upstream and will be fixed in the future.