### PR TITLE
Fix integration test failure

### DIFF
--- a/terraform/eks/container_insights_agent.tf
+++ b/terraform/eks/container_insights_agent.tf
@@ -46,6 +46,8 @@ resource "kubectl_manifest" "config_map" {
 }
 
 resource "kubectl_manifest" "daemonset" {
+  count = var.aoc_base_scenario == "infra" ? 1 : 0
+
   yaml_body = data.template_file.daemonset_file.rendered
   depends_on = [
     kubectl_manifest.config_map

--- a/terraform/eks/otlp.tf
+++ b/terraform/eks/otlp.tf
@@ -36,7 +36,7 @@ module "aoc_oltp" {
   testing_id          = module.common.testing_id
   eks_pod_config_path = fileexists("${var.testcase}/eks_pod_config.tpl") ? "${var.testcase}/eks_pod_config.tpl" : module.common.default_eks_pod_config_path
   sample_app = {
-    image               = var.sample_app_image != "" ? var.sample_app.image : module.basic_components.0.sample_app_image
+    image               = var.sample_app_image != "" ? var.sample_app_image : module.basic_components.0.sample_app_image
     name                = var.sample_app
     mode                = var.sample_app_mode
     metric_namespace    = module.common.otel_service_namespace

--- a/validator/src/main/java/com/amazon/aoc/validators/AbstractCWMetricsValidator.java
+++ b/validator/src/main/java/com/amazon/aoc/validators/AbstractCWMetricsValidator.java
@@ -46,7 +46,7 @@ public abstract class AbstractCWMetricsValidator implements IValidator {
   private CloudWatchService cloudWatchService;
   private List<Metric> expectedMetrics;
 
-  private static final int MAX_RETRY_COUNT = 6;
+  private static final int MAX_RETRY_COUNT = 10;
   private static final int CHECK_INTERVAL_IN_MILLI = 30 * 1000;
   private static final int CHECK_DURATION_IN_SECONDS = 2 * 60;
 


### PR DESCRIPTION
**Why do we need it?**
Fix regression after https://github.com/aws-observability/aws-otel-test-framework/pull/281 is merged.

This PR includes:
1. Fix type in `oltp.tf` which causes failure in zipkin_mock and jaeger_mock
2. Avoid creating Pods under container insight infra scenario
3. Increase the wait time for metric checks