### PR TITLE
Fixed https mocked server /put-data* endpoint.

### DIFF
--- a/mocked_servers/https/Dockerfile
+++ b/mocked_servers/https/Dockerfile
@@ -1,6 +1,8 @@
-FROM golang:1.17 as build
+FROM golang:1.17 AS build
 WORKDIR $GOPATH/main
 COPY . .
+RUN go env -w GOPROXY=direct
+RUN GO111MODULE=on go mod download
 RUN GO111MODULE=on CGO_ENABLED=0 GOOS=linux go build -o=/bin/main .
 
 FROM scratch

--- a/mocked_servers/https/go.mod
+++ b/mocked_servers/https/go.mod
@@ -1,3 +1,5 @@
 module github.com/aws-observability/aws-otel-test-framework/mockedservers/https
 
 go 1.17
+
+require github.com/gorilla/mux v1.8.0

--- a/mocked_servers/https/go.sum
+++ b/mocked_servers/https/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=

--- a/mocked_servers/https/main.go
+++ b/mocked_servers/https/main.go
@@ -22,6 +22,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/gorilla/mux"
 )
 
 const (
@@ -89,8 +91,8 @@ func main() {
 	go func(ts *transactionStore) {
 		defer wg.Done()
 
-		dataApp := http.NewServeMux()
-		dataApp.HandleFunc("/put-data/", ts.dataReceived)
+		dataApp := mux.NewRouter()
+		dataApp.PathPrefix("/put-data").HandlerFunc(ts.dataReceived)
 		dataApp.HandleFunc("/trace/v1", ts.dataReceived)
 		dataApp.HandleFunc("/metric/v1", ts.dataReceived)
 		if err := http.ListenAndServeTLS(":443", CertFilePath, KeyFilePath, dataApp); err != nil {


### PR DESCRIPTION
Fixes https://github.com/aws-observability/aws-otel-test-framework/issues/404 as the prometheus exporter pushes to `/put-data`, which was not matching on `/put-data/`.

Tested against `otlp_*_exporter_*_mock`, `otlp_mock`, `sapm_exporter_trace_mock`, and `prometheus_mock`