### PR TITLE
Remove invalid comma in json testing template

### DIFF
--- a/validator/src/main/resources/expected-data-template/otelSDKexpectedAWSSDKTrace.mustache
+++ b/validator/src/main/resources/expected-data-template/otelSDKexpectedAWSSDKTrace.mustache
@@ -22,7 +22,7 @@
         }
       },
       "aws": {
-        "operation": "ListBuckets",
+        "operation": "ListBuckets"
       },
       "namespace": "aws"
     }


### PR DESCRIPTION
## Description

I found out during manual testing that this extra comma will break the testing framework because this makes it invalid JSON.