### PR TITLE
Bumped up sample app SDK versions.

### DIFF
--- a/sample-apps/spark/Dockerfile
+++ b/sample-apps/spark/Dockerfile
@@ -7,7 +7,7 @@ COPY ./settings.gradle ./settings.gradle
 
 RUN gradle build
 RUN tar -xvf build/distributions/spark-sample-app-1.0.tar
-RUN wget https://github.com/aws-observability/aws-otel-java-instrumentation/releases/download/v0.18.0-aws.1/aws-opentelemetry-agent.jar
+RUN wget https://github.com/aws-observability/aws-otel-java-instrumentation/releases/download/v1.4.1/aws-opentelemetry-agent.jar
 
 FROM amazoncorretto:11 
 

--- a/sample-apps/spark/build.gradle
+++ b/sample-apps/spark/build.gradle
@@ -38,9 +38,9 @@ dependencies {
     implementation "io.grpc:grpc-api:1.34.1"
     implementation "io.grpc:grpc-netty-shaded:1.34.1"
 
-    implementation platform("io.opentelemetry:opentelemetry-bom:1.0.1")
+    implementation platform("io.opentelemetry:opentelemetry-bom:1.4.1")
     implementation "io.opentelemetry:opentelemetry-api"
-    implementation "io.opentelemetry:opentelemetry-sdk-metrics:1.0.0-alpha"
+    implementation "io.opentelemetry:opentelemetry-sdk-metrics:1.4.1-alpha"
     implementation "io.opentelemetry:opentelemetry-sdk-extension-aws"
     
     testImplementation group: 'junit', name: 'junit', version: '4.12'

--- a/sample-apps/spark/src/main/java/com/amazon/sampleapp/MetricEmitter.java
+++ b/sample-apps/spark/src/main/java/com/amazon/sampleapp/MetricEmitter.java
@@ -18,7 +18,7 @@
 
 package com.amazon.sampleapp;
 
-import io.opentelemetry.api.metrics.GlobalMetricsProvider;
+import io.opentelemetry.api.metrics.GlobalMeterProvider;
 import io.opentelemetry.api.metrics.common.Labels;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.LongSumObserver;
@@ -58,7 +58,7 @@ public class MetricEmitter {
   String latencyMetricName;
 
   public MetricEmitter() {
-    Meter meter = GlobalMetricsProvider.getMeter("aws-otel", "1.0");
+    Meter meter = GlobalMeterProvider.getMeter("aws-otel", "1.0");
 
     // give a instanceId appending to the metricname so that we can check the metric for each round
     // of integ-test


### PR DESCRIPTION
Validated by running `otlp_trace` and `otlp_metric` with the terraform/ec2 and terraform/ecs tests.