### PR TITLE
update test for container insights

### DIFF
--- a/terraform/eks/container-insights-agent/cluster_role.tpl
+++ b/terraform/eks/container-insights-agent/cluster_role.tpl
@@ -20,5 +20,5 @@ rules:
     verbs: ["create", "get"]
   - apiGroups: [""]
     resources: ["configmaps"]
-    resourceNames: ["aoc-clusterleader"]
+    resourceNames: ["otel-container-insight-clusterleader"]
     verbs: ["get","update"]

--- a/terraform/eks/container-insights-agent/config_map.tpl
+++ b/terraform/eks/container-insights-agent/config_map.tpl
@@ -15,7 +15,6 @@ data:
       awscontainerinsightreceiver:
 
     processors:
-      awscontainerinsightprocessor:
       batch/metrics:
         timeout: 60s
 
@@ -95,7 +94,7 @@ data:
       pipelines:
         metrics:
           receivers: [awscontainerinsightreceiver]
-          processors: [awscontainerinsightprocessor, batch/metrics]
+          processors: [batch/metrics]
           exporters: [awsemf]
 
       extensions: [health_check]

--- a/terraform/eks/container-insights-agent/daemonset.tpl
+++ b/terraform/eks/container-insights-agent/daemonset.tpl
@@ -17,8 +17,6 @@ spec:
         - name: aws-otel-collector
           image: ${OTELIMAGE}
           env:
-            - name: AWS_REGION
-              value: ${REGION} 
             - name: K8S_NODE_NAME
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
Update the test config for container insights:

* update the lock name for leader election
* remove the container insight processor (no longer needed)
* remove the env var for aws region (no longer needed)

### Tests

Ran the relevant test against my own EKS cluster and it passed.
