### PR TITLE
Set service.name for spring boot app too.

### DIFF
--- a/validator/src/main/resources/expected-data-template/springboot/springbootAppExpectedAWSSDKTrace.mustache
+++ b/validator/src/main/resources/expected-data-template/springboot/springbootAppExpectedAWSSDKTrace.mustache
@@ -1,5 +1,5 @@
 [{
-  "name": "/aws-sdk-call",
+  "name": "aws-otel-integ-test",
   "http": {
     "request": {
       "url": "{{endpoint}}/aws-sdk-call",

--- a/validator/src/main/resources/expected-data-template/springboot/springbootAppExpectedHTTPTrace.mustache
+++ b/validator/src/main/resources/expected-data-template/springboot/springbootAppExpectedHTTPTrace.mustache
@@ -1,5 +1,5 @@
 [{
-  "name": "/outgoing-http-call",
+  "name": "aws-otel-integ-test",
   "http": {
     "request": {
       "url": "{{endpoint}}/outgoing-http-call",


### PR DESCRIPTION
We weren't setting this before, but now that service.name is required by otel we need it to be a reasonable value.