### PR TITLE
Lock to Gradle 6 in docker build to fix integration test

### DIFF
--- a/load-generator/Dockerfile
+++ b/load-generator/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle as builder
+FROM gradle:6.8.3 as builder
 
 # build
 WORKDIR /app

--- a/sample-apps/jaeger-zipkin-sample-app/Dockerfile
+++ b/sample-apps/jaeger-zipkin-sample-app/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle as builder
+FROM gradle:6.8.3 as builder
 
 WORKDIR /app
 COPY ./build.gradle ./build.gradle

--- a/sample-apps/spark/Dockerfile
+++ b/sample-apps/spark/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle as build
+FROM gradle:6.8.3 as build
 
 WORKDIR /app
 COPY ./build.gradle ./build.gradle

--- a/validator/Dockerfile
+++ b/validator/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle as build
+FROM gradle:6.8.3 as build
 
 WORKDIR /app
 COPY ./build.gradle ./build.gradle

--- a/validator/build.gradle
+++ b/validator/build.gradle
@@ -31,28 +31,28 @@ repositories {
 }
 
 dependencies {
-    testImplementation group: 'junit', name: 'junit', version: '4.12'
-    testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.16.1'
+    testCompile group: 'junit', name: 'junit', version: '4.12'
+    testCompile group: 'org.assertj', name: 'assertj-core', version: '3.16.1'
 
     // log
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.7'
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.7'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.7'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.7'
 
     // mustache template
-    implementation group: 'com.github.spullara.mustache.java', name: 'compiler', version: '0.8.9'
+    compile group: 'com.github.spullara.mustache.java', name: 'compiler', version: '0.8.9'
 
     // apache io utils
-    implementation group: 'commons-io', name: 'commons-io', version: '2.4'
+    compile group: 'commons-io', name: 'commons-io', version: '2.4'
 
     // yaml reader
-    implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.11.1'
+    compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.11.1'
 
     // json flattener
-    implementation group: 'com.github.wnameless', name: 'json-flattener', version: '0.1.0'
-    implementation group: 'com.github.fge', name: 'json-schema-validator', version: '2.0.0'
+    compile group: 'com.github.wnameless', name: 'json-flattener', version: '0.1.0'
+    compile group: 'com.github.fge', name: 'json-schema-validator', version: '2.0.0'
 
     // command cli
-    implementation 'info.picocli:picocli:4.3.2'
+    compile 'info.picocli:picocli:4.3.2'
 
     compileOnly 'info.picocli:picocli-codegen:4.3.2'
 
@@ -70,7 +70,7 @@ dependencies {
     implementation("com.squareup.okhttp3:okhttp:4.9.0")
 
     // command cli
-    implementation 'info.picocli:picocli:4.3.2'
+    compile 'info.picocli:picocli:4.3.2'
 
     compileOnly 'info.picocli:picocli-codegen:4.3.2'
 }


### PR DESCRIPTION
* Revert https://github.com/aws-observability/aws-otel-test-framework/pull/272 since it only fix validator docker build.
* For now, stick with Gradle 6 to let all CI/CD tests working. 
* Plan to upgrade whole project to Gradle 7 later after CI/CD workflow get fixed.