### PR TITLE
Fix AMI filter and docker installation

### DIFF
--- a/terraform/ec2/amis.tf
+++ b/terraform/ec2/amis.tf
@@ -265,7 +265,7 @@ data "aws_ami" "amazonlinux2" {
 
   filter {
     name   = "name"
-    values = ["amzn2-ami-hvm*"]
+    values = ["amzn2-ami-hvm*-gp2"]
   }
 
   owners = ["amazon"] # Canonical

--- a/terraform/ec2/main.tf
+++ b/terraform/ec2/main.tf
@@ -297,6 +297,7 @@ resource "null_resource" "setup_sample_app_and_mock_server" {
   }
   provisioner "remote-exec" {
     inline = [
+      "sudo yum update -y",
       "sudo amazon-linux-extras install docker -y",
       "sudo service docker start",
       "sudo usermod -a -G docker ec2-user",


### PR DESCRIPTION
* Refine the filter string to pick up correct AMI image.
* Install docker by following instructions in [Docker basics for Amazon ECS](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/docker-basics.html)