### PR TITLE
Avoid having null pointers error when the context is missing

### DIFF
--- a/validator/src/main/java/com/amazon/aoc/validators/CWMetricValidator.java
+++ b/validator/src/main/java/com/amazon/aoc/validators/CWMetricValidator.java
@@ -74,7 +74,7 @@ public class CWMetricValidator implements IValidator {
     for (Metric metric : expectedMetricList) {
       for (Dimension dimension : metric.getDimensions()) {
 
-        if (Object.equals(dimension.getValue(), null) || dimension.getValue().equals("")) {
+        if (dimension.getValue() == null || dimension.getValue().equals("")) {
           continue;
         }
 

--- a/validator/src/main/java/com/amazon/aoc/validators/CWMetricValidator.java
+++ b/validator/src/main/java/com/amazon/aoc/validators/CWMetricValidator.java
@@ -74,7 +74,7 @@ public class CWMetricValidator implements IValidator {
     for (Metric metric : expectedMetricList) {
       for (Dimension dimension : metric.getDimensions()) {
 
-        if (dimension.getValue() == null || dimension.getValue().equals("")) {
+        if (Object.equals(dimension.getValue(), null) || dimension.getValue().equals("")) {
           continue;
         }
 

--- a/validator/src/main/java/com/amazon/aoc/validators/CWMetricValidator.java
+++ b/validator/src/main/java/com/amazon/aoc/validators/CWMetricValidator.java
@@ -73,6 +73,11 @@ public class CWMetricValidator implements IValidator {
     Set<String> skippedDimensionNameList = new HashSet<>();
     for (Metric metric : expectedMetricList) {
       for (Dimension dimension : metric.getDimensions()) {
+
+        if (dimension.getValue() == null || dimension.getValue().equals("")) {
+          continue;
+        }
+
         if (dimension.getValue().equals("SKIP")) {
           skippedDimensionNameList.add(dimension.getName());
         }


### PR DESCRIPTION
**Description:**
Sometimes when the [ecs_context is missing or not being added](https://github.com/aws-observability/aws-otel-test-framework/blob/terraform/terraform/ecs/main.tf#L330-L335), the metrics getting from the container will miss some dimension value (default is empty). Therefore, to avoid having NullPointerException error, we need to add a condition for skipping these dimensions to make it fail faster and easier to know why these metrics are failing.

**How to test**:
For ecs test case such as ecsmetrics, define `sample_app_callable = true` and run the test case on ecs to see the error.
**Example:**  cd terraform/ecs && terraform init && terraform apply -var="testcase=../testcases/ecsmetrics" -var-file="../testcases/ecsmetrics/parameters.tfvars" -auto-approve