### PR TITLE
Add SSM package test for ADOT Collector in ec2 test

### DIFF
--- a/terraform/ec2/amis.tf
+++ b/terraform/ec2/amis.tf
@@ -23,6 +23,8 @@ variable "ami_family" {
       download_command_pattern = "wget %s"
       install_command = "sudo dpkg -i aws-otel-collector.deb"
       start_command = "sudo /opt/aws/aws-otel-collector/bin/aws-otel-collector-ctl -c /tmp/ot-default.yml -a start"
+      status_command = "sudo /opt/aws/aws-otel-collector/bin/aws-otel-collector-ctl -c /tmp/ot-default.yml -a status"
+      ssm_validate = "sudo /opt/aws/aws-otel-collector/bin/aws-otel-collector-ctl -c /tmp/ot-default.yml -a status | grep running"
       connection_type = "ssh"
       user_data = ""
       wait_cloud_init = "for i in {1..60}; do [ ! -f /var/lib/cloud/instance/boot-finished ] && echo 'Waiting for cloud-init...' && sleep 1 || break; done"
@@ -35,6 +37,8 @@ variable "ami_family" {
       download_command_pattern = "curl %s --output aws-otel-collector.rpm"
       install_command = "sudo rpm -Uvh aws-otel-collector.rpm"
       start_command = "sudo /opt/aws/aws-otel-collector/bin/aws-otel-collector-ctl -c /tmp/ot-default.yml -a start"
+      status_command = "sudo /opt/aws/aws-otel-collector/bin/aws-otel-collector-ctl -c /tmp/ot-default.yml -a status"
+      ssm_validate = "sudo /opt/aws/aws-otel-collector/bin/aws-otel-collector-ctl -c /tmp/ot-default.yml -a status | grep running"
       connection_type = "ssh"
       user_data = ""
       wait_cloud_init = "for i in {1..60}; do [ ! -f /var/lib/cloud/instance/boot-finished ] && echo 'Waiting for cloud-init...' && sleep 1 || break; done"
@@ -47,6 +51,8 @@ variable "ami_family" {
       download_command_pattern = "powershell -command \"Invoke-WebRequest -Uri %s -OutFile C:\\aws-otel-collector.msi\""
       install_command = "msiexec /i C:\\aws-otel-collector.msi"
       start_command = "powershell \"& 'C:\\Program Files\\Amazon\\AwsOtelCollector\\aws-otel-collector-ctl.ps1' -ConfigLocation C:\\ot-default.yml -Action start\""
+      status_command = "powershell \"& 'C:\\Program Files\\Amazon\\AwsOtelCollector\\aws-otel-collector-ctl.ps1' -ConfigLocation C:\\ot-default.yml -Action status\""
+      ssm_validate = "powershell \"& 'C:\\Program Files\\Amazon\\AwsOtelCollector\\aws-otel-collector-ctl.ps1' -ConfigLocation C:\\ot-default.yml -Action status\" | findstr running"
       connection_type = "winrm"
       user_data = <<EOF
 <powershell>

--- a/terraform/ec2/main.tf
+++ b/terraform/ec2/main.tf
@@ -70,6 +70,9 @@ locals {
 
   # get instance subnet, use separate subnet for soaking and performance test as it takes more instances and some times eat up all the available ip address in the subnet
   instance_subnet = var.testing_type == "e2e" ? tolist(module.basic_components.aoc_public_subnet_ids)[1] : tolist(module.basic_components.aoc_public_subnet_ids)[0]
+
+  # get SSM package version, latest is the default version
+  ssm_package_version = var.aoc_version == "latest" ? "\"\"" : trimprefix(var.aoc_version, "v")
 }
 
 ## launch a sidecar instance to install data emitter and the mocked server
@@ -228,6 +231,7 @@ resource "null_resource" "download_collector_from_s3" {
 }
 
 resource "null_resource" "start_collector" {
+  count = var.install_package_source == "ssm" ? 0 : 1
   # either getting the install package from s3 or from local
   depends_on = [null_resource.download_collector_from_local, null_resource.download_collector_from_s3]
   provisioner "file" {
@@ -260,6 +264,38 @@ resource "null_resource" "start_collector" {
   }
 }
 
+resource "aws_ssm_parameter" "setup_aoc_config" {
+  count = var.install_package_source == "ssm" ? 1 : 0
+  name  = format("aoc-config-%s", module.common.testing_id)
+  type  = "String"
+  value = var.ssm_config
+}
+
+resource "null_resource" "install_collector_from_ssm" {
+  depends_on = [null_resource.check_patch, aws_ssm_parameter.setup_aoc_config]
+  count = var.install_package_source == "ssm" ? 1 : 0
+
+  provisioner "remote-exec" {
+    inline = [
+      local.ami_family["wait_cloud_init"],
+    ]
+
+    connection {
+      type = local.connection_type
+      user = local.login_user
+      private_key = local.connection_type == "ssh" ? local.private_key_content : null
+      password = local.connection_type == "winrm" ? rsadecrypt(aws_instance.aoc.password_data, local.private_key_content) : null
+      host = aws_instance.aoc.public_ip
+    }
+  }
+
+    provisioner "local-exec" {
+      command = <<-EOT
+        bash ../templates/local/ssm-install-aoc.sh ${aws_instance.aoc.id} ${var.ssm_package_name} ${local.ssm_package_version} ${aws_ssm_parameter.setup_aoc_config[0].name}
+    EOT
+  }
+}
+
 ########################################
 # Start Sample app and mocked server
 #########################################
@@ -285,6 +321,7 @@ data "template_file" "docker_compose" {
 }
 
 resource "null_resource" "setup_sample_app_and_mock_server" {
+  count = var.disable_mocked_server ? 0 : 1
   depends_on = [null_resource.check_patch]
   provisioner "file" {
     content = data.template_file.docker_compose.rendered
@@ -376,7 +413,7 @@ resource "null_resource" "install_cwagent" {
 # Validation
 ##########################################
 module "validator" {
-  count = !var.skip_validation ? 1 : 0
+  count = !var.skip_validation && !var.enable_ssm_validate ? 1 : 0
   source = "../validation"
 
   validation_config = var.validation_config
@@ -394,6 +431,26 @@ module "validator" {
   aws_secret_access_key = var.aws_secret_access_key
 
   depends_on = [null_resource.setup_sample_app_and_mock_server, null_resource.start_collector]
+}
+
+resource "null_resource" "ssm_validation" {
+  depends_on = [null_resource.install_collector_from_ssm]
+  count = !var.skip_validation && var.enable_ssm_validate ? 1 : 0
+
+  provisioner "remote-exec" {
+    inline = [
+      local.ami_family["status_command"],
+      local.ami_family["ssm_validate"],
+    ]
+
+    connection {
+      type = local.connection_type
+      user = local.login_user
+      private_key = local.connection_type == "ssh" ? local.private_key_content : null
+      password = local.connection_type == "winrm" ? rsadecrypt(aws_instance.aoc.password_data, local.private_key_content) : null
+      host = aws_instance.aoc.public_ip
+    }
+  }
 }
 
 output "public_ip" {

--- a/terraform/ec2/variables.tf
+++ b/terraform/ec2/variables.tf
@@ -75,7 +75,7 @@ variable "negative_soaking" {
 }
 
 
-# options: s3, local
+# options: s3, local, ssm
 variable "install_package_source" {
   default = "s3" # which means we download rpm/dev/msi from s3, the links are defined in the ami map.
 }
@@ -101,3 +101,28 @@ variable "patch" {
   default = false
 }
 
+######################
+# SSM related
+######################
+
+# ADOT SSM package name
+variable "ssm_package_name" {
+  default = "AWSDistroOTel-Collector"
+}
+
+# Base64 value of ADOT Collector YMAL configuration
+variable "ssm_config" {
+  default = ""
+}
+
+# bypass mocked server setup
+variable "disable_mocked_server" {
+  type = bool
+  default = false
+}
+
+# use ssm_validation instead of validator
+variable "enable_ssm_validate" {
+  type = bool
+  default = false
+}

--- a/terraform/templates/local/ssm-install-aoc.sh
+++ b/terraform/templates/local/ssm-install-aoc.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+set -ue
+
+instance_id=$1
+package_name=$2
+package_version=$3
+parameter_name=$4
+
+echo "Sleep 15s for EC2 become online in SSM."
+sleep 15
+
+for i in {1..30}; do
+  output=$(aws ssm describe-instance-information --filters "Key=InstanceIds,Values=$instance_id")
+  echo ${output}
+  status=$(echo ${output} | python3 -c "import sys, json; print('online') if len(json.load(sys.stdin)['InstanceInformationList']) == 1 else print('down')")
+  if [[ ${status} == "online" ]]
+  then
+    break
+  else
+    echo "Wait 3s for EC2 become online in SSM...""$i"
+    sleep 3
+  fi
+done
+
+for j in {1..3}; do
+  output=$(aws ssm send-command \
+    --document-name "AWS-ConfigureAWSPackage" \
+    --document-version "1" \
+    --targets '[{"Key":"InstanceIds","Values":["'$instance_id'"]}]' \
+    --parameters '{"action":["Install"],"installationType":["Uninstall and reinstall"],"name":["'$package_name'"],"version":["'$package_version'"],"additionalArguments":["{\"SSM_CONFIG\": \"{{ssm:'$parameter_name'}}\"}"]}' \
+    --timeout-seconds 600 \
+    --max-concurrency "50" \
+    --max-errors "0" \
+    --region us-west-2)
+  echo ${output}
+
+  command_id=$(echo ${output} | python3 -c "import sys, json; print(json.load(sys.stdin)['Command']['CommandId'])")
+
+  echo "Sleep 15s for SSM command execution."
+  sleep 15
+
+  for i in {1..30}; do
+    output=$(aws ssm get-command-invocation \
+        --command-id "$command_id" \
+        --instance-id "$instance_id")
+    echo ${output}
+    status=$(echo ${output} | python3 -c "import sys, json; print(json.load(sys.stdin)['Status'])")
+    if [[ ${status} == "Success" ]]
+    then
+      echo "Sleep 15s for ADOT Collector start..."
+      sleep 15
+      exit 0
+    elif [[ ${status} == "Failed" ]]
+    then
+      break
+    else
+      echo "Wait 3s for SSM command complete...""$i"
+      sleep 3
+    fi
+  done
+
+  echo "SSM installation failed. Try again...""$j"
+done
+
+

--- a/terraform/testcases/ssm_package/parameters.tfvars
+++ b/terraform/testcases/ssm_package/parameters.tfvars
@@ -1,0 +1,18 @@
+# SSM package name for Otel Collector
+ssm_package_name = "testAWSDistroOTel-Collector"
+
+# Base64 value of Otel Collector YAML configuration
+ssm_config = "ZXh0ZW5zaW9uczoKICBoZWFsdGhfY2hlY2s6CiAgcHByb2Y6CiAgICBlbmRwb2ludDogMC4wLjAuMDoxNzc3CgpyZWNlaXZlcnM6CiAgb3RscDoKICAgIHByb3RvY29sczoKICAgICAgZ3JwYzoKICAgICAgICBlbmRwb2ludDogMC4wLjAuMDo0MzE3Cgpwcm9jZXNzb3JzOgogIGJhdGNoOgoKZXhwb3J0ZXJzOgogIGxvZ2dpbmc6CiAgICBsb2dsZXZlbDogZGVidWcKICBhd3N4cmF5OgogICAgcmVnaW9uOiAndXMtd2VzdC0yJwogIGF3c2VtZjoKICAgIHJlZ2lvbjogJ3VzLXdlc3QtMicKCnNlcnZpY2U6CiAgcGlwZWxpbmVzOgogICAgdHJhY2VzOgogICAgICByZWNlaXZlcnM6IFtvdGxwXQogICAgICBleHBvcnRlcnM6IFthd3N4cmF5XQogICAgbWV0cmljczoKICAgICAgcmVjZWl2ZXJzOiBbb3RscF0KICAgICAgZXhwb3J0ZXJzOiBbYXdzZW1mXQoKICBleHRlbnNpb25zOiBbcHByb2ZdCg=="
+
+# enable SSM package validation
+enable_ssm_validate = true
+
+# disable mocked server
+disable_mocked_server = true
+
+# enable patch
+patch = true
+
+# enable SSM installation
+install_package_source = "ssm"
+


### PR DESCRIPTION
Add SSM package validation to ADOT collect test framework. The usage of new testcase `ssm_package` is as same as existing ec2 testcases. The var `ssm_package_name` and var `ssm_config` are parameters of the new testcase.