### PR TITLE
Removed http subsegment name to generalize template for all SDKs

### DIFF
--- a/validator/src/main/resources/expected-data-template/otelSDKexpectedHTTPTrace.mustache
+++ b/validator/src/main/resources/expected-data-template/otelSDKexpectedHTTPTrace.mustache
@@ -15,7 +15,6 @@
   },
   "subsegments": [
     {
-      "name": "HTTP GET",
       "http": {
         "request": {
           "url": "https://aws\\.amazon\\.com/",


### PR DESCRIPTION
Currently file `otelSDKexpectedHTTPTrace.mustache` is using `HTTP GET` as span name for outgoing http request, and JS, .NET, and Go will fail the validation test if using `default-otel-trace-validation.yml`. As a result of that, they have to create their own specific [templates](https://github.com/aws-observability/aws-otel-test-framework/tree/terraform/validator/src/main/resources/expected-data-template) for validation. 

Submit this PR to remove the subsegment name so that it can be applied by all SDKs.