### PR TITLE
Update AWS SDK Trace mustache to match spec

### DIFF
--- a/validator/src/main/resources/expected-data-template/otelSDKexpectedAWSSDKTrace.mustache
+++ b/validator/src/main/resources/expected-data-template/otelSDKexpectedAWSSDKTrace.mustache
@@ -23,7 +23,9 @@
       },
       "metadata": {
         "default": {
-          "aws.service": "s3"
+          "rpc.service": "S3",
+          "rpc.method": "ListBuckets",
+          "rpc.system": "aws-api"
         }
       },
       "namespace": "aws"


### PR DESCRIPTION
# Description

The new [specification for AWS SDK instrumentations](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/instrumentation/aws-sdk.md#common-attributes) says that the `rpc.<info>` attributes should be used to describe the metadata on the request. This replaces `aws.service` so we should update our template to match it.

We discovered this when [a workflow on our ADOT OTel python failed](https://github.com/aws-observability/aws-otel-python/runs/3842652590?check_suite_focus=true) which led us to [this recent change in the OTel Python instrumentation](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/674/files#diff-05ef2bbeb79bb2d595bf8a3f7fa2d475d0f34f80804e5e1ba0d9a253d2c0e0e3L241). The change was done to follow the spec.

This PR will fix the OTel Python build, and because no one else uses this template, should not impact other downstream ADOT language repos.