### PR TITLE
OTel Template adds aws.* bc it represents X-Ray expected data

### DIFF
--- a/validator/src/main/resources/expected-data-template/otelSDKexpectedAWSSDKTrace.mustache
+++ b/validator/src/main/resources/expected-data-template/otelSDKexpectedAWSSDKTrace.mustache
@@ -23,14 +23,6 @@
       },
       "aws": {
         "operation": "ListBuckets",
-      }
-      "metadata": {
-        "default": {
-          "aws.service": "s3",
-          "rpc.service": "S3",
-          "rpc.method": "ListBuckets",
-          "rpc.system": "aws-api"
-        }
       },
       "namespace": "aws"
     }

--- a/validator/src/main/resources/expected-data-template/otelSDKexpectedAWSSDKTrace.mustache
+++ b/validator/src/main/resources/expected-data-template/otelSDKexpectedAWSSDKTrace.mustache
@@ -21,8 +21,12 @@
           "status": 200
         }
       },
+      "aws": {
+        "operation": "ListBuckets",
+      }
       "metadata": {
         "default": {
+          "aws.service": "s3",
           "rpc.service": "S3",
           "rpc.method": "ListBuckets",
           "rpc.system": "aws-api"
@@ -31,4 +35,12 @@
       "namespace": "aws"
     }
   ]
+},
+{
+  "name": "S3",
+  "inferred":true,
+  "aws": {
+      "operation": "ListBuckets"
+  },
+  "origin": "AWS::S3"
 }]


### PR DESCRIPTION
# Description

We discovered that removing the `aws.operation` attribute on the S3 span resulted in a regression in the OTel Python + X-Ray experience: https://github.com/aws-observability/aws-otel-lambda/pull/165

Because of this, we filed (**BLOCKED ON**) https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/6109 to make the Collector add these attributes.

This is the discrepancy in X-Ray:

**Before** (Expected):

```json
{
    ...,
    "Segments": [
        ...,
        ...,
        {
            ...,
            "Document": {
                ...,
                "subsegments": [
                    ...,
                    {
                        "id": "889eb8ec2a65dea8",
                        "name": "S3",
                        ...,
                        "aws": {
                            "xray": {
                                "auto_instrumentation": false,
                                "sdk_version": "1.5.0",
                                "sdk": "opentelemetry for python"
                            },
                            "region": "us-west-2",
                            "operation": "ListBuckets",
                            "request_id": "Q21YRKZZZ5Y3NKN0"
                        },
                        "metadata": {
                            "default": {
                                "aws.service": "s3",
                                "retry_attempts": 0
                            }
                        },
                        "namespace": "aws"
                    }
                ]
            }
        },
        ...,
        {
            "Id": "3b5da1970904eded",
            "Document": {
                "id": "3b5da1970904eded",
                "name": "S3",
                ...,
                "inferred": true,
                ...,
                "aws": {
                    "xray": {
                        "auto_instrumentation": false,
                        "sdk_version": "1.5.0",
                        "sdk": "opentelemetry for python"
                    },
                    "region": "us-west-2",
                    "operation": "ListBuckets",
                    "request_id": "Q21YRKZZZ5Y3NKN0"
                },
                "origin": "AWS::S3"
            }
        }
    ]
}
```


**After** (Regression):

```json
{
    ...,
    "Segments": [
        {
            ...,
            "Document": {
                ...,
                "subsegments": [
                    ...,
                    {
                        "id": "93db1e4f7259e9ff",
                        "name": "S3",
                        ...,
                        "aws": {
                            "xray": {
                                "auto_instrumentation": false,
                                "sdk_version": "1.6.2",
                                "sdk": "opentelemetry for python"
                            },
                            "region": "us-west-2",
                            "request_id": "W5YH3M930Q6JKM8S"
                        },
                        "metadata": {
                            "default": {
                                "rpc.service": "S3",
                                "rpc.method": "ListBuckets",
                                "retry_attempts": 0,
                                "rpc.system": "aws-api"
                            }
                        },
                        "namespace": "remote"
                    }
                ]
            }
        },
        ...,
        {
            "Id": "0734305e3d141d9f",
            "Document": {
                "id": "0734305e3d141d9f",
                "name": "S3",
                ...,
                "inferred": true,
                ...,
            }
        },
        ...
    ]
}
```

So we use the **Before** to guide our template here.