### PR TITLE
remove statuscode check for xray trace validation

### DIFF
--- a/validator/src/main/resources/expected-data-template/xraySDKexpectedHTTPTrace.mustache
+++ b/validator/src/main/resources/expected-data-template/xraySDKexpectedHTTPTrace.mustache
@@ -15,9 +15,6 @@
         "request": {
           "url": "https://aws.amazon.com",
           "method": "get"
-        },
-        "response": {
-          "status": 200
         }
       },
       "namespace": "remote"


### PR DESCRIPTION
as we saw aws.amazon.com return 500 from time to time again.

https://github.com/aws-observability/aws-otel-collector/runs/1508712279?check_suite_focus=true