### PR TITLE
Add structured log validation for CloudWatch sample workloads

### DIFF
--- a/validator/build.gradle
+++ b/validator/build.gradle
@@ -49,6 +49,7 @@ dependencies {
 
     // json flattener
     compile group: 'com.github.wnameless', name: 'json-flattener', version: '0.1.0'
+    compile group: 'com.github.fge', name: 'json-schema-validator', version: '2.0.0'
 
     // command cli
     compile 'info.picocli:picocli:4.3.2'
@@ -60,6 +61,7 @@ dependencies {
     implementation 'com.amazonaws:aws-java-sdk-s3'
     implementation 'com.amazonaws:aws-java-sdk-cloudwatch'
     implementation 'com.amazonaws:aws-java-sdk-xray'
+    implementation 'com.amazonaws:aws-java-sdk-logs'
 
     // https://mvnrepository.com/artifact/com.github.awslabs/aws-request-signing-apache-interceptor
     implementation 'com.github.awslabs:aws-request-signing-apache-interceptor:b3772780da'

--- a/validator/src/main/java/com/amazon/aoc/exception/ExceptionCode.java
+++ b/validator/src/main/java/com/amazon/aoc/exception/ExceptionCode.java
@@ -31,6 +31,7 @@ public enum ExceptionCode {
   TRACE_LIST_NOT_MATCHED(50004, "trace list has different length"),
   DATA_EMITTER_UNAVAILABLE(50005, "the data emitter is unavailable to ping"),
   EMPTY_LIST(50007, "list is empty or null"),
+  LOG_FORMAT_NOT_MATCHED(50008, "log format not matched"),
 
   // build validator
   VALIDATION_TYPE_NOT_EXISTED(60001, "validation type not existed"),

--- a/validator/src/main/java/com/amazon/aoc/fileconfigs/ExpectedLogStructure.java
+++ b/validator/src/main/java/com/amazon/aoc/fileconfigs/ExpectedLogStructure.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.aoc.fileconfigs;
+
+public enum ExpectedLogStructure implements FileConfig {
+  EKS_CONTAINER_INSIGHT_LOG(
+          "/expected-data-template/eksContainerInsightExpectedLogStructures.mustache"),
+  ;
+
+  private String path;
+
+  ExpectedLogStructure(String path) {
+    this.path = path;
+  }
+
+  @Override
+  public String getPath() {
+    return this.path;
+  }
+}

--- a/validator/src/main/java/com/amazon/aoc/models/ValidationConfig.java
+++ b/validator/src/main/java/com/amazon/aoc/models/ValidationConfig.java
@@ -15,6 +15,7 @@
 
 package com.amazon.aoc.models;
 
+import com.amazon.aoc.fileconfigs.ExpectedLogStructure;
 import com.amazon.aoc.fileconfigs.ExpectedMetric;
 import com.amazon.aoc.fileconfigs.ExpectedTrace;
 import lombok.Data;
@@ -32,6 +33,7 @@ public class ValidationConfig {
 
   ExpectedMetric expectedMetricTemplate;
   ExpectedTrace expectedTraceTemplate;
+  ExpectedLogStructure expectedLogStructureTemplate;
 
   /**
    * alarm related.

--- a/validator/src/main/java/com/amazon/aoc/services/CloudWatchService.java
+++ b/validator/src/main/java/com/amazon/aoc/services/CloudWatchService.java
@@ -31,6 +31,11 @@ import com.amazonaws.services.cloudwatch.model.MetricStat;
 import com.amazonaws.services.cloudwatch.model.PutMetricDataRequest;
 import com.amazonaws.services.cloudwatch.model.PutMetricDataResult;
 import com.amazonaws.services.cloudwatch.model.StandardUnit;
+import com.amazonaws.services.logs.AWSLogs;
+import com.amazonaws.services.logs.AWSLogsClientBuilder;
+import com.amazonaws.services.logs.model.GetLogEventsRequest;
+import com.amazonaws.services.logs.model.GetLogEventsResult;
+import com.amazonaws.services.logs.model.OutputLogEvent;
 
 import java.util.Date;
 import java.util.List;
@@ -42,7 +47,8 @@ public class CloudWatchService {
   private static final int MAX_QUERY_PERIOD = 60;
   private static final String REQUESTER = "integrationTest";
 
-  AmazonCloudWatch amazonCloudWatch;
+  private AmazonCloudWatch amazonCloudWatch;
+  private AWSLogs awsLogs;
 
   /**
    * Construct CloudWatch Service with region.
@@ -51,6 +57,7 @@ public class CloudWatchService {
    */
   public CloudWatchService(String region) {
     amazonCloudWatch = AmazonCloudWatchClientBuilder.standard().withRegion(region).build();
+    awsLogs = AWSLogsClientBuilder.standard().withRegion(region).build();
   }
 
   /**
@@ -116,5 +123,25 @@ public class CloudWatchService {
    */
   public List<Datapoint> getDatapoints(GetMetricStatisticsRequest request) {
     return amazonCloudWatch.getMetricStatistics(request).getDatapoints();
+  }
+
+  /**
+   * getLogs fetches log entries from CloudWatch.
+   * @param logGroupName the log group name
+   * @param logStreamName the log stream name
+   * @param startFromTimestamp the start timestamp
+   * @param limit the maximum number of log events to be returned in a single query
+   * @return List of OutputLogEvent
+   */
+  public List<OutputLogEvent> getLogs(String logGroupName, String logStreamName,
+                                      long startFromTimestamp, int limit) {
+    GetLogEventsRequest request = new GetLogEventsRequest()
+            .withLogGroupName(logGroupName)
+            .withLogStreamName(logStreamName)
+            .withStartTime(startFromTimestamp)
+            .withLimit(limit);
+    
+    GetLogEventsResult result = awsLogs.getLogEvents(request);
+    return result.getEvents();
   }
 }

--- a/validator/src/main/java/com/amazon/aoc/validators/ContainerInsightStructuredLogValidator.java
+++ b/validator/src/main/java/com/amazon/aoc/validators/ContainerInsightStructuredLogValidator.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.aoc.validators;
+
+import com.amazon.aoc.callers.ICaller;
+import com.amazon.aoc.exception.BaseException;
+import com.amazon.aoc.exception.ExceptionCode;
+import com.amazon.aoc.fileconfigs.FileConfig;
+import com.amazon.aoc.helpers.MustacheHelper;
+import com.amazon.aoc.helpers.RetryHelper;
+import com.amazon.aoc.models.CloudWatchContext;
+import com.amazon.aoc.models.Context;
+import com.amazon.aoc.models.ValidationConfig;
+import com.amazon.aoc.services.CloudWatchService;
+import com.amazonaws.services.logs.model.OutputLogEvent;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.fge.jsonschema.main.JsonSchema;
+import com.github.fge.jsonschema.main.JsonSchemaFactory;
+import com.github.fge.jsonschema.report.ProcessingReport;
+import com.github.fge.jsonschema.util.JsonLoader;
+import lombok.extern.log4j.Log4j2;
+
+import java.time.Instant;
+import java.time.temporal.ChronoField;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Log4j2
+public class ContainerInsightStructuredLogValidator implements IValidator {
+  private CloudWatchService cloudWatchService;
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  private String logGroupName;
+
+  private Map<String, JsonSchema> jsonSchemaForApps;
+  private List<CloudWatchContext.App> validateApps;
+
+  private static final int MAX_RETRY_COUNT = 6;
+  private static final int QUERY_LIMIT = 500;
+  private static final int CHECK_INTERVAL_IN_MILLI = 30 * 1000;
+  private static final int CHECK_DURATION_IN_SECONDS = 2 * 60;
+
+  @Override
+  public void init(Context context, ValidationConfig validationConfig, ICaller caller,
+                   FileConfig expectedDataTemplate) throws Exception {
+    cloudWatchService = new CloudWatchService(context.getRegion());
+
+    CloudWatchContext cwContext = context.getCloudWatchContext();
+    logGroupName = String.format("/aws/containerinsights/%s/prometheus",
+            cwContext.getClusterName());
+    validateApps = getAppsToValidate(cwContext);
+
+    MustacheHelper mustacheHelper = new MustacheHelper();
+    String templateInput = mustacheHelper.render(expectedDataTemplate, context);
+    jsonSchemaForApps = parseJsonSchemaMap(templateInput);
+  }
+
+  @Override
+  public void validate() throws Exception {
+    log.info("[ContainerInsight] start validating structured log");
+
+    RetryHelper.retry(MAX_RETRY_COUNT, CHECK_INTERVAL_IN_MILLI, true, () -> {
+      Instant startTime = Instant.now().minusSeconds(CHECK_DURATION_IN_SECONDS)
+              .truncatedTo(ChronoUnit.MINUTES);
+
+      for (CloudWatchContext.App validatingApp : validateApps) {
+        List<OutputLogEvent> logEvents = cloudWatchService.getLogs(logGroupName,
+                validatingApp.getJob(), startTime.getLong(ChronoField.MILLI_OF_SECOND),
+                QUERY_LIMIT);
+        validateLogEvents(validatingApp, logEvents);
+      }
+    });
+    log.info("[ContainerInsight] finish validation successfully");
+  }
+
+  private void validateLogEvents(CloudWatchContext.App validatingApp,
+                                 List<OutputLogEvent> logEvents) throws Exception {
+    JsonSchema appSchema = jsonSchemaForApps.get(validatingApp.getName());
+
+    for (OutputLogEvent logEvent : logEvents) {
+      JsonNode logEventNode = mapper.readTree(logEvent.getMessage());
+      JsonNode logEventNamespaceNode = logEventNode.get("Namespace");
+      String logEventNamespace = logEventNamespaceNode == null ? "" :
+              logEventNamespaceNode.textValue();
+
+      if (!validatingApp.getNamespace().equals(logEventNamespace)) {
+        log.debug(String.format("[ContainerInsight] skip log validation: namespace not matched. "
+                + "Expected: %s, actual: %s", validatingApp.getNamespace(), logEventNamespace));
+      }
+
+      ProcessingReport report = appSchema.validate(JsonLoader.fromString(logEventNode.toString()));
+      if (report.isSuccess()) {
+        return;
+      }
+    }
+    throw new BaseException(
+            ExceptionCode.LOG_FORMAT_NOT_MATCHED, String.format("[ContainerInsight] none of the "
+            + "collected logs matches %s log structure", validatingApp.getName()));
+  }
+
+  private static List<CloudWatchContext.App> getAppsToValidate(CloudWatchContext cwContext) {
+    List<CloudWatchContext.App> apps = new ArrayList<>();
+    if (cwContext.getAppMesh() != null) {
+      apps.add(cwContext.getAppMesh());
+    }
+    if (cwContext.getNginx() != null) {
+      apps.add(cwContext.getNginx());
+    }
+    if (cwContext.getHaproxy() != null) {
+      apps.add(cwContext.getHaproxy());
+    }
+    if (cwContext.getJmx() != null) {
+      apps.add(cwContext.getJmx());
+    }
+    if (cwContext.getMemcached() != null) {
+      apps.add(cwContext.getMemcached());
+    }
+    return apps;
+  }
+
+  private static Map<String, JsonSchema> parseJsonSchemaMap(String templateInput) throws Exception {
+    Map<String, JsonSchema> jsonSchemaMap = new HashMap<>();
+    JsonNode schemaArrayNode = JsonLoader.fromString(templateInput);
+    JsonSchemaFactory jsonSchemaFactory = JsonSchemaFactory.byDefault();
+    for (JsonNode schemaNode : schemaArrayNode) {
+      if (schemaNode.get("app") == null || schemaNode.get("schema") == null) {
+        throw new BaseException(ExceptionCode.DATA_MODEL_NOT_MATCHED,
+                "Invalid schema format, missing property app or schema");
+      }
+      String appName = schemaNode.get("app").asText();
+      JsonSchema appSchema = jsonSchemaFactory.getJsonSchema(schemaNode.get("schema"));
+      jsonSchemaMap.put(appName, appSchema);
+    }
+    return jsonSchemaMap;
+  }
+
+}

--- a/validator/src/main/java/com/amazon/aoc/validators/ValidatorFactory.java
+++ b/validator/src/main/java/com/amazon/aoc/validators/ValidatorFactory.java
@@ -66,6 +66,10 @@ public class ValidatorFactory {
         validator = new ContainerInsightMetricsValidator();
         expectedData = validationConfig.getExpectedMetricTemplate();
         break;
+      case "eks-container-insight-logs":
+        validator = new ContainerInsightStructuredLogValidator();
+        expectedData = validationConfig.getExpectedLogStructureTemplate();
+        break;
       default:
         throw new BaseException(ExceptionCode.VALIDATION_TYPE_NOT_EXISTED);
     }

--- a/validator/src/main/resources/expected-data-template/eksContainerInsightExpectedLogStructures.mustache
+++ b/validator/src/main/resources/expected-data-template/eksContainerInsightExpectedLogStructures.mustache
@@ -1,0 +1,57 @@
+[
+  {
+    "app": "appMesh",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "title": "structured log schema",
+      "description": "json schema for the cloudwatch agent k8s structured log",
+      "type": "object",
+      "properties": {
+        "ClusterName": {},
+        "Namespace": {},
+        "TaskId": {},
+        "_aws": {
+          "properties": {
+            "CloudWatchMetrics": {},
+            "Timestamp": {}
+          },
+          "required": [
+            "CloudWatchMetrics",
+            "Timestamp"
+          ]
+        },
+        "instance": {},
+        "job": {},
+        "prom_metric_type": {},
+        "pod_name": {},
+        "container_name": {},
+        "app": {},
+        "envoy_http_conn_manager_prefix": {},
+        "envoy_http_downstream_rq_xx": {},
+        "envoy_response_code_class": {},
+        "pod_controller_kind": {},
+        "pod_controller_name": {},
+        "pod_phase": {}
+      },
+      "required": [
+        "ClusterName",
+        "Namespace",
+        "TaskId",
+        "_aws",
+        "instance",
+        "job",
+        "prom_metric_type",
+        "pod_name",
+        "container_name",
+        "app",
+        "envoy_http_conn_manager_prefix",
+        "envoy_http_downstream_rq_xx",
+        "envoy_response_code_class",
+        "pod_controller_kind",
+        "pod_controller_name",
+        "pod_phase"
+      ],
+      "additionalProperties": true
+    }
+  }
+]

--- a/validator/src/main/resources/validations/eks-container-insight.yml
+++ b/validator/src/main/resources/validations/eks-container-insight.yml
@@ -2,3 +2,7 @@
   validationType: "eks-container-insight-metrics"
   shouldValidateMetricValue: false
   expectedMetricTemplate: "EKS_CONTAINER_INSIGHT_METRIC"
+-
+  validationType: "eks-container-insight-logs"
+  shouldValidateMetricValue: false
+  expectedLogStructureTemplate: "EKS_CONTAINER_INSIGHT_LOG"


### PR DESCRIPTION
**Why do we need it?**
This is a follow-up PR of https://github.com/aws-observability/aws-otel-test-framework/pull/247.
In this PR, we add log schema checking to AppMesh workload.