### PR TITLE
Avoid conflicts when running multi CI jobs concurrently

### DIFF
--- a/terraform/containerinsight_eks_prometheus/appmesh/appmesh.tf
+++ b/terraform/containerinsight_eks_prometheus/appmesh/appmesh.tf
@@ -91,7 +91,7 @@ resource "kubernetes_service_account" "appmesh_sa" {
 }
 
 resource "helm_release" "eks" {
-  name      = "eks"
+  name      = "eks-${var.testing_id}"
   namespace = kubernetes_namespace.appmesh_ns.metadata[0].name
 
   repository = "https://aws.github.io/eks-charts"
@@ -150,10 +150,8 @@ resource "null_resource" "delete_mesh" {
 resource "null_resource" "appmesh_readiness_check" {
   provisioner "local-exec" {
     when    = create
-    command = "kubectl --kubeconfig=${var.kubeconfig} rollout status deployment eks-appmesh-controller -n${kubernetes_namespace.appmesh_ns.metadata[0].name}"
+    command = "kubectl --kubeconfig=${var.kubeconfig} rollout status deployment ${helm_release.eks.name}-appmesh-controller -n${kubernetes_namespace.appmesh_ns.metadata[0].name}"
   }
-  depends_on = [
-  helm_release.eks]
 }
 
 data "template_file" "traffic_deployment_file" {

--- a/terraform/containerinsight_eks_prometheus/haproxy/haproxy.tf
+++ b/terraform/containerinsight_eks_prometheus/haproxy/haproxy.tf
@@ -33,7 +33,7 @@ resource "kubernetes_namespace" "haproxy_ns" {
 }
 
 resource "helm_release" "haproxy" {
-  name      = "terraform"
+  name      = "haproxy-${var.testing_id}"
   namespace = kubernetes_namespace.haproxy_ns.metadata[0].name
 
   repository = "https://haproxy-ingress.github.io/charts"

--- a/terraform/containerinsight_eks_prometheus/nginx/nginx.tf
+++ b/terraform/containerinsight_eks_prometheus/nginx/nginx.tf
@@ -33,7 +33,7 @@ output "metric_dimension_namespace" {
 
 resource "kubernetes_namespace" "nginx_ns" {
   metadata {
-    name = "nginx-system-${var.testing_id}"
+    name = "nginx-${var.testing_id}"
   }
 }
 
@@ -44,7 +44,7 @@ resource "kubernetes_namespace" "traffic_ns" {
 }
 
 resource "helm_release" "nginx_ingress" {
-  name      = "terraform"
+  name      = "nginx-${var.testing_id}"
   namespace = kubernetes_namespace.nginx_ns.metadata[0].name
 
   repository = "https://kubernetes.github.io/ingress-nginx"

--- a/terraform/testcases/containerinsight_eks_prometheus/nginx_traffic_sample.tpl
+++ b/terraform/testcases/containerinsight_eks_prometheus/nginx_traffic_sample.tpl
@@ -1,23 +1,30 @@
-kind: Pod
-apiVersion: v1
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: banana-app
   namespace: ${NAMESPACE}
-  labels:
-    app: banana
 spec:
-  containers:
-    - name: banana-app
-      image: hashicorp/http-echo
-      args:
-        - "-text=banana"
-      resources:
-        limits:
-          cpu:  100m
-          memory: 100Mi
-        requests:
-          cpu: 50m
-          memory: 50Mi
+  replicas: 1
+  selector:
+    matchLabels:
+      app: banana
+  template:
+    metadata:
+      labels:
+        app: banana
+    spec:
+      containers:
+        - name: banana-app
+          image: hashicorp/http-echo
+          args:
+            - "-text=banana"
+          resources:
+            limits:
+              cpu:  100m
+              memory: 100Mi
+            requests:
+              cpu: 50m
+              memory: 50Mi
 ---
 
 kind: Service
@@ -32,27 +39,33 @@ spec:
     - port: 5678 # Default port for image
 
 ---
-
-kind: Pod
-apiVersion: v1
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: apple-app
   namespace: ${NAMESPACE}
-  labels:
-    app: apple
 spec:
-  containers:
-    - name: apple-app
-      image: hashicorp/http-echo
-      args:
-        - "-text=apple"
-      resources:
-        limits:
-          cpu:  100m
-          memory: 100Mi
-        requests:
-          cpu: 50m
-          memory: 50Mi
+  replicas: 1
+  selector:
+    matchLabels:
+      app: apple
+  template:
+    metadata:
+      labels:
+        app: apple
+    spec:
+      containers:
+        - name: apple-app
+          image: hashicorp/http-echo
+          args:
+            - "-text=apple"
+          resources:
+            limits:
+              cpu:  100m
+              memory: 100Mi
+            requests:
+              cpu: 50m
+              memory: 50Mi
 ---
 
 kind: Service
@@ -88,22 +101,30 @@ spec:
             servicePort: 5678
 
 ---
-
-apiVersion: v1
-kind: Pod
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: traffic-generator
   namespace: ${NAMESPACE}
 spec:
-  containers:
-    - name: traffic-generator
-      image: ellerbrock/alpine-bash-curl-ssl
-      command: ["/bin/bash"]
-      args: ["-c", "while :; do curl http://${EXTERNAL_IP}/apple > /dev/null 2>&1; curl http://${EXTERNAL_IP}/banana > /dev/null 2>&1; sleep 1; done"]
-      resources:
-        limits:
-          cpu:  100m
-          memory: 100Mi
-        requests:
-          cpu: 50m
-          memory: 50Mi
+  replicas: 1
+  selector:
+    matchLabels:
+      app: traffic-generator
+  template:
+    metadata:
+      labels:
+        app: traffic-generator
+    spec:
+      containers:
+        - name: traffic-generator
+          image: ellerbrock/alpine-bash-curl-ssl
+          command: ["/bin/bash"]
+          args: ["-c", "while :; do curl http://${EXTERNAL_IP}/apple > /dev/null 2>&1; curl http://${EXTERNAL_IP}/banana > /dev/null 2>&1; sleep 1; done"]
+          resources:
+            limits:
+              cpu:  100m
+              memory: 100Mi
+            requests:
+              cpu: 50m
+              memory: 50Mi

--- a/validator/src/main/resources/expected-data-template/container-insight/eks/prometheus/eksContainerInsightExpectedMetrics.mustache
+++ b/validator/src/main/resources/expected-data-template/container-insight/eks/prometheus/eksContainerInsightExpectedMetrics.mustache
@@ -193,7 +193,7 @@
     - name: Namespace
       value: {{cloudWatchContext.nginx.namespace}}
     - name: Service
-      value: terraform-ingress-nginx-controller-metrics
+      value: {{cloudWatchContext.nginx.namespace}}-ingress-nginx-controller-metrics
 - metricName: nginx_ingress_controller_nginx_process_resident_memory_bytes
   namespace: ContainerInsights/Prometheus
   dimensions:
@@ -202,7 +202,7 @@
     - name: Namespace
       value: {{cloudWatchContext.nginx.namespace}}
     - name: Service
-      value: terraform-ingress-nginx-controller-metrics
+      value: {{cloudWatchContext.nginx.namespace}}-ingress-nginx-controller-metrics
 - metricName: nginx_ingress_controller_nginx_process_cpu_seconds_total
   namespace: ContainerInsights/Prometheus
   dimensions:
@@ -211,7 +211,7 @@
     - name: Namespace
       value: {{cloudWatchContext.nginx.namespace}}
     - name: Service
-      value: terraform-ingress-nginx-controller-metrics
+      value: {{cloudWatchContext.nginx.namespace}}-ingress-nginx-controller-metrics
 - metricName: nginx_ingress_controller_success
   namespace: ContainerInsights/Prometheus
   dimensions:
@@ -220,7 +220,7 @@
     - name: Namespace
       value: {{cloudWatchContext.nginx.namespace}}
     - name: Service
-      value: terraform-ingress-nginx-controller-metrics
+      value: {{cloudWatchContext.nginx.namespace}}-ingress-nginx-controller-metrics
 - metricName: nginx_ingress_controller_config_last_reload_successful
   namespace: ContainerInsights/Prometheus
   dimensions:
@@ -229,7 +229,7 @@
     - name: Namespace
       value: {{cloudWatchContext.nginx.namespace}}
     - name: Service
-      value: terraform-ingress-nginx-controller-metrics
+      value: {{cloudWatchContext.nginx.namespace}}-ingress-nginx-controller-metrics
 - metricName: nginx_ingress_controller_nginx_process_connections_total
   namespace: ContainerInsights/Prometheus
   dimensions:
@@ -238,7 +238,7 @@
     - name: Namespace
       value: {{cloudWatchContext.nginx.namespace}}
     - name: Service
-      value: terraform-ingress-nginx-controller-metrics
+      value: {{cloudWatchContext.nginx.namespace}}-ingress-nginx-controller-metrics
 - metricName: nginx_ingress_controller_requests
   namespace: ContainerInsights/Prometheus
   dimensions:
@@ -247,7 +247,7 @@
     - name: Namespace
       value: {{cloudWatchContext.nginx.namespace}}
     - name: Service
-      value: terraform-ingress-nginx-controller-metrics
+      value: {{cloudWatchContext.nginx.namespace}}-ingress-nginx-controller-metrics
 - metricName: nginx_ingress_controller_requests
   namespace: ContainerInsights/Prometheus
   dimensions:
@@ -256,7 +256,7 @@
     - name: Namespace
       value: {{cloudWatchContext.nginx.namespace}}
     - name: Service
-      value: terraform-ingress-nginx-controller-metrics
+      value: {{cloudWatchContext.nginx.namespace}}-ingress-nginx-controller-metrics
     - name: status
       value: 200
 - metricName: nginx_ingress_controller_requests
@@ -267,7 +267,7 @@
     - name: Namespace
       value: {{cloudWatchContext.nginx.namespace}}
     - name: Service
-      value: terraform-ingress-nginx-controller-metrics
+      value: {{cloudWatchContext.nginx.namespace}}-ingress-nginx-controller-metrics
     - name: ingress
       value: ingress-nginx-demo
 
@@ -519,7 +519,7 @@
     - name: Namespace
       value: {{cloudWatchContext.haproxy.namespace}}
     - name: Service
-      value: terraform-haproxy-ingress-metrics
+      value: {{cloudWatchContext.haproxy.namespace}}-haproxy-ingress-metrics
 - metricName: haproxy_backend_bytes_in_total
   namespace: ContainerInsights/Prometheus
   dimensions:
@@ -528,7 +528,7 @@
     - name: Namespace
       value: {{cloudWatchContext.haproxy.namespace}}
     - name: Service
-      value: terraform-haproxy-ingress-metrics
+      value: {{cloudWatchContext.haproxy.namespace}}-haproxy-ingress-metrics
 - metricName: haproxy_backend_bytes_out_total
   namespace: ContainerInsights/Prometheus
   dimensions:
@@ -537,7 +537,7 @@
     - name: Namespace
       value: {{cloudWatchContext.haproxy.namespace}}
     - name: Service
-      value: terraform-haproxy-ingress-metrics
+      value: {{cloudWatchContext.haproxy.namespace}}-haproxy-ingress-metrics
 - metricName: haproxy_backend_connection_errors_total
   namespace: ContainerInsights/Prometheus
   dimensions:
@@ -546,7 +546,7 @@
     - name: Namespace
       value: {{cloudWatchContext.haproxy.namespace}}
     - name: Service
-      value: terraform-haproxy-ingress-metrics
+      value: {{cloudWatchContext.haproxy.namespace}}-haproxy-ingress-metrics
 - metricName: haproxy_backend_current_sessions
   namespace: ContainerInsights/Prometheus
   dimensions:
@@ -555,7 +555,7 @@
     - name: Namespace
       value: {{cloudWatchContext.haproxy.namespace}}
     - name: Service
-      value: terraform-haproxy-ingress-metrics
+      value: {{cloudWatchContext.haproxy.namespace}}-haproxy-ingress-metrics
 - metricName: haproxy_frontend_bytes_in_total
   namespace: ContainerInsights/Prometheus
   dimensions:
@@ -564,7 +564,7 @@
     - name: Namespace
       value: {{cloudWatchContext.haproxy.namespace}}
     - name: Service
-      value: terraform-haproxy-ingress-metrics
+      value: {{cloudWatchContext.haproxy.namespace}}-haproxy-ingress-metrics
 - metricName: haproxy_frontend_bytes_out_total
   namespace: ContainerInsights/Prometheus
   dimensions:
@@ -573,7 +573,7 @@
     - name: Namespace
       value: {{cloudWatchContext.haproxy.namespace}}
     - name: Service
-      value: terraform-haproxy-ingress-metrics
+      value: {{cloudWatchContext.haproxy.namespace}}-haproxy-ingress-metrics
 - metricName: haproxy_frontend_connections_total
   namespace: ContainerInsights/Prometheus
   dimensions:
@@ -582,7 +582,7 @@
     - name: Namespace
       value: {{cloudWatchContext.haproxy.namespace}}
     - name: Service
-      value: terraform-haproxy-ingress-metrics
+      value: {{cloudWatchContext.haproxy.namespace}}-haproxy-ingress-metrics
 - metricName: haproxy_frontend_http_requests_total
   namespace: ContainerInsights/Prometheus
   dimensions:
@@ -591,7 +591,7 @@
     - name: Namespace
       value: {{cloudWatchContext.haproxy.namespace}}
     - name: Service
-      value: terraform-haproxy-ingress-metrics
+      value: {{cloudWatchContext.haproxy.namespace}}-haproxy-ingress-metrics
 - metricName: haproxy_frontend_request_errors_total
   namespace: ContainerInsights/Prometheus
   dimensions:
@@ -600,7 +600,7 @@
     - name: Namespace
       value: {{cloudWatchContext.haproxy.namespace}}
     - name: Service
-      value: terraform-haproxy-ingress-metrics
+      value: {{cloudWatchContext.haproxy.namespace}}-haproxy-ingress-metrics
 - metricName: haproxy_frontend_requests_denied_total
   namespace: ContainerInsights/Prometheus
   dimensions:
@@ -609,7 +609,7 @@
     - name: Namespace
       value: {{cloudWatchContext.haproxy.namespace}}
     - name: Service
-      value: terraform-haproxy-ingress-metrics
+      value: {{cloudWatchContext.haproxy.namespace}}-haproxy-ingress-metrics
 - metricName: haproxy_frontend_current_sessions
   namespace: ContainerInsights/Prometheus
   dimensions:
@@ -618,7 +618,7 @@
     - name: Namespace
       value: {{cloudWatchContext.haproxy.namespace}}
     - name: Service
-      value: terraform-haproxy-ingress-metrics
+      value: {{cloudWatchContext.haproxy.namespace}}-haproxy-ingress-metrics
 - metricName: haproxy_backend_http_responses_total
   namespace: ContainerInsights/Prometheus
   dimensions:
@@ -627,7 +627,7 @@
     - name: Namespace
       value: {{cloudWatchContext.haproxy.namespace}}
     - name: Service
-      value: terraform-haproxy-ingress-metrics
+      value: {{cloudWatchContext.haproxy.namespace}}-haproxy-ingress-metrics
     - name: backend
       value: _default_backend
     - name: code
@@ -640,7 +640,7 @@
     - name: Namespace
       value: {{cloudWatchContext.haproxy.namespace}}
     - name: Service
-      value: terraform-haproxy-ingress-metrics
+      value: {{cloudWatchContext.haproxy.namespace}}-haproxy-ingress-metrics
     - name: frontend
       value: _front_http
     - name: code


### PR DESCRIPTION
Introduce testing_id to helm provision to avoid conflicts from running different CI jobs in the same cluster.

For App Mesh, it could only reduce the possibility of failure. When installing multi mesh controller to the same cluster, as helm will create duplicated MutatingWebhookConfiguration which causes the mutation happens for twice, it blocks the creation of Pods in the second or the other coming mesh namespaces with error:
```
VirtualNode create may not specify read-only field: spec.meshRef
```