### PR TITLE
fix zipkin, jaeger, ecsmetric testcases

### DIFF
--- a/terraform/setup/setup.tf
+++ b/terraform/setup/setup.tf
@@ -182,6 +182,14 @@ resource "aws_security_group" "aoc_sg" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  # zipkin/jaeger
+  ingress {
+    from_port   = 9411
+    to_port     = 9411
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
   egress {
     from_port   = 0
     to_port     = 0

--- a/validator/src/main/resources/expected-data-template/ecsContainerExpectedMetric.mustache
+++ b/validator/src/main/resources/expected-data-template/ecsContainerExpectedMetric.mustache
@@ -20,6 +20,9 @@
     -
       name: aws.ecs.task.id
       value: SKIP
+    -
+      name: cloud.availability_zone
+      value: SKIP
 -
   metricName: ecs.task.memory.utilized_{{testingId}}
   namespace: {{metricNamespace}}
@@ -41,6 +44,9 @@
       value: {{ecsContext.ecsTaskDefVersion}}
     -
       name: aws.ecs.task.id
+      value: SKIP
+    -
+      name: cloud.availability_zone
       value: SKIP
 -
   metricName: ecs.task.cpu.reserved_{{testingId}}
@@ -64,6 +70,9 @@
     -
       name: aws.ecs.task.id
       value: SKIP
+    -
+      name: cloud.availability_zone
+      value: SKIP
 -
   metricName: ecs.task.cpu.utilized_{{testingId}}
   namespace: {{metricNamespace}}
@@ -85,6 +94,9 @@
       value: {{ecsContext.ecsTaskDefVersion}}
     -
       name: aws.ecs.task.id
+      value: SKIP
+    -
+      name: cloud.availability_zone
       value: SKIP
 -
   metricName: ecs.task.network.rate.rx_{{testingId}}
@@ -108,6 +120,9 @@
     -
       name: aws.ecs.task.id
       value: SKIP
+    -
+      name: cloud.availability_zone
+      value: SKIP
 -
   metricName: ecs.task.network.rate.tx_{{testingId}}
   namespace: {{metricNamespace}}
@@ -129,6 +144,9 @@
       value: {{ecsContext.ecsTaskDefVersion}}
     -
       name: aws.ecs.task.id
+      value: SKIP
+    -
+      name: cloud.availability_zone
       value: SKIP
 -
   metricName: ecs.task.storage.read_bytes_{{testingId}}
@@ -152,6 +170,9 @@
     -
       name: aws.ecs.task.id
       value: SKIP
+    -
+      name: cloud.availability_zone
+      value: SKIP
 -
   metricName: ecs.task.storage.write_bytes_{{testingId}}
   namespace: {{metricNamespace}}
@@ -173,4 +194,7 @@
       value: {{ecsContext.ecsTaskDefVersion}}
     -
       name: aws.ecs.task.id
+      value: SKIP
+    -
+      name: cloud.availability_zone
       value: SKIP


### PR DESCRIPTION
### Description
1. Allow zipkin and jaeger receiver default http port to EC2 security group
2. Update the ECS metric template to fix the validation errors