### PR TITLE
Remove nested subsegment for AWS SDK call

### DIFF
--- a/validator/src/main/resources/expected-data-template/springboot/springbootAppExpectedAWSSDKTrace.mustache
+++ b/validator/src/main/resources/expected-data-template/springboot/springbootAppExpectedAWSSDKTrace.mustache
@@ -23,22 +23,7 @@
               "status": 200
             }
           },
-          "namespace": "aws",
-          "subsegments": [
-            {
-              "name": "s3\\.{{region}}\\.amazonaws\\.com",
-              "http": {
-                "request": {
-                  "url": "https://s3\\.{{region}}\\.amazonaws\\.com/",
-                  "method": "GET"
-                },
-                "response": {
-                  "status": 200
-                }
-              },
-              "namespace": "remote"
-            }
-          ]
+          "namespace": "aws"
         }
       ]
     }


### PR DESCRIPTION
I think we may have had a nested transport span in previous versions but not anymore. At least, that's how I read the failure n https://github.com/aws-observability/aws-otel-java-instrumentation/runs/1535106837