### PR TITLE
Add UDP endpoint to StatsD soaking test command

### DIFF
--- a/terraform/ec2_setup/main.tf
+++ b/terraform/ec2_setup/main.tf
@@ -41,7 +41,8 @@ module "ec2_setup" {
   skip_validation = true
 
   # soaking test config
-  soaking_compose_file = var.sample_app_mode == "push" ? "../templates/defaults/soaking_docker_compose.tpl" : "../templates/defaults/soaking_docker_compose_pull_mode.tpl"
+  # StatsD use its own docker compose for udp port
+  soaking_compose_file = fileexists("${var.testcase}/soaking_docker_compose.tpl") ? "${var.testcase}/soaking_docker_compose.tpl" : (var.sample_app_mode == "push" ? "../templates/defaults/soaking_docker_compose.tpl" : "../templates/defaults/soaking_docker_compose_pull_mode.tpl")
   soaking_data_mode = var.soaking_data_mode
   soaking_data_rate = var.soaking_data_rate
   soaking_data_type = var.soaking_data_type

--- a/terraform/ec2_setup/variables.tf
+++ b/terraform/ec2_setup/variables.tf
@@ -17,7 +17,7 @@ variable "testing_ami" {
 }
 
 variable "soaking_sample_app_image" {
-  default = "aottestbed/aws-otel-load-generator:v0.1.0"
+  default = "aottestbed/aws-otel-load-generator:v0.1.3"
 }
 
 variable "soaking_sample_app" {

--- a/terraform/testcases/statsd/soaking_docker_compose.tpl
+++ b/terraform/testcases/statsd/soaking_docker_compose.tpl
@@ -1,0 +1,24 @@
+version: "3.8"
+services:
+  mocked_server:
+    image: ${mocked_server_image}
+    ports:
+      - "80:8080"
+      - "443:443"
+    deploy:
+      resources:
+        limits:
+          memory: 4G
+  ot-metric-emitter:
+    privileged: true
+    image: ${sample_app_image}
+    command: ["${data_mode}", "-r=${rate}", "-u=${udp_endpoint}", "-d=${data_type}"]
+    environment:
+      OTEL_RESOURCE_ATTRIBUTES: ${otel_resource_attributes}
+      AWS_XRAY_DAEMON_ADDRESS: ${udp_endpoint}
+      COLLECTOR_UDP_ADDRESS: ${udp_endpoint}
+      AWS_REGION: ${region}
+    deploy:
+      resources:
+        limits:
+          memory: 16G


### PR DESCRIPTION
## Change
1. use latest load generate which contains statsD metric.
2. add soaking docker compose file to statsD since the default is using `grpc_endpoint`, statsD is using `udp_endpoint`.
3. change `main.tf` to let others can config their soaking docker compose file.
## Test
The output is reasonable
1. {“testcase”:“statsd”,“instanceType”:“m5.2xlarge”,“receivers”:[“statsd”],“processors”:[],“exporters”:[“awsemf”,“logging”],“dataType”:“statsd”,“dataMode”:“metric”,“dataRate”:100,“avgCpu”:0.5966679033981541,“avgMem”:62.01623893333332,“commitId”:“dummy_commit”,“collectionPeriod”:10,“testingAmi”:“soaking_linux”}
2. {“testcase”:“statsd”,“instanceType”:“m5.2xlarge”,“receivers”:[“statsd”],“processors”:[],“exporters”:[“awsemf”,“logging”],“dataType”:“statsd”,“dataMode”:“metric”,“dataRate”:1000,“avgCpu”:5.893365319063977,“avgMem”:62.210798933333336,“commitId”:“dummy_commit”,“collectionPeriod”:10,“testingAmi”:“soaking_linux”}
3. {“testcase”:“statsd”,“instanceType”:“m5.2xlarge”,“receivers”:[“statsd”],“processors”:[],“exporters”:[“awsemf”,“logging”],“dataType”:“statsd”,“dataMode”:“metric”,“dataRate”:5000,“avgCpu”:26.46701327930025,“avgMem”:61.554824533333324,“commitId”:“dummy_commit”,“collectionPeriod”:10,“testingAmi”:“soaking_linux”}
Can see metrics in CW console.
