### PR TITLE
fix the iptables command for ami centos6

### DIFF
--- a/terraform/ec2/amis.tf
+++ b/terraform/ec2/amis.tf
@@ -181,7 +181,7 @@ variable "amis" {
       user_data = <<EOF
 #! /bin/bash
 sudo iptables -I INPUT -p tcp -m tcp --dport 55680 -j ACCEPT
-sudo iptables -I INPUT -p tcp -m tcp --dport 55690 -j ACCEPT
+sudo iptables -I INPUT -p udp -m udp --dport 55690 -j ACCEPT
 sudo service iptables save
 EOF
     }


### PR DESCRIPTION
by allowing udp port 55690 to get xray receiver test passed