### PR TITLE
add region in Prometheus_mock config to bypass the endpoint edit check

### DIFF
--- a/terraform/testcases/prometheus_mock/otconfig.tpl
+++ b/terraform/testcases/prometheus_mock/otconfig.tpl
@@ -10,6 +10,8 @@ receivers:
 exporters:
   awsprometheusremotewrite:
     endpoint: "https://${mock_endpoint}"
+    aws_auth:
+      region: "us-west-2"
 service:
   pipelines:
     metrics:


### PR DESCRIPTION
**Description**
add region in Prometheus_mock config to bypass the endpoint edit check
**Upstream code change,**
https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/3210/files#diff-e04adbe45cbcabfd21dd6578285bdc866744c741d69758608645369afb756d12R76

https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/3210/files#diff-e04adbe45cbcabfd21dd6578285bdc866744c741d69758608645369afb756d12R119

**Test**
Verified in local