### PR TITLE
tf: Fix ignore error flag position for ec2 patch report

### DIFF
--- a/terraform/ec2/main.tf
+++ b/terraform/ec2/main.tf
@@ -128,16 +128,16 @@ resource "null_resource" "check_patch" {
 
   provisioner "local-exec" {
     command = <<-EOT
-     "${self.triggers.aotutil}" ssm wait-patch "${self.triggers.sidecar_id} --ignore-error"
-     "${self.triggers.aotutil}" ssm wait-patch "${self.triggers.aoc_id} --ignore-error"
+     "${self.triggers.aotutil}" ssm wait-patch "${self.triggers.sidecar_id}" --ignore-error
+     "${self.triggers.aotutil}" ssm wait-patch "${self.triggers.aoc_id}" --ignore-error
     EOT
   }
 
   provisioner "local-exec" {
     when    = destroy
     command = <<-EOT
-      "${self.triggers.aotutil}" ssm wait-patch-report "${self.triggers.sidecar_id} --ignore-error"
-      "${self.triggers.aotutil}" ssm wait-patch-report "${self.triggers.aoc_id} --ignore-error"
+      "${self.triggers.aotutil}" ssm wait-patch-report "${self.triggers.sidecar_id}" --ignore-error
+      "${self.triggers.aotutil}" ssm wait-patch-report "${self.triggers.aoc_id}" --ignore-error
     EOT
   }
 }


### PR DESCRIPTION
Introduced in https://github.com/aws-observability/aws-otel-test-framework/pull/285 I put the quote at the wrong place and didn't test it before commit.