### PR TITLE
reduce the canary testing cycles due to long running time

### DIFF
--- a/terraform/soaking/variables.tf
+++ b/terraform/soaking/variables.tf
@@ -54,10 +54,6 @@ variable "soaking_data_rate" {
   default = "1000"
 }
 
-variable "soaking_data_type" {
-  default = "otlp"
-}
-
 variable "soaking_sample_app" {
   default = ""
 }

--- a/validator/src/main/java/com/amazon/aoc/App.java
+++ b/validator/src/main/java/com/amazon/aoc/App.java
@@ -139,7 +139,7 @@ public class App implements Callable<Integer> {
     int maxValidationCycles = 1;
     ValidatorFactory validatorFactory = new ValidatorFactory(context);
     if (this.isCanary) {
-      maxValidationCycles = 30;
+      maxValidationCycles = 20;
     }
     for (int cycle = 0; cycle < maxValidationCycles; cycle++) {
       for (ValidationConfig validationConfigItem : validationConfigList) {


### PR DESCRIPTION
reduce the canary testing cycles because canary workflow took more than 1 hour to finish now.

https://github.com/aws-observability/aws-otel-collector/actions/runs/778860168