### PR TITLE
tf: Add ssm policy for ecs ec2 instances

### DIFF
--- a/terraform/ecs/efs.tf
+++ b/terraform/ecs/efs.tf
@@ -46,16 +46,11 @@ data "aws_ami" "amazonlinux2" {
   most_recent = true
 
   filter {
-    name   = "owner-alias"
-    values = ["amazon"]
-  }
-
-  filter {
     name   = "name"
-    values = ["amzn2-ami-hvm*"]
+    values = ["amzn2-ami-hvm-2.0.????????.?-x86_64-gp2"]
   }
 
-  owners = ["amazon"] # Canonical
+  owners = ["amazon"]
 }
 
 resource "tls_private_key" "ssh_key" {

--- a/terraform/ecs/instance-policy.json
+++ b/terraform/ecs/instance-policy.json
@@ -1,0 +1,50 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ecs:CreateCluster",
+        "ecs:DeregisterContainerInstance",
+        "ecs:DiscoverPollEndpoint",
+        "ecs:Poll",
+        "ecs:RegisterContainerInstance",
+        "ecs:StartTelemetrySession",
+        "ecs:Submit*",
+        "ecr:GetAuthorizationToken",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:BatchGetImage",
+        "ecr:BatchCheckLayerAvailability",
+        "s3:GetObject",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents",
+        "ssm:DescribeAssociation",
+        "ssm:GetDeployablePatchSnapshotForInstance",
+        "ssm:GetDocument",
+        "ssm:DescribeDocument",
+        "ssm:GetManifest",
+        "ssm:GetParameter",
+        "ssm:GetParameters",
+        "ssm:ListAssociations",
+        "ssm:ListInstanceAssociations",
+        "ssm:PutInventory",
+        "ssm:PutComplianceItems",
+        "ssm:PutConfigurePackageResult",
+        "ssm:UpdateAssociationStatus",
+        "ssm:UpdateInstanceAssociationStatus",
+        "ssm:UpdateInstanceInformation",
+        "ssmmessages:CreateControlChannel",
+        "ssmmessages:CreateDataChannel",
+        "ssmmessages:OpenControlChannel",
+        "ssmmessages:OpenDataChannel",
+        "ec2messages:AcknowledgeMessage",
+        "ec2messages:DeleteMessage",
+        "ec2messages:FailMessage",
+        "ec2messages:GetEndpoint",
+        "ec2messages:GetMessages",
+        "ec2messages:SendReply"
+      ],
+      "Resource": "*"
+    }
+  ]
+}

--- a/terraform/ecs/main.tf
+++ b/terraform/ecs/main.tf
@@ -56,15 +56,17 @@ module "ecs_cluster" {
   source  = "infrablocks/ecs-cluster/aws"
   version = "3.0.0"
 
-  cluster_name                  = module.common.testing_id
-  component                     = "aoc"
-  deployment_identifier         = "testing"
-  vpc_id                        = module.basic_components.aoc_vpc_id
-  subnet_ids                    = module.basic_components.aoc_private_subnet_ids
-  region                        = var.region
-  associate_public_ip_addresses = "yes"
-  security_groups               = [module.basic_components.aoc_security_group_id]
-  cluster_desired_capacity      = 1
+  cluster_name                         = module.common.testing_id
+  component                            = "aoc"
+  deployment_identifier                = "testing"
+  vpc_id                               = module.basic_components.aoc_vpc_id
+  subnet_ids                           = module.basic_components.aoc_private_subnet_ids
+  region                               = var.region
+  associate_public_ip_addresses        = "yes"
+  security_groups                      = [module.basic_components.aoc_security_group_id]
+  cluster_desired_capacity             = 1
+  cluster_instance_iam_policy_contents = file("instance-policy.json")
+  // TODO(pingleig): pass patch tag for canary and soaking (if any)
 }
 
 resource "aws_ssm_parameter" "otconfig" {


### PR DESCRIPTION
This would allow ssm to report host status, patch does not work until we pass the patch tag