### PR TITLE
Reduced number of retries for soaking test alarm validation

### DIFF
--- a/validator/src/main/java/com/amazon/aoc/services/CloudWatchAlarmService.java
+++ b/validator/src/main/java/com/amazon/aoc/services/CloudWatchAlarmService.java
@@ -21,8 +21,8 @@ public class CloudWatchAlarmService {
    * @return the list of MetricAlarm Object
    */
   public List<MetricAlarm> listAlarms(List<String> alarmNameList) {
-    DescribeAlarmsResult describeALarmsResult =
+    DescribeAlarmsResult describeAlarmsResult =
         amazonCloudWatch.describeAlarms(new DescribeAlarmsRequest().withAlarmNames(alarmNameList));
-    return describeALarmsResult.getMetricAlarms();
+    return describeAlarmsResult.getMetricAlarms();
   }
 }

--- a/validator/src/main/java/com/amazon/aoc/validators/AlarmPullingValidator.java
+++ b/validator/src/main/java/com/amazon/aoc/validators/AlarmPullingValidator.java
@@ -60,7 +60,7 @@ public class AlarmPullingValidator implements IValidator {
           alarmList.sort(Comparator.comparing(MetricAlarm::getAlarmName));
           for (int i = 0; i != context.getAlarmNameList().size(); ++i) {
             if (!context.getAlarmNameList().get(i).equals(alarmList.get(i).getAlarmName())) {
-              log.error("alarm {} can not be found", context.getAlarmNameList().get(i));
+              log.error("alarm {} cannot be found", context.getAlarmNameList().get(i));
               //emit soaking validation metric
               cloudWatchService.putMetricData(SOAKING_NAMESPACE, METRIC_NAME, 0.0, dimension);
               System.exit(1);

--- a/validator/src/main/resources/validations/alarm-pulling-validation.yml
+++ b/validator/src/main/resources/validations/alarm-pulling-validation.yml
@@ -1,4 +1,4 @@
 -
   validationType: "alarm-pulling"
   pullingDuration: 10 #seconds
-  pullingTimes: 1800
+  pullingTimes: 1700


### PR DESCRIPTION
There are multiple soaking tests that are cancelled before completion (ex: [run-soaking-test (statsd, soaking_linux)](https://github.com/aws-observability/aws-otel-collector/runs/4054558138?check_suite_focus=true)). This is because the jobs exceed the 6 hour limit.

https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#usage-limits
> Job execution time - Each job in a workflow can run for up to 6 hours of execution time. If a job reaches this limit, the job is terminated and fails to complete.

Reducing the number of retries for the test should reduce the likelihood of timeout.