### PR TITLE
Add StatsD test metrics for timer/histogram

### DIFF
--- a/docs/run-mock-test.md
+++ b/docs/run-mock-test.md
@@ -33,7 +33,7 @@ Install Docker compose: https://docs.docker.com/compose/install/
 ```
 cd aws-otel-test-framework/terraform/mock
 terraform init
-terraform apply -var="testcase=../testcases/otlp_mock -var-file=../testcases/otlp_mock/parameters.tfvars" 
+terraform apply -var="testcase=../testcases/otlp_mock" -var-file=../testcases/otlp_mock/parameters.tfvars
 terraform destroy
 ```
 

--- a/sample-apps/statsd/webserver.py
+++ b/sample-apps/statsd/webserver.py
@@ -26,7 +26,7 @@ def send_statsd_metrics():
     logging.warning(INSTANCE_ID)
     logging.warning(RECEIVER_ADDRESS)
     if INSTANCE_ID is not None and RECEIVER_ADDRESS is not None:
-        statsD_metric = bytes('statsdTestMetric1g_%s:1|g|#mykey1:myvalue1,mykey2:myvalue2\nstatsdTestMetric1c_%s:1|c|#mykey3:myvalue3' % (INSTANCE_ID, INSTANCE_ID),'utf-8')
+        statsD_metric = bytes('statsdTestMetric1g_%s:1|g|#mykey1:myvalue1,mykey2:myvalue2\nstatsdTestMetric1c_%s:1|c|#mykey3:myvalue3\nstatsdTestMetric1ms_%s:1|ms|#mykey4:myvalue4\nstatsdTestMetric1h_%s:1|h|#mykey5:myvalue5' % (INSTANCE_ID, INSTANCE_ID,  INSTANCE_ID,  INSTANCE_ID),'utf-8')
         opened_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         opened_socket.sendto(statsD_metric, (RECEIVER_ADDRESS.split(':')[0], int(RECEIVER_ADDRESS.split(':')[1])))
     return

--- a/terraform/testcases/statsd/otconfig.tpl
+++ b/terraform/testcases/statsd/otconfig.tpl
@@ -1,7 +1,7 @@
 receivers:
   statsd:
     endpoint: 0.0.0.0:${udp_port}
-    aggregation_interval: 60s
+    aggregation_interval: 20s
 exporters:
   awsemf:
     namespace: '${otel_service_namespace}/${otel_service_name}'

--- a/terraform/testcases/statsd_mock/otconfig.tpl
+++ b/terraform/testcases/statsd_mock/otconfig.tpl
@@ -1,7 +1,7 @@
 receivers:
   statsd:
     endpoint: 0.0.0.0:${udp_port}
-    aggregation_interval: 60s
+    aggregation_interval: 20s
 exporters:
   logging:
     loglevel: debug

--- a/validator/src/main/resources/expected-data-template/statsdExpectedMetric.mustache
+++ b/validator/src/main/resources/expected-data-template/statsdExpectedMetric.mustache
@@ -16,3 +16,19 @@
     -
       name: mykey3
       value: myvalue3
+
+-
+  metricName: statsdTestMetric1ms_{{testingId}}
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: mykey4
+      value: myvalue4
+
+-
+  metricName: statsdTestMetric1h_{{testingId}}
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: mykey5
+      value: myvalue5


### PR DESCRIPTION
In upstream 0.25.0 and 0.26.0, StatsD receiver includes new support for timing/timer and histogram. 
* I added new metrics to test. 
* Revise one typo.

Tested in Mock, ECS and EKS. It passed. 