### PR TITLE
added regex support and improved retrying

### DIFF
--- a/validator/src/main/java/com/amazon/aoc/exception/ExceptionCode.java
+++ b/validator/src/main/java/com/amazon/aoc/exception/ExceptionCode.java
@@ -25,7 +25,7 @@ public enum ExceptionCode {
 
   // validating errors
   TRACE_ID_NOT_MATCHED(50001, "trace id not matched"),
-  DATA_MODEL_NOT_MATCHED(50006, "trace id not matched"),
+  DATA_MODEL_NOT_MATCHED(50006, "data model not matched"),
   TRACE_SPAN_LIST_NOT_MATCHED(50002, "trace span list has different length"),
   TRACE_SPAN_NOT_MATCHED(50003, "trace span not matched"),
   TRACE_LIST_NOT_MATCHED(50004, "trace list has different length"),

--- a/validator/src/main/java/com/amazon/aoc/helpers/RetryHelper.java
+++ b/validator/src/main/java/com/amazon/aoc/helpers/RetryHelper.java
@@ -37,6 +37,7 @@ public class RetryHelper {
       int retryCount, int sleepInMilliSeconds, boolean throwExceptionInTheEnd, Retryable retryable)
       throws Exception {
     Exception exceptionInTheEnd = null;
+    int initialCount = retryCount;
     while (retryCount-- > 0) {
       try {
         log.info("retry attempt left : {} ", retryCount);
@@ -49,8 +50,8 @@ public class RetryHelper {
       }
     }
 
+    log.error("All {} retries exhausted", initialCount);
     if (throwExceptionInTheEnd) {
-      log.error("retries exhausted, possible");
       throw exceptionInTheEnd;
     }
     return false;

--- a/validator/src/main/java/com/amazon/aoc/models/xray/Entity.java
+++ b/validator/src/main/java/com/amazon/aoc/models/xray/Entity.java
@@ -15,6 +15,7 @@ import java.util.Map;
  */
 @Getter
 @Setter
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 public class Entity {
   private String name;
   private String id;
@@ -25,21 +26,13 @@ public class Entity {
   private String origin;
   private String traceId;
 
-  @JsonInclude(JsonInclude.Include.NON_DEFAULT)
   private double endTime;
-  @JsonInclude(JsonInclude.Include.NON_DEFAULT)
   private boolean fault;
-  @JsonInclude(JsonInclude.Include.NON_DEFAULT)
   private boolean error;
-  @JsonInclude(JsonInclude.Include.NON_DEFAULT)
   private boolean throttle;
-  @JsonInclude(JsonInclude.Include.NON_DEFAULT)
   private boolean inProgress;
-  @JsonInclude(JsonInclude.Include.NON_DEFAULT)
   private boolean inferred;
-  @JsonInclude(JsonInclude.Include.NON_DEFAULT)
   private boolean stubbed;
-
   private String namespace;
 
   private List<Entity> subsegments;
@@ -48,6 +41,7 @@ public class Entity {
   private Map<String, Object> http;
   private Map<String, Object> aws;
   private Map<String, Object> sql;
+  private Map<String, Object> service;
 
   private Map<String, Map<String, Object>> metadata;
   private Map<String, Object> annotations;

--- a/validator/src/main/java/com/amazon/aoc/validators/TraceValidator.java
+++ b/validator/src/main/java/com/amazon/aoc/validators/TraceValidator.java
@@ -41,6 +41,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Pattern;
 
 @Log4j2
 public class TraceValidator implements IValidator {
@@ -65,39 +66,47 @@ public class TraceValidator implements IValidator {
 
   @Override
   public void validate() throws Exception {
-    // get stored trace
-    Map<String, Object> storedTrace = this.getStoredTrace();
-    log.info("value of stored trace map: {}", storedTrace);
-    // create trace id list to retrieve trace from x-ray service
-    String traceId = (String) storedTrace.get("[0].trace_id");
-    List<String> traceIdList = Collections.singletonList(traceId);
-
-    // get retrieved trace from x-ray service
-    boolean isMatched = RetryHelper.retry(10,
+    // 2 retries for calling the sample app to handle the Lambda case,
+    // where first request might be a cold start and have an additional unexpected subsegment
+    boolean isMatched = RetryHelper.retry(2,
         Integer.parseInt(GenericConstants.SLEEP_IN_MILLISECONDS.getVal()),
         false,
         () -> {
-        Map<String, Object> retrievedTrace = this.getRetrievedTrace(traceIdList);
-        log.info("value of retrieved trace map: {}", retrievedTrace);
-        // data model validation of other fields of segment document
-        for (Map.Entry<String, Object> entry : storedTrace.entrySet()) {
-          String targetKey = entry.getKey();
-          if (retrievedTrace.get(targetKey) == null) {
-            log.error("mis target data: {}", targetKey);
-            throw new BaseException(ExceptionCode.DATA_MODEL_NOT_MATCHED);
-          }
-          if (!entry
-                  .getValue()
-                  .toString()
-                  .equalsIgnoreCase(retrievedTrace.get(targetKey).toString())) {
-            log.error("data model validation failed");
-            log.info("mis matched data model field list");
-            log.info("value of stored trace map: {}", entry.getValue());
-            log.info("value of retrieved map: {}", retrievedTrace.get(entry.getKey()));
-            log.info("==========================================");
-            throw new BaseException(ExceptionCode.DATA_MODEL_NOT_MATCHED);
-          }
-        }
+        // Call sample app and get locally stored trace
+        Map<String, Object> storedTrace = this.getStoredTrace();
+        log.info("value of stored trace map: {}", storedTrace);
+
+        // prepare list of trace IDs to retrieve from X-Ray service
+        String traceId = (String) storedTrace.get("[0].trace_id");
+        List<String> traceIdList = Collections.singletonList(traceId);
+
+        // Retry 5 times to since segments might not be immediately available in X-Ray service
+        RetryHelper.retry(
+            5,
+            () -> {
+              // get retrieved trace from x-ray service
+              Map<String, Object> retrievedTrace = this.getRetrievedTrace(traceIdList);
+              log.info("value of retrieved trace map: {}", retrievedTrace);
+
+              // data model validation of other fields of segment document
+              for (Map.Entry<String, Object> entry : storedTrace.entrySet()) {
+                String targetKey = entry.getKey();
+                if (retrievedTrace.get(targetKey) == null) {
+                  log.error("mis target data: {}", targetKey);
+                  throw new BaseException(ExceptionCode.DATA_MODEL_NOT_MATCHED);
+                }
+
+                if (!Pattern.matches(entry.getValue().toString(),
+                    retrievedTrace.get(targetKey).toString())) {
+                  log.error("data model validation failed");
+                  log.info("mis matched data model field list");
+                  log.info("value of stored trace map: {}", entry.getValue());
+                  log.info("value of retrieved map: {}", retrievedTrace.get(entry.getKey()));
+                  log.info("==========================================");
+                  throw new BaseException(ExceptionCode.DATA_MODEL_NOT_MATCHED);
+                }
+              }
+            });
       });
 
     if (!isMatched) {
@@ -109,28 +118,12 @@ public class TraceValidator implements IValidator {
 
   // this method will hit get trace from x-ray service and get retrieved trace
   private Map<String, Object> getRetrievedTrace(List<String> traceIdList) throws Exception {
-    AtomicReference<Map<String, Object>> flattenedJsonMapForRetrievedTrace =
-        new AtomicReference<>();
-    RetryHelper.retry(
-        30,
-        () -> {
-          List<Trace> retrieveTraceList = null;
-          retrieveTraceList = xrayService.listTraceByIds(traceIdList);
-          if (retrieveTraceList == null || retrieveTraceList.isEmpty()) {
-            throw new BaseException(ExceptionCode.EMPTY_LIST);
-          }
+    List<Trace> retrieveTraceList = xrayService.listTraceByIds(traceIdList);
+    if (retrieveTraceList == null || retrieveTraceList.isEmpty()) {
+      throw new BaseException(ExceptionCode.EMPTY_LIST);
+    }
 
-          // in case the json format is wrong, retry it.
-          if (!retrieveTraceList.isEmpty()) {
-            flattenedJsonMapForRetrievedTrace.set(
-                this.flattenDocument(retrieveTraceList.get(0).getSegments()));
-          } else {
-            log.error("retrieved trace list is empty or null");
-            throw new BaseException(ExceptionCode.EMPTY_LIST);
-          }
-        });
-
-    return flattenedJsonMapForRetrievedTrace.get();
+    return this.flattenDocument(retrieveTraceList.get(0).getSegments());
   }
 
   private Map<String, Object> flattenDocument(List<Segment> segmentList) {

--- a/validator/src/main/resources/expected-data-template/lambdaExpectedTrace.mustache
+++ b/validator/src/main/resources/expected-data-template/lambdaExpectedTrace.mustache
@@ -8,6 +8,7 @@
      ]
  },
 {
+    "name":"serverlessrepo-aot-py38-sar-function-.*",
     "http":{
         "response":{
             "status":200
@@ -16,17 +17,18 @@
     "origin":"AWS::Lambda"
 },
 {
+    "name":"serverlessrepo-aot-py38-sar-function-.*",
     "origin":"AWS::Lambda::Function",
     "subsegments":[
         {
             "name":"Invocation",
                          "subsegments":[
                              {
-                                 "name":"lambda_function.lambda_handler",
+                                 "name":"lambda_function\\.lambda_handler",
                                  "aws":{
                                      "xray":{
                                          "auto_instrumentation":false,
-                                         "sdk_version":"0.16b1",
+                                         "sdk_version":"0\\.16b1",
                                          "sdk":"opentelemetry for python"
                                      }
                                  }
@@ -44,7 +46,7 @@
     "inferred":true,
     "http":{
         "request":{
-            "url":"http://httpbin.org/",
+            "url":"http://httpbin\\.org/",
             "method":"GET"
         }
     }

--- a/validator/src/main/resources/expected-data-template/otelSDKexpectedHTTPTrace.mustache
+++ b/validator/src/main/resources/expected-data-template/otelSDKexpectedHTTPTrace.mustache
@@ -18,7 +18,7 @@
       "name": "HTTP GET",
       "http": {
         "request": {
-          "url": "https://aws.amazon.com/",
+          "url": "https://aws\\.amazon\\.com/",
           "method": "GET"
         },
         "response": {

--- a/validator/src/main/resources/expected-data-template/xraySDKexpectedHTTPTrace.mustache
+++ b/validator/src/main/resources/expected-data-template/xraySDKexpectedHTTPTrace.mustache
@@ -13,7 +13,7 @@
       "name": "aws.amazon.com",
       "http": {
         "request": {
-          "url": "https://aws.amazon.com",
+          "url": "https://aws\\.amazon\\.com",
           "method": "get"
         }
       },


### PR DESCRIPTION
Added standard Java regex support to the trace templates we use for validation. Benefit is that for auto-generated strings like Lambda functions created with SAM, we can match partially for the deterministic portion of the name and regex match the random part. This can also let us check for the mere presence of fields in the retrieved trace even if we don't know what their values would be, by including the field with a value of `*` in the template. The drawbacks are that regex characters (*, ?, .) will now need to be escaped if we want to match them literally, which I've done by adding `\\` for all existing periods (`.`) in the templates.

I've also changed the retry logic so that there are 2 levels of retries - at the top level we have 2 retries to call the sample app and generate trace data to handle the Lambda case where the first invocation might be a cold start and have an undesired extra subsegment. Inside that we have 5 retries to get trace data from the X-Ray service to ensure all expected segments are able to be retrieved. I've verified this works with the Lambda cold start and X-Ray SDK trace validations.

Also a couple other minor bug fixes.