### PR TITLE
Update load generator's data type to statsD

### DIFF
--- a/docs/get-performance-model.md
+++ b/docs/get-performance-model.md
@@ -45,7 +45,8 @@ cd aws-otel-test-framework/terraform/performance
 terraform init
 terraform apply -var="data_rate=100" -var="testcase=../testcases/{{testcase name}}" -var="install_package_source=local" -var-file="../testcases/{{testcase name}}/parameters.tfvars"
 terraform destroy
-cat performance_model.json
+cd output
+cat performance.json
 ```
 
 2. Run on rate 1000 tps
@@ -55,7 +56,8 @@ cd aws-otel-test-framework/terraform/performance
 terraform init
 terraform apply -var="data_rate=1000" -var="testcase=../testcases/{{testcase name}}" -var="install_package_source=local" -var-file="../testcases/{{testcase name}}/parameters.tfvars"
 terraform destroy
-cat performance_model.json
+cd output
+cat performance.json
 ```
 
 3. Run on rate 5000 tps
@@ -65,7 +67,8 @@ cd aws-otel-test-framework/terraform/performance
 terraform init
 terraform apply -var="data_rate=5000" -var="testcase=../testcases/{{testcase name}}" -var="install_package_source=local" -var-file="../testcases/{{testcase name}}/parameters.tfvars"
 terraform destroy
-cat performance_model.json
+cd output
+cat performance.json
 ```
 
 4. the performance model could be found under `aws-otel-test-framework/terraform/performance/output/performance.json`, and you can open an issue to [AWS Otel Collector Repo](https://github.com/aws-observability/aws-otel-collector) with the performance model file so we can gather it into the performance model readme. 

--- a/terraform/testcases/statsd/parameters.tfvars
+++ b/terraform/testcases/statsd/parameters.tfvars
@@ -9,3 +9,5 @@ soaking_data_mode = "metric"
 
 # data model type. possible values: otlp, xray, etc
 soaking_data_type = "statsd"
+
+data_type="statsd"


### PR DESCRIPTION
* Add `data_type` here to enable statsD type when doing performance tests
* Revise some typos for performance test documents. 

{“testcase”:“statsd”,“instanceType”:“m5.2xlarge”,“receivers”:[“statsd”],“processors”:[],“exporters”:[“awsemf”,“logging”],“dataType”:“statsd”,“dataMode”:“metric”,“dataRate”:100,“avgCpu”:0.014999056263828822,“avgMem”:51.3046528,“commitId”:“dummy_commit”,“collectionPeriod”:10,“testingAmi”:“soaking_linux”}

{“testcase”:“statsd”,“instanceType”:“m5.2xlarge”,“receivers”:[“statsd”],“processors”:[],“exporters”:[“awsemf”,“logging”],“dataType”:“statsd”,“dataMode”:“metric”,“dataRate”:1000,“avgCpu”:0.016665346910702938,“avgMem”:53.072964266666666,“commitId”:“dummy_commit”,“collectionPeriod”:10,“testingAmi”:“soaking_linux”}

{“testcase”:“statsd”,“instanceType”:“m5.2xlarge”,“receivers”:[“statsd”],“processors”:[],“exporters”:[“awsemf”,“logging”],“dataType”:“statsd”,“dataMode”:“metric”,“dataRate”:5000,“avgCpu”:0.02033322330651426,“avgMem”:51.72906666666667,“commitId”:“dummy_commit”,“collectionPeriod”:10,“testingAmi”:“soaking_linux”}