### PR TITLE
Removed EKS k8s cluster name attribute from expected trace.

### DIFF
--- a/validator/src/main/resources/expected-data-template/spark/sparkAppExpectedEKSTrace.mustache
+++ b/validator/src/main/resources/expected-data-template/spark/sparkAppExpectedEKSTrace.mustache
@@ -12,8 +12,7 @@
   "metadata": {
     "default": {
         "otel.resource.cloud.provider": "aws",
-        "otel.resource.cloud.platform": "aws_eks",
-        "k8s.cluster.name": "{{cloudWatchContext.clusterName}}"
+        "otel.resource.cloud.platform": "aws_eks"
     }
   }
 }]


### PR DESCRIPTION
The k8s cluster name attribute is currently not implemented in the resource detection processor (https://github.com/aws-observability/aws-otel-test-framework/pull/323)