### PR TITLE
Add AMP Validator

### DIFF
--- a/validator/src/main/java/com/amazon/aoc/clients/CortexClient.java
+++ b/validator/src/main/java/com/amazon/aoc/clients/CortexClient.java
@@ -25,6 +25,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Objects;
+import java.lang.System;
 
 @Log4j2
 public class CortexClient {
@@ -82,16 +83,18 @@ public class CortexClient {
    *
    * @param query the Prometheus expression query string
    */
-  public List<PrometheusMetric> queryMetricNameOnly(String query)
+  public List<PrometheusMetric> queryMetricLastHour(String query)
           throws IOException, URISyntaxException, BaseException {
     HttpUrl rawUrl = HttpUrl.parse(cortexInstanceEndpoint);
+    int currentTime = System.currentTimeMillis() / 1000;
     URI uri = new URIBuilder()
             .setScheme(Objects.requireNonNull(rawUrl).scheme())
             .setHost(rawUrl.host())
             .setPort(rawUrl.port())
-            .setPath(rawUrl.encodedPath() + "/api/v1/query")
+            .setPath(rawUrl.encodedPath() + "/api/v1/query_range")
             .addParameter("query", query)
-            .addParameter("time", 1627582605)
+            .addParameter("start", currentTime - 3600)
+            .addParameter("end", currentTime)
             .build();
 
     HttpGet request = new HttpGet(uri);

--- a/validator/src/main/java/com/amazon/aoc/clients/CortexClient.java
+++ b/validator/src/main/java/com/amazon/aoc/clients/CortexClient.java
@@ -77,6 +77,27 @@ public class CortexClient {
     return execute(request);
   }
 
+  /**
+   * list metrics from the cortex instance via the query endpoint.
+   *
+   * @param query the Prometheus expression query string
+   */
+  public List<PrometheusMetric> queryMetricNameOnly(String query)
+          throws IOException, URISyntaxException, BaseException {
+    HttpUrl rawUrl = HttpUrl.parse(cortexInstanceEndpoint);
+    URI uri = new URIBuilder()
+            .setScheme(Objects.requireNonNull(rawUrl).scheme())
+            .setHost(rawUrl.host())
+            .setPort(rawUrl.port())
+            .setPath(rawUrl.encodedPath() + "/api/v1/query")
+            .addParameter("query", query)
+            .addParameter("time", 1627582605)
+            .build();
+
+    HttpGet request = new HttpGet(uri);
+    return execute(request);
+  }
+
   private List<PrometheusMetric> execute(HttpGet request) throws IOException, BaseException {
     HttpResponse response = httpClient.execute(request);
 

--- a/validator/src/main/java/com/amazon/aoc/clients/CortexClient.java
+++ b/validator/src/main/java/com/amazon/aoc/clients/CortexClient.java
@@ -87,15 +87,16 @@ public class CortexClient {
   public List<PrometheusMetric> queryMetricLastHour(String query)
           throws IOException, URISyntaxException, BaseException {
     HttpUrl rawUrl = HttpUrl.parse(cortexInstanceEndpoint);
-    int currentTimeEpoch = (int) System.currentTimeMillis() / 1000;
+    long endEpochTime = (System.currentTimeMillis() / 1000);
+
     URI uri = new URIBuilder()
             .setScheme(Objects.requireNonNull(rawUrl).scheme())
             .setHost(rawUrl.host())
-            .setPort(rawUrl.port())
             .setPath(rawUrl.encodedPath() + "/api/v1/query_range")
             .addParameter("query", query)
-            .addParameter("start", currentTimeEpoch - 3600 + "")
-            .addParameter("end", currentTimeEpoch + "")
+            .addParameter("start", Long.toString(endEpochTime - 3600))
+            .addParameter("end", Long.toString(endEpochTime))
+            .addParameter("step", "15")
             .build();
 
     HttpGet request = new HttpGet(uri);

--- a/validator/src/main/java/com/amazon/aoc/clients/CortexClient.java
+++ b/validator/src/main/java/com/amazon/aoc/clients/CortexClient.java
@@ -79,22 +79,23 @@ public class CortexClient {
   }
 
   /**
-   * list metrics from the cortex instance via the query endpoint.
+   * list metrics for the last one hour interval
+   * from the cortex instance via the query endpoint.
    *
    * @param query the Prometheus expression query string
    */
   public List<PrometheusMetric> queryMetricLastHour(String query)
           throws IOException, URISyntaxException, BaseException {
     HttpUrl rawUrl = HttpUrl.parse(cortexInstanceEndpoint);
-    int currentTime = System.currentTimeMillis() / 1000;
+    int currentTimeEpoch = (int) System.currentTimeMillis() / 1000;
     URI uri = new URIBuilder()
             .setScheme(Objects.requireNonNull(rawUrl).scheme())
             .setHost(rawUrl.host())
             .setPort(rawUrl.port())
             .setPath(rawUrl.encodedPath() + "/api/v1/query_range")
             .addParameter("query", query)
-            .addParameter("start", currentTime - 3600)
-            .addParameter("end", currentTime)
+            .addParameter("start", currentTimeEpoch - 3600 + "")
+            .addParameter("end", currentTimeEpoch + "")
             .build();
 
     HttpGet request = new HttpGet(uri);

--- a/validator/src/main/java/com/amazon/aoc/clients/CortexClient.java
+++ b/validator/src/main/java/com/amazon/aoc/clients/CortexClient.java
@@ -25,7 +25,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Objects;
-import java.lang.System;
 
 @Log4j2
 public class CortexClient {

--- a/validator/src/main/java/com/amazon/aoc/fileconfigs/PredefinedExpectedTemplate.java
+++ b/validator/src/main/java/com/amazon/aoc/fileconfigs/PredefinedExpectedTemplate.java
@@ -25,6 +25,7 @@ public enum PredefinedExpectedTemplate implements FileConfig {
   /**
    * metric template, defined in resources.
    */
+  AMP_EXPECTED_METRIC("/expected-data-template/ampExpectedMetric.mustache")
   DEFAULT_EXPECTED_METRIC("/expected-data-template/defaultExpectedMetric.mustache"),
   ENHANCED_EXPECTED_METRIC("/expected-data-template/enhancedExpectedMetric.mustache"),
   STATSD_EXPECTED_METRIC("/expected-data-template/statsdExpectedMetric.mustache"),

--- a/validator/src/main/java/com/amazon/aoc/fileconfigs/PredefinedExpectedTemplate.java
+++ b/validator/src/main/java/com/amazon/aoc/fileconfigs/PredefinedExpectedTemplate.java
@@ -25,7 +25,7 @@ public enum PredefinedExpectedTemplate implements FileConfig {
   /**
    * metric template, defined in resources.
    */
-  AMP_EXPECTED_METRIC("/expected-data-template/ampExpectedMetric.mustache")
+  AMP_EXPECTED_METRIC("/expected-data-template/ampExpectedMetric.mustache"),
   DEFAULT_EXPECTED_METRIC("/expected-data-template/defaultExpectedMetric.mustache"),
   ENHANCED_EXPECTED_METRIC("/expected-data-template/enhancedExpectedMetric.mustache"),
   STATSD_EXPECTED_METRIC("/expected-data-template/statsdExpectedMetric.mustache"),

--- a/validator/src/main/java/com/amazon/aoc/models/prometheus/PrometheusMetric.java
+++ b/validator/src/main/java/com/amazon/aoc/models/prometheus/PrometheusMetric.java
@@ -23,6 +23,9 @@ public class PrometheusMetric {
   @JsonProperty("value")
   private List<String> rawValue;
 
+  @JsonProperty("values")
+  private List<List<String>> rawValues;
+
   public String getMetricName() {
     return labels.get(NAME_FIELD);
   }

--- a/validator/src/main/java/com/amazon/aoc/services/CortexService.java
+++ b/validator/src/main/java/com/amazon/aoc/services/CortexService.java
@@ -55,7 +55,7 @@ public class CortexService {
     return listMetrics(query, newTimestamp.toPlainString());
   }
 
-    /**
+  /**
    * listMetricsLastHour fetches metrics from the last hour from cortex instance.
    *
    * @param query the Prometheus expression query string

--- a/validator/src/main/java/com/amazon/aoc/services/CortexService.java
+++ b/validator/src/main/java/com/amazon/aoc/services/CortexService.java
@@ -56,14 +56,14 @@ public class CortexService {
   }
 
     /**
-   * listMetrics fetches metrics from cortex instance.
+   * listMetricsLastHour fetches metrics from the last hour from cortex instance.
    *
    * @param query the Prometheus expression query string
    * @return List of PrometheusMetrics
    */
-  public List<PrometheusMetric> listMetricsWithNameOnly(final String query)
+  public List<PrometheusMetric> listMetricsLastHour(final String query)
           throws IOException, URISyntaxException, BaseException {
-    return new CortexClient(context).queryMetricNameOnly(query);
+    return new CortexClient(context).queryMetricLastHour(query);
   }
 
   /**

--- a/validator/src/main/java/com/amazon/aoc/services/CortexService.java
+++ b/validator/src/main/java/com/amazon/aoc/services/CortexService.java
@@ -55,6 +55,17 @@ public class CortexService {
     return listMetrics(query, newTimestamp.toPlainString());
   }
 
+    /**
+   * listMetrics fetches metrics from cortex instance.
+   *
+   * @param query the Prometheus expression query string
+   * @return List of PrometheusMetrics
+   */
+  public List<PrometheusMetric> listMetricsWithNameOnly(final String query)
+          throws IOException, URISyntaxException, BaseException {
+    return new CortexClient(context).queryMetricNameOnly(query);
+  }
+
   /**
    * listMetrics fetches metrics from cortex instance.
    *

--- a/validator/src/main/java/com/amazon/aoc/validators/AMPMetricValidator.java
+++ b/validator/src/main/java/com/amazon/aoc/validators/AMPMetricValidator.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.aoc.validators;
+
+import com.amazon.aoc.callers.ICaller;
+import com.amazon.aoc.clients.PullModeSampleAppClient;
+import com.amazon.aoc.exception.BaseException;
+import com.amazon.aoc.exception.ExceptionCode;
+import com.amazon.aoc.fileconfigs.FileConfig;
+import com.amazon.aoc.helpers.MustacheHelper;
+import com.amazon.aoc.helpers.RetryHelper;
+import com.amazon.aoc.models.Context;
+import com.amazon.aoc.models.ValidationConfig;
+import com.amazon.aoc.models.prometheus.PrometheusMetric;
+import com.amazon.aoc.services.CortexService;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.log4j.Log4j2;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+@Log4j2
+public class PrometheusMetricValidator implements IValidator {
+  private static final int MAX_RETRY_COUNT = 30;
+
+  private final MustacheHelper mustacheHelper = new MustacheHelper();
+  private Context context;
+  private FileConfig expectedMetric;
+  private ValidationConfig validationConfig;
+
+  public void validate() throws Exception {
+    log.info("Start prometheus metric validating");
+
+    RetryHelper.retry(
+        MAX_RETRY_COUNT,
+        () -> {
+          // get expected metrics
+          List<PrometheusMetric> expectedMetricList = this.getExpectedMetricList(context);
+
+          // Since we add 20s to timestamp, must sleep 20s between requests
+          TimeUnit.SECONDS.sleep(20);
+
+          // get metric from cortex
+          CortexService cortexService = new CortexService(context);
+
+          List<PrometheusMetric> metricList =
+                  this.listMetricFromPrometheus(cortexService, expectedMetricList);
+
+          log.info("check if all the expected metrics are found");
+          compareMetricLists(expectedMetricList, metricList);
+
+          log.info("check if there're unexpected additional metric getting fetched");
+          compareMetricLists(metricList, expectedMetricList);
+        });
+
+    log.info("finish metric validation");
+  }
+
+  /**
+   * Check if every metric in toBeChckedMetricList is in baseMetricList.
+   *
+   * @param toBeCheckedMetricList toBeCheckedMetricList
+   * @param baseMetricList        baseMetricList
+   */
+  private void compareMetricLists(List<PrometheusMetric> toBeCheckedMetricList,
+                                  List<PrometheusMetric> baseMetricList)
+          throws BaseException {
+    // load metrics into a tree set
+    Comparator<PrometheusMetric> comparator = PrometheusMetric::comparePrometheusMetricLabels;
+
+    if (validationConfig.getShouldValidateMetricValue()) {
+      comparator = PrometheusMetric::staticPrometheusMetricCompare;
+    }
+
+    Set<PrometheusMetric> metricSet = new TreeSet<>(comparator);
+    metricSet.addAll(baseMetricList);
+
+    for (PrometheusMetric metric : toBeCheckedMetricList) {
+      if (!metricSet.contains(metric)) {
+        throw new BaseException(
+                ExceptionCode.EXPECTED_METRIC_NOT_FOUND,
+                String.format(
+                        "metric in toBeCheckedMetricList %s not found in baseMetricList: %s",
+                        metric, metricSet));
+      }
+    }
+  }
+
+  private List<PrometheusMetric> getExpectedMetricList(Context context) throws Exception {
+    if (!validationConfig.getExpectedResultPath().isEmpty()) {
+      log.info("getting expected metrics from sample endpoint");
+      PullModeSampleAppClient<List<PrometheusMetric>> pullModeSampleAppClient =
+              new PullModeSampleAppClient<>(context,
+                      validationConfig.getExpectedResultPath(),
+                      new ObjectMapper()
+                              .getTypeFactory()
+                              .constructCollectionType(List.class, PrometheusMetric.class));
+      return pullModeSampleAppClient.getExpectedResults();
+    }
+
+    log.info("getting expected metrics");
+    // get expected metrics as yaml from config
+    String jsonExpectedMetrics =  mustacheHelper.render(this.expectedMetric, context);
+
+    // load metrics from yaml
+    ObjectMapper mapper = new ObjectMapper(new JsonFactory());
+    List<PrometheusMetric> expectedMetricList =
+        mapper.readValue(
+            jsonExpectedMetrics.getBytes(StandardCharsets.UTF_8),
+            new TypeReference<List<PrometheusMetric>>() {
+            });
+
+    return removeSkippedMetrics(expectedMetricList);
+  }
+
+  private List<PrometheusMetric> listMetricFromPrometheus(
+          CortexService cortexService, List<PrometheusMetric> expectedMetricList)
+          throws IOException, URISyntaxException, BaseException {
+    // search by metric name
+    List<PrometheusMetric> result = new ArrayList<>();
+    for (PrometheusMetric expectedMetric : expectedMetricList) {
+      // retrieve metric based on the sample app generated timestamp
+      result.addAll(cortexService.listMetricsWithTimestamp(expectedMetric.getMetricName(),
+              expectedMetric.getMetricTimestamp()));
+    }
+    return removeSkippedMetrics(result);
+  }
+
+  private List<PrometheusMetric> removeSkippedMetrics(List<PrometheusMetric> expectedMetrics) {
+    return expectedMetrics.stream()
+            .filter(metric -> !metric.isSkippedMetric())
+            .collect(Collectors.toList());
+  }
+
+  @Override
+  public void init(
+          Context context,
+          ValidationConfig validationConfig,
+          ICaller caller,
+          FileConfig expectedMetricTemplate)
+          throws Exception {
+    this.context = context;
+    this.expectedMetric = expectedMetricTemplate;
+    this.validationConfig = validationConfig;
+  }
+}

--- a/validator/src/main/java/com/amazon/aoc/validators/PrometheusStaticMetricValidator.java
+++ b/validator/src/main/java/com/amazon/aoc/validators/PrometheusStaticMetricValidator.java
@@ -49,7 +49,8 @@ public class PrometheusStaticMetricValidator implements IValidator {
 
   public void validate() throws Exception {
     log.info("Start prometheus metric validating");
-
+    log.info("allow lambda function to finish running and propagate");
+    TimeUnit.SECONDS.sleep(60);
     // get expected metrics
     final List<PrometheusMetric> expectedMetricList = this.getExpectedMetricList(
       context);
@@ -60,7 +61,7 @@ public class PrometheusStaticMetricValidator implements IValidator {
         () -> {
           List<PrometheusMetric> metricList =
                   this.listMetricFromPrometheus(cortexService, expectedMetricList);
-
+          
           log.info("check if all the expected metrics are found");
           compareMetricLists(expectedMetricList, metricList);
 
@@ -81,7 +82,7 @@ public class PrometheusStaticMetricValidator implements IValidator {
                                   List<PrometheusMetric> baseMetricList)
           throws BaseException {
     // load metrics into a tree set
-    Comparator<PrometheusMetric> comparator = PrometheusMetric::staticPrometheusMetricCompare;
+    Comparator<PrometheusMetric> comparator = PrometheusMetric::comparePrometheusMetricLabels;
 
     if (validationConfig.getShouldValidateMetricValue()) {
       comparator = PrometheusMetric::staticPrometheusMetricCompare;
@@ -148,6 +149,7 @@ public class PrometheusStaticMetricValidator implements IValidator {
           throws Exception {
     this.context = context;
     this.cortexService = new CortexService(context);
+    this.validationConfig = validationConfig;
     this.expectedMetric = expectedMetricTemplate;
   }
 }

--- a/validator/src/main/java/com/amazon/aoc/validators/PrometheusStaticMetricValidator.java
+++ b/validator/src/main/java/com/amazon/aoc/validators/PrometheusStaticMetricValidator.java
@@ -136,7 +136,7 @@ public class PrometheusStaticMetricValidator implements IValidator {
     // search by metric name
     List<PrometheusMetric> result = new ArrayList<>();
     for (PrometheusMetric metricName : metricNameSet) {
-      result.addAll(cortexService.listMetricsWithNameOnly(expectedMetric.getMetricName());
+      result.addAll(cortexService.listMetricsLastHour(expectedMetric.getMetricName());
     }
     return removeSkippedMetrics(result);
   }

--- a/validator/src/main/java/com/amazon/aoc/validators/PrometheusStaticMetricValidator.java
+++ b/validator/src/main/java/com/amazon/aoc/validators/PrometheusStaticMetricValidator.java
@@ -47,13 +47,14 @@ public class PrometheusStaticMetricValidator implements IValidator {
   private ValidationConfig validationConfig;
   private CortexService cortexService;
 
+  @Override
   public void validate() throws Exception {
     log.info("Start prometheus metric validating");
     log.info("allow lambda function to finish running and propagate");
     TimeUnit.SECONDS.sleep(60);
     // get expected metrics
     final List<PrometheusMetric> expectedMetricList = this.getExpectedMetricList(
-      context);
+        context);
 
     // get metrics from prometheus
     RetryHelper.retry(

--- a/validator/src/main/java/com/amazon/aoc/validators/PrometheusStaticMetricValidator.java
+++ b/validator/src/main/java/com/amazon/aoc/validators/PrometheusStaticMetricValidator.java
@@ -39,7 +39,7 @@ import java.util.stream.Collectors;
 
 @Log4j2
 public class PrometheusStaticMetricValidator implements IValidator {
-  private static final int MAX_RETRY_COUNT = 3;
+  private static final int MAX_RETRY_COUNT = 30;
 
   private final MustacheHelper mustacheHelper = new MustacheHelper();
   private Context context;

--- a/validator/src/main/java/com/amazon/aoc/validators/PrometheusStaticMetricValidator.java
+++ b/validator/src/main/java/com/amazon/aoc/validators/PrometheusStaticMetricValidator.java
@@ -25,7 +25,7 @@ import com.amazon.aoc.models.Context;
 import com.amazon.aoc.models.ValidationConfig;
 import com.amazon.aoc.models.prometheus.PrometheusMetric;
 import com.amazon.aoc.services.CortexService;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.log4j.Log4j2;
@@ -39,7 +39,7 @@ import java.util.stream.Collectors;
 
 @Log4j2
 public class PrometheusStaticMetricValidator implements IValidator {
-  private static final int MAX_RETRY_COUNT = 5;
+  private static final int MAX_RETRY_COUNT = 3;
 
   private final MustacheHelper mustacheHelper = new MustacheHelper();
   private Context context;
@@ -49,7 +49,6 @@ public class PrometheusStaticMetricValidator implements IValidator {
 
   public void validate() throws Exception {
     log.info("Start prometheus metric validating");
-    log.info("test");
 
     // get expected metrics
     final List<PrometheusMetric> expectedMetricList = this.getExpectedMetricList(
@@ -104,14 +103,14 @@ public class PrometheusStaticMetricValidator implements IValidator {
 
   private List<PrometheusMetric> getExpectedMetricList(Context context) throws Exception {
     log.info("getting expected metrics");
-    // get expected metrics as yaml from config
-    String yamlExpectedMetrics =  mustacheHelper.render(this.expectedMetric, context);
+    // get expected metrics as json from config
+    String jsonExpectedMetrics =  mustacheHelper.render(this.expectedMetric, context);
 
-    // load metrics from yaml
-    ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+    // load metrics from json
+    ObjectMapper mapper = new ObjectMapper(new JsonFactory());
     List<PrometheusMetric> expectedMetricList =
         mapper.readValue(
-          yamlExpectedMetrics.getBytes(StandardCharsets.UTF_8),
+          jsonExpectedMetrics.getBytes(StandardCharsets.UTF_8),
             new TypeReference<List<PrometheusMetric>>() {
             });
 

--- a/validator/src/main/java/com/amazon/aoc/validators/ValidatorFactory.java
+++ b/validator/src/main/java/com/amazon/aoc/validators/ValidatorFactory.java
@@ -52,6 +52,7 @@ public class ValidatorFactory {
       case "prom-static-metric":
         validator = new PrometheusStaticMetricValidator();
         expectedData = validationConfig.getExpectedMetricTemplate();
+        break;
       case "prom-metric":
         validator = new PrometheusMetricValidator();
         expectedData = validationConfig.getExpectedMetricTemplate();

--- a/validator/src/main/java/com/amazon/aoc/validators/ValidatorFactory.java
+++ b/validator/src/main/java/com/amazon/aoc/validators/ValidatorFactory.java
@@ -49,6 +49,9 @@ public class ValidatorFactory {
         validator = new CWMetricValidator();
         expectedData = validationConfig.getExpectedMetricTemplate();
         break;
+      case "amp-metric":
+        validator = new AMPMetricValidator();
+        expectedData = validationConfig.getExpectedMetricTemplate();
       case "prom-metric":
         validator = new PrometheusMetricValidator();
         expectedData = validationConfig.getExpectedMetricTemplate();

--- a/validator/src/main/java/com/amazon/aoc/validators/ValidatorFactory.java
+++ b/validator/src/main/java/com/amazon/aoc/validators/ValidatorFactory.java
@@ -49,8 +49,8 @@ public class ValidatorFactory {
         validator = new CWMetricValidator();
         expectedData = validationConfig.getExpectedMetricTemplate();
         break;
-      case "amp-metric":
-        validator = new AMPMetricValidator();
+      case "prom-static-metric":
+        validator = new PrometheusStaticMetricValidator();
         expectedData = validationConfig.getExpectedMetricTemplate();
       case "prom-metric":
         validator = new PrometheusMetricValidator();

--- a/validator/src/main/resources/expected-data-template/ampExpectedMetric.mustache
+++ b/validator/src/main/resources/expected-data-template/ampExpectedMetric.mustache
@@ -1,1 +1,3 @@
-{"__name__":"queueSizeChange","apiName":"/lambda-sample-app","statusCode":"200"}
+[{"metric":
+    {"__name__":"queueSizeChange","apiName":"/lambda-sample-app","statusCode":"200"}
+}]

--- a/validator/src/main/resources/expected-data-template/ampExpectedMetric.mustache
+++ b/validator/src/main/resources/expected-data-template/ampExpectedMetric.mustache
@@ -1,3 +1,7 @@
 [{"metric":
-    {"__name__":"queueSizeChange","apiName":"/lambda-sample-app","statusCode":"200"}
+    {"__name__":"queueSizeChange","apiName":"/lambda-sample-app","statusCode":"200"},
+  "value":
+    [],
+  "values":
+    []
 }]

--- a/validator/src/main/resources/expected-data-template/ampExpectedMetric.mustache
+++ b/validator/src/main/resources/expected-data-template/ampExpectedMetric.mustache
@@ -1,0 +1,1 @@
+"result":[{"metric":{"__name__":"queueSizeChange","apiName":"/lambda-sample-app","statusCode":"200"}

--- a/validator/src/main/resources/expected-data-template/ampExpectedMetric.mustache
+++ b/validator/src/main/resources/expected-data-template/ampExpectedMetric.mustache
@@ -1,1 +1,1 @@
-"result":[{"metric":{"__name__":"queueSizeChange","apiName":"/lambda-sample-app","statusCode":"200"}
+{"__name__":"queueSizeChange","apiName":"/lambda-sample-app","statusCode":"200"}

--- a/validator/src/main/resources/validations/prometheus-static-metric-validation.yml
+++ b/validator/src/main/resources/validations/prometheus-static-metric-validation.yml
@@ -2,4 +2,3 @@
   validationType: "prom-static-metric"
   shouldValidateMetricValue: false
   expectedMetricTemplate: "AMP_EXPECTED_METRIC"
-

--- a/validator/src/main/resources/validations/prometheus-static-metric-validation.yml
+++ b/validator/src/main/resources/validations/prometheus-static-metric-validation.yml
@@ -1,0 +1,5 @@
+-
+  validationType: "prom-static-metric"
+  shouldValidateMetricValue: false
+  expectedMetricTemplate: "AMP_EXPECTED_METRIC"
+


### PR DESCRIPTION
In this PR, there is a new static Prometheus metric validator. As we pull expected metrics from a provided mustache file, we want to verify those metrics against the actual metrics pulled from AMP(when given a query endpoint). (This mustache file is temporary and will be changed in the future).

This validator shares some similarity to the dynamic prometheus metric [validator](https://github.com/aws-observability/aws-otel-test-framework/blob/terraform/validator/src/main/java/com/amazon/aoc/validators/PrometheusMetricValidator.java) but since we do have an access to the timestamp of a metric time series we will be querying all metrics within the last hour. PromQL is not designed to be able to query all metrics without a timestamp hence the decision to query all metrics in the last hour was made.