### PR TITLE
reduce checking patch time to 5 minutes

### DIFF
--- a/terraform/templates/local/check-patch.sh
+++ b/terraform/templates/local/check-patch.sh
@@ -5,7 +5,7 @@ set -e
 instance_id=$1
 
 n=0
-until [ "$n" -ge 20 ]
+until [ "$n" -ge 5 ]
 do
   aws ssm describe-instance-associations-status --instance-id "$instance_id" | grep "AWS-RunPatchBaseline" -A10 | grep "Success" && echo "patch finished" && break
   echo "waiting for patch, sleep 1 minute"


### PR DESCRIPTION
it was 20 minutes which is too long for canary test.