### PR TITLE
Update validator readme with working example

### DIFF
--- a/validator/README.md
+++ b/validator/README.md
@@ -7,7 +7,7 @@ validator is one of the component of the testing framework, and can be run indep
 run this command in the root dir of the testing framework
 
 ```shell
-./gradlew :validator:run --args='-c default-validation.yml --endpoint "the endpoint to test(Ex. 127.0.0.1:4567)'
+./gradlew :validator:run --args='-c default-otel-trace-validation.yml --endpoint http://127.0.0.1:4567'
 ```
 
 help
@@ -22,7 +22,7 @@ help
 uses: aws-observability/aws-otel-collector-test-framework@terraform
 with:
     running_type: validator
-    opts: "-c default-validation.yml --endpoint "the endpoint to test(Ex. 127.0.0.1:4567)"
+    opts: "-c default-otel-trace-validation.yml --endpoint 'the endpoint to test(Ex. 127.0.0.1:4567)'"
 ```
 
 ## Add a validation suite


### PR DESCRIPTION
# Description

Made the following updates to the readme:
- In my local tests I found that `--endpoint 127.0.0.1:8080` will **not work** while `--endpoint http://127.0.0.1:8080` _will_ work.
- It seems like there is no `default-validation.yml` file, so I replaced it with one that I know works for OTel Python at least.
