### PR TITLE
Increase timeout for cloud-init and SSM operations

### DIFF
--- a/terraform/ec2/amis.tf
+++ b/terraform/ec2/amis.tf
@@ -27,7 +27,7 @@ variable "ami_family" {
       ssm_validate             = "sudo /opt/aws/aws-otel-collector/bin/aws-otel-collector-ctl -c /tmp/ot-default.yml -a status | grep running"
       connection_type          = "ssh"
       user_data                = ""
-      wait_cloud_init          = "for i in {1..60}; do [ ! -f /var/lib/cloud/instance/boot-finished ] && echo 'Waiting for cloud-init...' && sleep 1 || break; done"
+      wait_cloud_init          = "for i in {1..300}; do [ ! -f /var/lib/cloud/instance/boot-finished ] && echo 'Waiting for cloud-init...'$i && sleep 1 || break; done"
     }
     linux = {
       login_user               = "ec2-user"
@@ -41,7 +41,7 @@ variable "ami_family" {
       ssm_validate             = "sudo /opt/aws/aws-otel-collector/bin/aws-otel-collector-ctl -c /tmp/ot-default.yml -a status | grep running"
       connection_type          = "ssh"
       user_data                = ""
-      wait_cloud_init          = "for i in {1..60}; do [ ! -f /var/lib/cloud/instance/boot-finished ] && echo 'Waiting for cloud-init...' && sleep 1 || break; done"
+      wait_cloud_init          = "for i in {1..300}; do [ ! -f /var/lib/cloud/instance/boot-finished ] && echo 'Waiting for cloud-init...'$i && sleep 1 || break; done"
     }
     windows = {
       login_user               = "Administrator"

--- a/terraform/templates/local/ssm-install-aoc.sh
+++ b/terraform/templates/local/ssm-install-aoc.sh
@@ -18,8 +18,8 @@ for i in {1..30}; do
   then
     break
   else
-    echo "Wait 3s for EC2 become online in SSM...""$i"
-    sleep 3
+    echo "Wait 5s for EC2 become online in SSM...""$i"
+    sleep 5
   fi
 done
 
@@ -40,7 +40,7 @@ for j in {1..3}; do
   echo "Sleep 15s for SSM command execution."
   sleep 15
 
-  for i in {1..30}; do
+  for i in {1..60}; do
     output=$(aws ssm get-command-invocation \
         --command-id "$command_id" \
         --instance-id "$instance_id")
@@ -48,15 +48,15 @@ for j in {1..3}; do
     status=$(echo ${output} | python3 -c "import sys, json; print(json.load(sys.stdin)['Status'])")
     if [[ ${status} == "Success" ]]
     then
-      echo "Sleep 15s for ADOT Collector start..."
-      sleep 15
+      echo "Sleep 30s for ADOT Collector start..."
+      sleep 30
       exit 0
     elif [[ ${status} == "Failed" ]]
     then
       break
     else
-      echo "Wait 3s for SSM command complete...""$i"
-      sleep 3
+      echo "Wait 5s for SSM command complete...""$i"
+      sleep 5
     fi
   done
 


### PR DESCRIPTION
The cloud-init might take up to 3 mins in redhat 7/8 AMI. Increase wait timeout of cloud-init and SSM operations in order to make SSM package test more stable. It won't increase running duration of most test cases.