### PR TITLE
Disable Counter metrics in Prom Sample App

### DIFF
--- a/sample-apps/prometheus/Dockerfile
+++ b/sample-apps/prometheus/Dockerfile
@@ -2,6 +2,7 @@ FROM golang:1.15 AS mod
 WORKDIR $GOPATH/main
 COPY go.mod .
 COPY go.sum .
+RUN go env -w GOPROXY=direct
 RUN GO111MODULE=on go mod download
 
 FROM golang:1.15 as build

--- a/sample-apps/prometheus/go.sum
+++ b/sample-apps/prometheus/go.sum
@@ -88,6 +88,7 @@ github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
@@ -347,6 +348,7 @@ golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20200103221440-774c71fcf114/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.3.1/go.mod h1:6wY9I6uQWHQ8EM57III9mq/AjF+i8G65rmVagqKMtkk=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=

--- a/sample-apps/prometheus/metric_collector.go
+++ b/sample-apps/prometheus/metric_collector.go
@@ -25,7 +25,7 @@ func newMetricCollector() metricCollector {
 func (mc metricCollector) convertMetricsToExportedMetrics() *[]MetricResponse {
 	metricsResponse := []MetricResponse{}
 
-	mc.handleCounters(&metricsResponse)
+	//mc.handleCounters(&metricsResponse)
 	mc.handleGauges(&metricsResponse)
 	mc.handleHistograms(&metricsResponse)
 	mc.handleSummarys(&metricsResponse)
@@ -33,6 +33,9 @@ func (mc metricCollector) convertMetricsToExportedMetrics() *[]MetricResponse {
 	return &metricsResponse
 }
 
+// Prometheus Receiver failed to handle counter type of metrics for some reason.
+// Disable it in Prometheus test sample app for now. Will need to follow up with AMP team on real root causes.
+/*
 func (mc metricCollector) handleCounters(metricsResponse *[]MetricResponse) {
 	for _, counter := range mc.counters {
 		metric := &dto.Metric{}
@@ -47,6 +50,7 @@ func (mc metricCollector) handleCounters(metricsResponse *[]MetricResponse) {
 		})
 	}
 }
+*/
 
 func (mc metricCollector) handleGauges(metricsResponse *[]MetricResponse) {
 	for _, gauge := range mc.gauges {


### PR DESCRIPTION
Disable Counter metrics in Prom Sample App Since there was some breaking changes in Prom receiver previously. Will need to follow up with AMP team.