### PR TITLE
Remove patching setting for SSM package test

### DIFF
--- a/terraform/testcases/ssm_package/parameters.tfvars
+++ b/terraform/testcases/ssm_package/parameters.tfvars
@@ -10,9 +10,6 @@ enable_ssm_validate = true
 # disable mocked server
 disable_mocked_server = true
 
-# enable patch
-patch = true
-
 # enable SSM installation
 install_package_source = "ssm"
 


### PR DESCRIPTION
Don't do patching to save some test time in CI test.