### PR TITLE
Fix validate build with gradle v7.0'

### DIFF
--- a/validator/build.gradle
+++ b/validator/build.gradle
@@ -31,28 +31,28 @@ repositories {
 }
 
 dependencies {
-    testCompile group: 'junit', name: 'junit', version: '4.12'
-    testCompile group: 'org.assertj', name: 'assertj-core', version: '3.16.1'
+    testImplementation group: 'junit', name: 'junit', version: '4.12'
+    testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.16.1'
 
     // log
-    compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.7'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.7'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.7'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.7'
 
     // mustache template
-    compile group: 'com.github.spullara.mustache.java', name: 'compiler', version: '0.8.9'
+    implementation group: 'com.github.spullara.mustache.java', name: 'compiler', version: '0.8.9'
 
     // apache io utils
-    compile group: 'commons-io', name: 'commons-io', version: '2.4'
+    implementation group: 'commons-io', name: 'commons-io', version: '2.4'
 
     // yaml reader
-    compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.11.1'
+    implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.11.1'
 
     // json flattener
-    compile group: 'com.github.wnameless', name: 'json-flattener', version: '0.1.0'
-    compile group: 'com.github.fge', name: 'json-schema-validator', version: '2.0.0'
+    implementation group: 'com.github.wnameless', name: 'json-flattener', version: '0.1.0'
+    implementation group: 'com.github.fge', name: 'json-schema-validator', version: '2.0.0'
 
     // command cli
-    compile 'info.picocli:picocli:4.3.2'
+    implementation 'info.picocli:picocli:4.3.2'
 
     compileOnly 'info.picocli:picocli-codegen:4.3.2'
 
@@ -70,7 +70,7 @@ dependencies {
     implementation("com.squareup.okhttp3:okhttp:4.9.0")
 
     // command cli
-    compile 'info.picocli:picocli:4.3.2'
+    implementation 'info.picocli:picocli:4.3.2'
 
     compileOnly 'info.picocli:picocli-codegen:4.3.2'
 }


### PR DESCRIPTION
Validator docker build failed after gradle docker upgrade to v7.0. This PR should fix it and recover integration test.