### PR TITLE
[ecs] Add dummy cloudwatch_context.json for ecs prometheus

### DIFF
--- a/terraform/templates/prometheus/cloudwatch_context.json
+++ b/terraform/templates/prometheus/cloudwatch_context.json
@@ -1,0 +1,3 @@
+{
+  "clusterName": "${cluster_name}"
+}

--- a/terraform/testcases/containerinsight_ecs_prometheus/README.md
+++ b/terraform/testcases/containerinsight_ecs_prometheus/README.md
@@ -66,6 +66,20 @@ make validate
 
 List of common problems you may encounter.
 
+### CloudWatch Context
+
+Some tests have a different `ecs_taskdef_directory` e.g. [prometheus_mock](../prometheus_mock/parameters.tfvars). And
+you need to put a dummy `cloudwatch_context.json` in that directory.
+
+```text
+Error: Invalid function argument
+
+  on main.tf line 378, in data "template_file" "cloudwatch_context":
+ 378:   template = file(local.cloudwatch_context_path)
+    |----------------
+    | local.cloudwatch_context_path is "../templates/prometheus/cloudwatch_context.json"
+```
+
 ### Unknown variable
 
 You are using wrong variable name in template files, or you didn't define the var when rendering template.


### PR DESCRIPTION
Fix test failures in https://github.com/aws-observability/aws-otel-collector/runs/2954887759?check_suite_focus=true

It is using a different task def directory, i.e. not `default`