### PR TITLE
add plugin version back in module build.gradle since docker build fai…

### DIFF
--- a/sample-apps/spark/build.gradle
+++ b/sample-apps/spark/build.gradle
@@ -3,7 +3,7 @@ plugins {
 
     // Apply the application plugin to add support for building a CLI application.
     id 'application'
-    id 'com.google.cloud.tools.jib'
+    id 'com.google.cloud.tools.jib' version "2.7.1"
 }
 
 group 'com.amazon.sampleapp'

--- a/validator/build.gradle
+++ b/validator/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java'
 
     id 'application'
-    id 'com.google.cloud.tools.jib'
+    id 'com.google.cloud.tools.jib' version "2.7.1"
 
     // lombok
     id "io.freefair.lombok" version "5.1.0"


### PR DESCRIPTION
…led with unknown plugin version

The workflow was failed due to docker build is failed.
* https://github.com/aws-observability/aws-otel-collector/runs/1842837502?check_suite_focus=true#step:6:465