### PR TITLE
Changed OTLP default port to 4317.

### DIFF
--- a/docs/run-mock-test.md
+++ b/docs/run-mock-test.md
@@ -73,7 +73,7 @@ the output will be
 CONTAINER ID        IMAGE                   COMMAND                  CREATED             STATUS              PORTS                    NAMES
 8a48f60534cf        mock_validator          "/app/bin/app -c=def…"   12 seconds ago      Up 10 seconds                                mock_validator_1
 443ee2e388ea        mock_sample_app         "/app/bin/spark-samp…"   32 seconds ago      Up 31 seconds       0.0.0.0:4567->4567/tcp   mock_sample_app_1
-67f401637b67        mock_aws-ot-collector   "/awscollector --con…"   34 seconds ago      Up 32 seconds       55680-55681/tcp          mock_aws-ot-collector_1
+67f401637b67        mock_aws-ot-collector   "/awscollector --con…"   34 seconds ago      Up 32 seconds       4317-4318/tcp          mock_aws-ot-collector_1
 db75def68bb0        mock_mocked-server      "docker-entrypoint.s…"   36 seconds ago      Up 34 seconds       0.0.0.0:80->8080/tcp     mock_mocked-server_1
 ```
 

--- a/load-generator/README.md
+++ b/load-generator/README.md
@@ -16,17 +16,17 @@
 
 ### OTLP Metrics Load Test Sample Command,
 ```
-./gradlew :load-generator:run --args="metric -r=10000 -u=localhost:55680 -d=otlp -f=10000"
+./gradlew :load-generator:run --args="metric -r=10000 -u=localhost:4317 -d=otlp -f=10000"
 ```
 
 ### OTLP Trace Load Test Sample Command,
 ```
-./gradlew :load-generator:run --args="trace -r=100 -u=localhost:55680 -d=otlp"
+./gradlew :load-generator:run --args="trace -r=100 -u=localhost:4317 -d=otlp"
 ```
 
 ### X-Ray Trace Load Test Sample Command,
 ```
-./gradlew :load-generator:run --args="trace -r=100 -u=localhost:55680 -d=xray"
+./gradlew :load-generator:run --args="trace -r=100 -u=localhost:4317 -d=xray"
 ```
 
 ### StatsD Metrics Load Test Sample Command,

--- a/load-generator/src/main/java/com/amazon/opentelemetry/load/generator/command/CommonOption.java
+++ b/load-generator/src/main/java/com/amazon/opentelemetry/load/generator/command/CommonOption.java
@@ -29,7 +29,7 @@ public class CommonOption {
 
   @Option(names = {"-u", "--url"},
       description = "aws-otel-collector receiver endpoint",
-      defaultValue = "localhost:55680")
+      defaultValue = "localhost:4317")
   private String endpoint;
 
   @Option(names = {"-d", "--dataFormat"},

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -105,7 +105,7 @@ an example:
       "environment": [
         {
           "name": "OTEL_EXPORTER_OTLP_ENDPOINT",
-          "value": "127.0.0.1:55680"
+          "value": "127.0.0.1:4317"
         },
         {
           "name": "INSTANCE_ID",
@@ -155,8 +155,8 @@ an example:
       "memory": 256,
       "portMappings": [
         {
-          "containerPort": 55680,
-          "hostPort": 55680,
+          "containerPort": 4317,
+          "hostPort": 4317,
           "protocol": "tcp"
         }
       ],

--- a/terraform/common/outputs.tf
+++ b/terraform/common/outputs.tf
@@ -87,7 +87,7 @@ output "mocked_server_lb_port" {
 }
 
 output "grpc_port" {
-  value = "55680"
+  value = "4317"
 }
 
 output "udp_port" {

--- a/terraform/ec2/amis.tf
+++ b/terraform/ec2/amis.tf
@@ -180,7 +180,7 @@ variable "amis" {
       arch = "amd64"
       user_data = <<EOF
 #! /bin/bash
-sudo iptables -I INPUT -p tcp -m tcp --dport 55680 -j ACCEPT
+sudo iptables -I INPUT -p tcp -m tcp --dport 4317 -j ACCEPT
 sudo iptables -I INPUT -p udp -m udp --dport 55690 -j ACCEPT
 sudo service iptables save
 EOF

--- a/terraform/setup/setup.tf
+++ b/terraform/setup/setup.tf
@@ -140,8 +140,8 @@ resource "aws_security_group" "aoc_sg" {
   }
 
   ingress {
-    from_port = 55680
-    to_port = 55680
+    from_port = 4317
+    to_port = 4317
     protocol = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }

--- a/terraform/templates/defaults/ecs_taskdef.tpl
+++ b/terraform/templates/defaults/ecs_taskdef.tpl
@@ -65,8 +65,8 @@
       "memory": 256,
       "portMappings": [
         {
-          "containerPort": 55680,
-          "hostPort": 55680,
+          "containerPort": 4317,
+          "hostPort": 4317,
           "protocol": "tcp"
         },
         {

--- a/terraform/templates/prometheus/ecs_taskdef.tpl
+++ b/terraform/templates/prometheus/ecs_taskdef.tpl
@@ -39,8 +39,8 @@
       "memory": 256,
       "portMappings": [
         {
-          "containerPort": 55680,
-          "hostPort": 55680,
+          "containerPort": 4317,
+          "hostPort": 4317,
           "protocol": "tcp"
         },
         {


### PR DESCRIPTION
Update test cases with new OTLP default port number changed in following commit.
https://github.com/open-telemetry/opentelemetry-specification/commit/4dd4ee0d


