### PR TITLE
Add statsd sample app, statsd test cases

### DIFF
--- a/load-generator/README.md
+++ b/load-generator/README.md
@@ -28,3 +28,8 @@
 ```
 ./gradlew :load-generator:run --args="trace -r=100 -u=localhost:55680 -d=xray"
 ```
+
+### StatsD Metrics Load Test Sample Command,
+```
+./gradlew :load-generator:run --args="metric -r=100 -u=localhost:8125 -d=statsd"
+```

--- a/load-generator/src/main/java/com/amazon/opentelemetry/load/generator/emitter/EmitterFactory.java
+++ b/load-generator/src/main/java/com/amazon/opentelemetry/load/generator/emitter/EmitterFactory.java
@@ -37,6 +37,8 @@ public class EmitterFactory {
   private static Emitter getMetricEmitter(Parameter param) {
     if (param.getDataFormat().equalsIgnoreCase(Constants.OTLP)) {
       return new OtlpMetricEmitter(param);
+    } else if (param.getDataFormat().equalsIgnoreCase(Constants.STATSD)) {
+      return new StatsdMetricEmitter(param);
     } else {
       throw new RuntimeException("unknown metric data format specified");
     }

--- a/load-generator/src/main/java/com/amazon/opentelemetry/load/generator/emitter/StatsdMetricEmitter.java
+++ b/load-generator/src/main/java/com/amazon/opentelemetry/load/generator/emitter/StatsdMetricEmitter.java
@@ -1,0 +1,52 @@
+package com.amazon.opentelemetry.load.generator.emitter;
+
+import com.amazon.opentelemetry.load.generator.model.Parameter;
+
+
+import java.io.IOException;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+
+
+public class StatsdMetricEmitter extends MetricEmitter{
+
+    InetAddress ipAddress;
+    int portAddress;
+    private DatagramSocket socket;
+
+    public StatsdMetricEmitter(Parameter param) {
+        super();
+        this.param = param;
+    }
+
+    @Override
+    public void emitDataLoad() throws Exception {
+        this.setupProvider();
+        this.start(() -> nextDataPoint());
+    }
+
+    @Override
+    public void setupProvider() throws Exception {
+        ipAddress = InetAddress.getByName(param.getEndpoint().split(":",2)[0]);
+        portAddress = Integer.parseInt(param.getEndpoint().split(":",2)[1]);
+        socket = new DatagramSocket();
+    }
+
+    @Override
+    public void nextDataPoint() {
+        try {
+            sendStatsd();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void sendStatsd() throws IOException {
+        byte buf[];
+        String payload = "statsdTestMetric1:1|g|#mykey:myvalue,mykey2:myvalue2";
+        buf = payload.getBytes();
+        DatagramPacket packet = new DatagramPacket(buf, buf.length, ipAddress, portAddress);
+        socket.send(packet);
+    }
+}

--- a/load-generator/src/main/java/com/amazon/opentelemetry/load/generator/util/Constants.java
+++ b/load-generator/src/main/java/com/amazon/opentelemetry/load/generator/util/Constants.java
@@ -19,5 +19,6 @@ public class Constants {
 
   public static final String OTLP = "otlp";
   public static final String XRAY = "xray";
+  public static final String STATSD = "statsd";
 
 }

--- a/sample-apps/statsd/Dockerfile
+++ b/sample-apps/statsd/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.8
+COPY . /statsd
+WORKDIR /statsd
+ENV PYTHONUNBUFFERED=1
+CMD ["python", "webserver.py"]

--- a/sample-apps/statsd/webserver.py
+++ b/sample-apps/statsd/webserver.py
@@ -1,0 +1,46 @@
+from http.server import HTTPServer, BaseHTTPRequestHandler
+import os
+import socket
+import logging
+import json
+
+class httpHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == '/a':
+            self.wfile.write('Helloa! '.encode())
+        elif self.path == '/statsd':
+            send_statsd_metrics()
+            self.send_response(200)
+            self.send_header('Content-type', 'application/json')
+            self.end_headers()
+            self.wfile.write(json.dumps({'traceId': 'dummy'}).encode())
+        elif self.path == '/':
+            self.send_response(200)
+            self.end_headers()
+        else:
+            self.wfile.write('Hello! '.encode())
+
+def send_statsd_metrics():
+    INSTANCE_ID = os.getenv('INSTANCE_ID')
+    RECEIVER_ADDRESS = os.getenv('COLLECTOR_UDP_ADDRESS')
+    logging.warning(INSTANCE_ID)
+    logging.warning(RECEIVER_ADDRESS)
+    if INSTANCE_ID is not None and RECEIVER_ADDRESS is not None:
+        statsD_metric = bytes('statsdTestMetric1g_%s:1|g|#mykey1:myvalue1,mykey2:myvalue2\nstatsdTestMetric1c_%s:1|c|#mykey3:myvalue3' % (INSTANCE_ID, INSTANCE_ID),'utf-8')
+        opened_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        opened_socket.sendto(statsD_metric, (RECEIVER_ADDRESS.split(':')[0], int(RECEIVER_ADDRESS.split(':')[1])))
+    return
+
+def main():
+    ADDRESS = os.getenv('LISTEN_ADDRESS')
+    if ADDRESS is not None:
+        HOST = ADDRESS.split(':')[0]
+        PORT = int(ADDRESS.split(':')[1])
+    else:
+        HOST = '0.0.0.0'
+        PORT = 4321
+    server = HTTPServer((HOST, PORT), httpHandler)
+    server.serve_forever()
+
+if __name__ == '__main__':
+    main()

--- a/terraform/eks/main.tf
+++ b/terraform/eks/main.tf
@@ -324,6 +324,11 @@ resource "kubernetes_deployment" "sample_app_deployment" {
           }
 
           env {
+            name = "COLLECTOR_UDP_ADDRESS"
+            value = "${kubernetes_service.aoc_udp_service[0].metadata[0].name}:${module.common.udp_port}"
+          }
+
+          env {
             name = "AWS_XRAY_DAEMON_ADDRESS"
             value = "${kubernetes_service.aoc_udp_service[0].metadata[0].name}:${module.common.udp_port}"
           }

--- a/terraform/templates/defaults/docker_compose.tpl
+++ b/terraform/templates/defaults/docker_compose.tpl
@@ -17,6 +17,7 @@ services:
       INSTANCE_ID: ${testing_id}
       OTEL_EXPORTER_OTLP_ENDPOINT: ${grpc_endpoint}
       AWS_XRAY_DAEMON_ADDRESS: ${udp_endpoint}
+      COLLECTOR_UDP_ADDRESS: ${udp_endpoint}
       AWS_REGION: ${region}
 
     healthcheck:

--- a/terraform/templates/defaults/ecs_taskdef.tpl
+++ b/terraform/templates/defaults/ecs_taskdef.tpl
@@ -22,6 +22,10 @@
            "value": "127.0.0.1:${udp_port}"
         },
         {
+           "name": "COLLECTOR_UDP_ADDRESS",
+           "value": "127.0.0.1:${udp_port}"
+        },
+        {
             "name": "AWS_REGION",
             "value": "${region}"
         },

--- a/terraform/templates/defaults/soaking_docker_compose.tpl
+++ b/terraform/templates/defaults/soaking_docker_compose.tpl
@@ -16,6 +16,7 @@ services:
     environment:
       OTEL_RESOURCE_ATTRIBUTES: ${otel_resource_attributes}
       AWS_XRAY_DAEMON_ADDRESS: ${udp_endpoint}
+      COLLECTOR_UDP_ADDRESS: ${udp_endpoint}
       AWS_REGION: ${region}
     deploy:
       resources:

--- a/terraform/templates/local/docker_compose.tpl
+++ b/terraform/templates/local/docker_compose.tpl
@@ -41,5 +41,6 @@ services:
       - INSTANCE_ID=${testing_id}
       - OTEL_EXPORTER_OTLP_ENDPOINT=aws-ot-collector:${grpc_port}
       - AWS_XRAY_DAEMON_ADDRESS=aws-ot-collector:${udp_port}
+      - COLLECTOR_UDP_ADDRESS=aws-ot-collector:${udp_port}
     depends_on:
       - aws-ot-collector

--- a/terraform/templates/local/docker_compose_from_source.tpl
+++ b/terraform/templates/local/docker_compose_from_source.tpl
@@ -42,5 +42,6 @@ services:
       - INSTANCE_ID=${testing_id}
       - OTEL_EXPORTER_OTLP_ENDPOINT=aws-ot-collector:${grpc_port}
       - AWS_XRAY_DAEMON_ADDRESS=aws-ot-collector:${udp_port}
+      - COLLECTOR_UDP_ADDRESS=aws-ot-collector:${udp_port}
     depends_on:
       - aws-ot-collector

--- a/terraform/testcases/statsd/otconfig.tpl
+++ b/terraform/testcases/statsd/otconfig.tpl
@@ -1,0 +1,15 @@
+receivers:
+  statsd:
+    endpoint: 0.0.0.0:${udp_port}
+    aggregation_interval: 60s
+exporters:
+  awsemf:
+    namespace: '${otel_service_namespace}/${otel_service_name}'
+    region: '${region}'
+  logging:
+    loglevel: debug
+service:
+  pipelines:
+    metrics:
+      receivers: [statsd]
+      exporters: [awsemf, logging]

--- a/terraform/testcases/statsd/parameters.tfvars
+++ b/terraform/testcases/statsd/parameters.tfvars
@@ -1,0 +1,11 @@
+# this file is defined in validator/src/main/resources/validations
+validation_config="statsd-metric-validation.yml"
+
+# sample application image to emit the trace data
+sample_app="statsd"
+
+# data type will be emitted. Possible values: metric or trace
+soaking_data_mode = "metric"
+
+# data model type. possible values: otlp, xray, etc
+soaking_data_type = "statsd"

--- a/terraform/testcases/statsd_mock/otconfig.tpl
+++ b/terraform/testcases/statsd_mock/otconfig.tpl
@@ -1,0 +1,15 @@
+receivers:
+  statsd:
+    endpoint: 0.0.0.0:${udp_port}
+    aggregation_interval: 60s
+exporters:
+  logging:
+    loglevel: debug
+  otlphttp:
+    metrics_endpoint: "https://${mock_endpoint}"
+    insecure: true
+service:
+  pipelines:
+    metrics:
+      receivers: [statsd]
+      exporters: [otlphttp]

--- a/terraform/testcases/statsd_mock/parameters.tfvars
+++ b/terraform/testcases/statsd_mock/parameters.tfvars
@@ -1,0 +1,11 @@
+# this file is defined in validator/src/main/resources/validations
+validation_config="statsd-mocked-metric-validation.yml"
+
+# sample application image to emit the trace data
+sample_app="statsd"
+
+# data type will be emitted. Possible values: metric or trace
+soaking_data_mode = "metric"
+
+# data model type. possible values: otlp, xray, etc
+soaking_data_type = "statsd"

--- a/validator/src/main/resources/expected-data-template/statsdExpectedMetric.mustache
+++ b/validator/src/main/resources/expected-data-template/statsdExpectedMetric.mustache
@@ -1,21 +1,18 @@
 -
-  metricName: testCounter.metric_{{testingId}}
+  metricName: statsdTestMetric1g_{{testingId}}
   namespace: {{metricNamespace}}
   dimensions:
     -
-      name: key
-      value: val
+      name: mykey1
+      value: myvalue1
     -
-      name: key1
-      value: val1
+      name: mykey2
+      value: myvalue2
 
 -
-  metricName: testGauge.metric_{{testingId}}
+  metricName: statsdTestMetric1c_{{testingId}}
   namespace: {{metricNamespace}}
   dimensions:
     -
-      name: keyg
-      value: valg
-    -
-      name: keyg1
-      value: valg1
+      name: mykey3
+      value: myvalue3

--- a/validator/src/main/resources/validations/statsd-metric-validation.yml
+++ b/validator/src/main/resources/validations/statsd-metric-validation.yml
@@ -1,4 +1,6 @@
 -
   validationType: "cw-metric"
-  callingType: "none"
+  httpMethod: "get"
+  httpPath: "/statsd"
+  callingType: "http"
   expectedMetricTemplate: "STATSD_EXPECTED_METRIC"

--- a/validator/src/main/resources/validations/statsd-mocked-metric-validation.yml
+++ b/validator/src/main/resources/validations/statsd-mocked-metric-validation.yml
@@ -1,0 +1,5 @@
+-
+  validationType: "mocked-server"
+  httpPath: "/statsd"
+  httpMethod: "get"
+  callingType: "http"


### PR DESCRIPTION
Add statsd sample app
1. get the environment variable `LISTEN_ADDRESS` for host and port address
2. use the `statsdTestMetric1g_INSTANCE_ID` as the metric name

Add statsd test cases
1. add mock and regular testcases 
2. add an environment variable COLLECTOR_UDP_ADDRESS to distinguish with AWS_XRAY_DAEMON_ADDRESS
3. test in ECS, EKS

Add statsd performance test
run `./gradlew :load-generator:run --args="metric -r=1000 -u=localhost:55690 -d=statsd -f=10000"` and can see metrics in CW (using statsd receiver and emf exporter)