### PR TITLE
Fix the canary test for gRPC

### DIFF
--- a/terraform/canary/main.tf
+++ b/terraform/canary/main.tf
@@ -42,6 +42,8 @@ module "ec2_setup" {
   region = var.region
   testcase = var.testcase
   validation_config = var.validation_config
+  mock_endpoint = var.mock_endpoint
+  mocked_server = var.mocked_server
   sample_app_image = var.sample_app_image != "" ? var.sample_app_image : module.basic_components.sample_app_image
   package_s3_bucket = "aws-otel-collector"
   skip_validation = false


### PR DESCRIPTION
**Description:**
Fix the canary test for gRPC test case
**Tests:**
```
cd terraform/canary && terraform init && terraform apply -auto-approve -lock=false -var-file="../testcases/otlp_grpc_exporter_metric_mock/parameters.tfvars" -var="aoc_version=latest" -var="testcase=../testcases/otlp_grpc_exporter_metric_mock" -var="testing_ami=canary_linux"
cd terraform/canary && terraform init && terraform apply -auto-approve -lock=false -var-file="../testcases/otlp_grpc_exporter_metric_mock/parameters.tfvars" -var="aoc_version=latest" -var="testcase=../testcases/otlp_grpc_exporter_metric_mock" -var="testing_ami=canary_windows"
```