### PR TITLE
Update New Relic config

### DIFF
--- a/terraform/testcases/newrelic_exporter_metric_mock/otconfig.tpl
+++ b/terraform/testcases/newrelic_exporter_metric_mock/otconfig.tpl
@@ -15,7 +15,7 @@ exporters:
     loglevel: debug
   newrelic:
     apikey: super-secret-api-key
-    metrics_url_override: "https://${mock_endpoint}"
+    metrics_host_override: "${mock_endpoint}"
 
 service:
   pipelines:

--- a/terraform/testcases/newrelic_exporter_trace_mock/otconfig.tpl
+++ b/terraform/testcases/newrelic_exporter_trace_mock/otconfig.tpl
@@ -15,7 +15,7 @@ exporters:
     loglevel: debug
   newrelic:
     apikey: super-secret-api-key
-    spans_url_override: "https://${mock_endpoint}"
+    spans_host_override: "${mock_endpoint}"
 
 service:
   pipelines:


### PR DESCRIPTION
Noted in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/2481:

> `spans_url_override` and `metrics_url_override` has been renamed to `spans_host_override` and `metrics_host_override` to reflect the fact that you only need to specify host[:port] when overriding these endpoints.

I believe this should resolve the issue with the integration tests noted in https://github.com/aws-observability/aws-otel-collector/pull/392.