### PR TITLE
Fix nil string issue in remote-exec

### DIFF
--- a/terraform/canary/amis.tf
+++ b/terraform/canary/amis.tf
@@ -36,7 +36,7 @@ net start winrm
 Set-NetFirewallProfile -Profile Public -Enabled False
 </powershell>
 EOF
-      wait_cloud_init = ""
+      wait_cloud_init = " "
     }
   }
 }

--- a/terraform/ec2/amis.tf
+++ b/terraform/ec2/amis.tf
@@ -63,7 +63,7 @@ net start winrm
 Set-NetFirewallProfile -Profile Public -Enabled False
 </powershell>
 EOF
-      wait_cloud_init = ""
+      wait_cloud_init = " "
     }
   }
 }

--- a/terraform/ec2_setup/amis.tf
+++ b/terraform/ec2_setup/amis.tf
@@ -52,7 +52,7 @@ net start winrm
 Set-NetFirewallProfile -Profile Public -Enabled False
 </powershell>
 EOF
-      wait_cloud_init = ""
+      wait_cloud_init = " "
     }
   }
 }


### PR DESCRIPTION
The remote-exec provisioner doesn't support empty string as inline. Fix following error for windows AMI which failed canary test.
 Error: Error parsing <nil> as a string

Refer to:
https://github.com/hashicorp/terraform/issues/13970
https://github.com/hashicorp/terraform/pull/14134