### PR TITLE
Update JS Trace template for Upstream 0.23.0

### DIFF
--- a/validator/src/main/resources/expected-data-template/js/jsAppExpectedAWSSDKTrace.mustache
+++ b/validator/src/main/resources/expected-data-template/js/jsAppExpectedAWSSDKTrace.mustache
@@ -5,6 +5,12 @@
       "method": "GET"
     },
     "response": {
+      "status": 200
+    }
+  },
+  "aws": {
+    "xray": {
+      "sdk": "opentelemetry for nodejs"
     }
   },
   "metadata": {
@@ -14,11 +20,7 @@
   },
   "subsegments": [
     {
-      "name": "aws.s3.listBuckets",
-      "http": {
-        "response": {
-        }
-      },
+      "name": "s3",
       "metadata": {
         "default": {
           "aws.service.api": "S3"


### PR DESCRIPTION
Recently, the company that owns the `aws-sdk-instrumentation` package for OTel JS updated their package to [add additional attributes](https://github.com/aspecto-io/opentelemetry-ext-js/blob/master/packages/instrumentation-aws-sdk/src/aws-sdk.ts#L183) to all AWS SDK spans. Most notably, this [added the](https://github.com/aspecto-io/opentelemetry-ext-js/blob/master/packages/instrumentation-aws-sdk/src/utils.ts#L44) `rpc.service` attribute to all spans.

This changed how the trace appears in X-Ray, because our X-Ray exporter in Collector will place a [higher priority on the rpc service](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/fa50caea3d23fc6bcc16eae2835ad83a9e29adfb/exporter/awsxrayexporter/internal/translator/segment.go#L153-L157) name than [the span's given name](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/fa50caea3d23fc6bcc16eae2835ad83a9e29adfb/exporter/awsxrayexporter/internal/translator/segment.go#L171-L173).

This is a step in the right direction, but eventually we would want the upstream instrumentation package to use uppercase letters as is defined in the spec [for AWS instrumentations](https://github.com/open-telemetry/opentelemetry-specification/blob/68e7c42c634d457078520e506fcb8399efcb72bb/semantic_conventions/trace/instrumentation/aws-sdk.yml#L20-L22).