### PR TITLE
modified url to resolve aws-request-signing-apache-interceptor package

### DIFF
--- a/validator/build.gradle
+++ b/validator/build.gradle
@@ -25,7 +25,7 @@ repositories {
     mavenCentral()
 
     maven {
-        url 'https://repository.mulesoft.org/nexus/content/repositories/public/'
+        url 'https://jitpack.io'
     }
 }
 


### PR DESCRIPTION
Resolve Gradle build failure for validator module.

Found bug via integration test for Go SDK: https://github.com/aws/aws-xray-sdk-go/pull/271/checks?check_run_id=1596291691

Git issue: https://github.com/awslabs/aws-request-signing-apache-interceptor/issues/2