### PR TITLE
Fix AMI setup for canary/soaking test.

### DIFF
--- a/terraform/canary/amis.tf
+++ b/terraform/canary/amis.tf
@@ -10,6 +10,7 @@ variable "ami_family" {
       start_command = "sudo /opt/aws/aws-otel-collector/bin/aws-otel-collector-ctl -c /tmp/ot-default.yml -a start"
       connection_type = "ssh"
       user_data = ""
+      wait_cloud_init = "for i in {1..60}; do [ ! -f /var/lib/cloud/instance/boot-finished ] && echo 'Waiting for cloud-init...' && sleep 1 || break; done"
     }
     windows = {
       login_user = "Administrator"
@@ -35,6 +36,7 @@ net start winrm
 Set-NetFirewallProfile -Profile Public -Enabled False
 </powershell>
 EOF
+      wait_cloud_init = ""
     }
   }
 }

--- a/terraform/ec2_setup/amis.tf
+++ b/terraform/ec2_setup/amis.tf
@@ -18,6 +18,7 @@ variable "ami_family" {
       soaking_cpu_metric_name = "procstat_cpu_usage"
       soaking_mem_metric_name = "procstat_memory_rss"
       soaking_process_name = "aws-otel-collector"
+      wait_cloud_init = "for i in {1..60}; do [ ! -f /var/lib/cloud/instance/boot-finished ] && echo 'Waiting for cloud-init...' && sleep 1 || break; done"
     }
     windows = {
       login_user = "Administrator"
@@ -51,6 +52,7 @@ net start winrm
 Set-NetFirewallProfile -Profile Public -Enabled False
 </powershell>
 EOF
+      wait_cloud_init = ""
     }
   }
 }


### PR DESCRIPTION
Add missing ami_family properties for canary/soaking test.
