### PR TITLE
Fix jaeger & zipkin perf & soaking tests

### DIFF
--- a/terraform/testcases/jaeger_mock/otconfig.tpl
+++ b/terraform/testcases/jaeger_mock/otconfig.tpl
@@ -24,5 +24,5 @@ service:
     traces:
       receivers: [jaeger]
       processors: [batch]
-      exporters: [otlphttp]
+      exporters: [otlphttp, logging]
   extensions: [pprof]

--- a/terraform/testcases/jaeger_mock/soaking_docker_compose.tpl
+++ b/terraform/testcases/jaeger_mock/soaking_docker_compose.tpl
@@ -1,0 +1,21 @@
+version: "3.8"
+services:
+  mocked_server:
+    image: ${mocked_server_image}
+    ports:
+      - "80:8080"
+      - "443:443"
+    deploy:
+      resources:
+        limits:
+          memory: 4G
+  ot-metric-emitter:
+    privileged: true
+    image: ${sample_app_image}
+    command: ["${data_mode}", "-r=${rate}", "-u=http://${http_endpoint}", "-d=${data_type}"]
+    environment:
+      AWS_REGION: ${region}
+    deploy:
+      resources:
+        limits:
+          memory: 16G

--- a/terraform/testcases/zipkin_mock/soaking_docker_compose.tpl
+++ b/terraform/testcases/zipkin_mock/soaking_docker_compose.tpl
@@ -1,0 +1,21 @@
+version: "3.8"
+services:
+  mocked_server:
+    image: ${mocked_server_image}
+    ports:
+      - "80:8080"
+      - "443:443"
+    deploy:
+      resources:
+        limits:
+          memory: 4G
+  ot-metric-emitter:
+    privileged: true
+    image: ${sample_app_image}
+    command: ["${data_mode}", "-r=${rate}", "-u=http://${http_endpoint}", "-d=${data_type}"]
+    environment:
+      AWS_REGION: ${region}
+    deploy:
+      resources:
+        limits:
+          memory: 16G


### PR DESCRIPTION
### Description
Fixed the soaking and Performance tests for Jaeger and Zipkin so we can get the performance test result output.

```
terraform init && terraform apply -auto-approve -lock=false -var="data_rate=5000" -var="commit_id=644834bc304b699c1957f95fa4e451d032288297" -var="testcase=../testcases/jaeger_mock" -var-file="../testcases/jaeger_mock/parameters.tfvars" -var="aoc_version=v0.9.0-793988308" -var="testing_ami=soaking_linux" -var="ssh_key_name=aoc-ssh-key-2020-07-22" -var="sshkey_s3_bucket=aoc-ssh-key" -var="sshkey_s3_private_key=aoc-ssh-key-2020-07-22.txt"
➜  performance git:(soak_fix) ✗ cat output/performance.json 
{"testcase":"jaeger_mock","instanceType":"m5.2xlarge","receivers":["jaeger"],"processors":["batch"],"exporters":["otlphttp","logging"],"dataType":"jaeger","dataMode":"trace","dataRate":5000,"avgCpu":19.584404239981712,"avgMem":160.118784,"commitId":"644834bc304b699c1957f95fa4e451d032288297","collectionPeriod":10,"testingAmi":"soaking_linux"}%                                                                                                                                                                              ➜  performance git:(soak_fix) ✗ pwd

```