### PR TITLE
tf: Fix ami for canaray and soaking

### DIFF
--- a/terraform/canary/amis.tf
+++ b/terraform/canary/amis.tf
@@ -45,13 +45,15 @@ variable "amis" {
       os_family = "windows"
       ami_search_pattern = "Windows_Server-2019-English-Full-Base-*"
       ami_owner = "amazon"
+      ami_product_code = []
       family = "windows"
       arch = "amd64"
     }
     canary_linux = {
       os_family = "amazon_linux"
-      ami_search_pattern = "amzn2-ami-hvm*"
+      ami_search_pattern = "amzn2-ami-hvm-2.0.????????.?-x86_64-gp2"
       ami_owner = "amazon"
+      ami_product_code = []
       family = "amazon_linux"
       arch = "amd64"
     }

--- a/terraform/ec2_setup/amis.tf
+++ b/terraform/ec2_setup/amis.tf
@@ -61,13 +61,15 @@ variable "amis" {
       os_family = "windows"
       ami_search_pattern = "Windows_Server-2019-English-Full-Base-*"
       ami_owner = "amazon"
+      ami_product_code = []
       family = "windows"
       arch = "amd64"
     }
     soaking_linux = {
       os_family = "amazon_linux"
-      ami_search_pattern = "amzn2-ami-hvm*"
+      ami_search_pattern = "amzn2-ami-hvm-2.0.????????.?-x86_64-gp2"
       ami_owner = "amazon"
+      ami_product_code = []
       family = "amazon_linux"
       arch = "amd64"
     }


### PR DESCRIPTION
In #238 forgot to update the AMI for canary and soaking, they need to have the empty product code and strict al2 filter