### PR TITLE
Change gRPC port 55671

### DIFF
--- a/mocked_servers/grpc_metrics/metrics_handler_server.js
+++ b/mocked_servers/grpc_metrics/metrics_handler_server.js
@@ -39,7 +39,7 @@ app.get("/check-data", function (req, res) {
 function main() {
     const server = new grpc.Server();
     server.addService(data_handler_proto.MetricsService.service, {Export: Export});
-    server.bindAsync('0.0.0.0:55670', grpc.ServerCredentials.createInsecure(), () => {
+    server.bindAsync('0.0.0.0:55671', grpc.ServerCredentials.createInsecure(), () => {
         server.start();
     });
     http.createServer(app).listen(8080, "0.0.0.0");

--- a/mocked_servers/grpc_trace/trace_handler_server.js
+++ b/mocked_servers/grpc_trace/trace_handler_server.js
@@ -39,7 +39,7 @@ app.get("/check-data", function (req, res) {
 function main() {
     var server = new grpc.Server();
     server.addService(data_handler_proto.TraceService.service, {Export: Export});
-    server.bindAsync('0.0.0.0:55670', grpc.ServerCredentials.createInsecure(), () => {
+    server.bindAsync('0.0.0.0:55671', grpc.ServerCredentials.createInsecure(), () => {
         server.start();
     });
     http.createServer(app).listen(8080, "0.0.0.0");

--- a/terraform/setup/setup.tf
+++ b/terraform/setup/setup.tf
@@ -126,8 +126,8 @@ resource "aws_security_group" "aoc_sg" {
   }
 
   ingress {
-    from_port = 55670
-    to_port = 55670
+    from_port = 55671
+    to_port = 55671
     protocol = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }

--- a/terraform/templates/defaults/docker_compose.tpl
+++ b/terraform/templates/defaults/docker_compose.tpl
@@ -5,7 +5,7 @@ services:
     ports:
       - "80:8080"
       - "443:443"
-      - "55670:55670"
+      - "55671:55671"
   sample_app:
     privileged: true
     image: ${sample_app_image}

--- a/terraform/templates/local/docker_compose.tpl
+++ b/terraform/templates/local/docker_compose.tpl
@@ -5,7 +5,7 @@ services:
       context: ../../mocked_servers/${mocked_server}
     ports:
       - 80:8080
-      - 55670:55670
+      - 55671:55671
 
   aws-ot-collector:
     build:

--- a/terraform/templates/local/docker_compose_from_source.tpl
+++ b/terraform/templates/local/docker_compose_from_source.tpl
@@ -5,7 +5,7 @@ services:
       context: ../../mocked_servers/${mocked_server}
     ports:
       - 80:8080
-      - 55670:55670
+      - 55671:55671
 
   aws-ot-collector:
     build:

--- a/terraform/testcases/otlp_grpc_exporter_metric_mock/parameters.tfvars
+++ b/terraform/testcases/otlp_grpc_exporter_metric_mock/parameters.tfvars
@@ -1,4 +1,4 @@
-mock_endpoint = "mocked-server:55670"
+mock_endpoint = "mocked-server:55671"
 mocked_server = "grpc_metrics"
 # data type will be emitted. Possible values: metric or trace
 soaking_data_mode = "metric"

--- a/terraform/testcases/otlp_grpc_exporter_trace_mock/parameters.tfvars
+++ b/terraform/testcases/otlp_grpc_exporter_trace_mock/parameters.tfvars
@@ -1,4 +1,4 @@
-mock_endpoint = "mocked-server:55670"
+mock_endpoint = "mocked-server:55671"
 mocked_server = "grpc_trace"
 # data type will be emitted. Possible values: metric or trace
 soaking_data_mode = "trace"


### PR DESCRIPTION
**Description:**
Change gRPC port to `55671` since `55670` is occupied on windows machine.

**Tests:**
```
cd terraform/ec2 && terraform init && terraform apply -auto-approve -lock=false -var-file="../testcases/otlp_grpc_exporter_trace_mock/parameters.tfvars"  -var="testcase=../testcases/otlp_grpc_exporter_trace_mock" -var="aoc_version=latest"
```
```
cd terraform/ecs && terraform init && terraform apply -auto-approve -lock=false -var-file="../testcases/otlp_grpc_exporter_metric_mock/parameters.tfvars"  -var="testcase=../testcases/otlp_grpc_exporter_metric_mock" -var="aoc_version=v0.4.0-407437170"
```