### PR TITLE
Restrict kubernetes version to be installed

### DIFF
--- a/terraform/containerinsight_eks_prometheus/main.tf
+++ b/terraform/containerinsight_eks_prometheus/main.tf
@@ -17,6 +17,14 @@
 # so in the eks/k8s test, we need tester to provide the cluster instead of creating it in terraform
 # so that we can shorten the execution time
 
+terraform {
+  required_providers {
+    kubernetes = {
+      version = "~> 1.13"
+    }
+  }
+}
+
 module "common" {
   source = "../common"
 


### PR DESCRIPTION
Got the following error when running as CI job remotely. It is caused by terraform downloading kubernetes v2 instead of v1.
```
Error: Unsupported argument
  on main.tf line 47, in provider "kubernetes":
  47:   load_config_file = false
```

This PR is created to fix this issue, and is validated by `terraform init -update && terraform apply`.