### PR TITLE
Remove fault values from expected trace templates

### DIFF
--- a/validator/src/main/resources/expected-data-template/otelSDKexpectedAWSSDKTrace.mustache
+++ b/validator/src/main/resources/expected-data-template/otelSDKexpectedAWSSDKTrace.mustache
@@ -1,6 +1,4 @@
 [{
-  "fault": false,
-  "error": false,
   "http": {
     "request": {
       "url": "{{endpoint}}/aws-sdk-call",
@@ -18,8 +16,6 @@
   "subsegments": [
     {
       "name": "S3",
-      "fault": false,
-      "error": false,
       "http": {
         "response": {
           "status": 200

--- a/validator/src/main/resources/expected-data-template/otelSDKexpectedHTTPTrace.mustache
+++ b/validator/src/main/resources/expected-data-template/otelSDKexpectedHTTPTrace.mustache
@@ -1,6 +1,4 @@
 [{
-  "fault": false,
-  "error": false,
   "http": {
     "request": {
       "url": "{{endpoint}}/outgoing-http-call",
@@ -18,8 +16,6 @@
   "subsegments": [
     {
       "name": "HTTP GET",
-      "fault": false,
-      "error": false,
       "http": {
         "request": {
           "url": "https://aws.amazon.com/",


### PR DESCRIPTION
Because of the update to the collector in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/1740, a span with no status set will _not_ produce a `fault` value.

This PR removes the expectation that the `fault` value is set.