### PR TITLE
support patching on soak and canary

### DIFF
--- a/terraform/canary/main.tf
+++ b/terraform/canary/main.tf
@@ -54,4 +54,6 @@ module "ec2_setup" {
 
   aws_access_key_id = var.aws_access_key_id
   aws_secret_access_key = var.aws_secret_access_key
+
+  patch = true
 }

--- a/terraform/ec2/variables.tf
+++ b/terraform/ec2/variables.tf
@@ -98,3 +98,11 @@ variable "testing_type" {
 variable "canary" {
   default = false
 }
+
+# if patch is true, we will wait until the instance gets patched after launching the instance,
+# also set a patch tag onto the instance so that the instance get picked by the ssm patching process.
+# and then start the installation of collector.
+variable "patch" {
+  default = false
+}
+

--- a/terraform/ec2_setup/main.tf
+++ b/terraform/ec2_setup/main.tf
@@ -72,4 +72,6 @@ module "ec2_setup" {
   debug = var.debug
 
   testing_type = var.testing_type
+
+  patch = var.patch
 }

--- a/terraform/ec2_setup/variables.tf
+++ b/terraform/ec2_setup/variables.tf
@@ -71,3 +71,7 @@ variable "install_package_local_path" {
 variable "testing_type" {
   default = "e2e"
 }
+
+variable "patch" {
+  default = false
+}

--- a/terraform/soaking/main.tf
+++ b/terraform/soaking/main.tf
@@ -45,6 +45,8 @@ module "ec2_setup" {
   negative_soaking = var.negative_soaking
 
   testing_type = "soaking"
+
+  patch = true
 }
 
 locals {

--- a/terraform/templates/local/check-patch.sh
+++ b/terraform/templates/local/check-patch.sh
@@ -1,0 +1,14 @@
+#! /bin/bash
+
+set -e
+
+instance_id=$1
+
+n=0
+until [ "$n" -ge 20 ]
+do
+  aws ssm describe-instance-associations-status --instance-id "$instance_id" | grep "AWS-RunPatchBaseline" -A10 | grep "Success" && echo "patch finished" && break
+  echo "waiting for patch, sleep 1 minute"
+  n=$((n+1))
+  sleep 60
+done


### PR DESCRIPTION
1 adding a flag in ec2 module
2. adding a tag in ec2 instance when patch is enabled
3. check patch status once instance is created.