### PR TITLE
Support multiple regions for resources creation

### DIFF
--- a/terraform/common/main.tf
+++ b/terraform/common/main.tf
@@ -20,3 +20,11 @@ resource "random_id" "testing_id" {
   byte_length = 8
 }
 
+# Get Account ID for user to easily get arn name from some resources on AWS such as the policy, name
+# Documentation: https://stackoverflow.com/a/68398082
+data "aws_caller_identity" "current" {}
+
+locals {
+  account_id = data.aws_caller_identity.current.account_id
+}
+

--- a/terraform/common/outputs.tf
+++ b/terraform/common/outputs.tf
@@ -17,6 +17,10 @@ output "testing_id" {
   value = random_id.testing_id.hex
 }
 
+output "account_id" {
+  value = local.account_id
+}
+
 output "aoc_image" {
   value = "${var.aoc_image_repo}:${var.aoc_version}"
 }
@@ -33,6 +37,9 @@ output "otel_service_name" {
   value = "aws-otel-integ-test"
 }
 
+output "appmesh_k8s_iam_policy" {
+  value = "AWSAppMeshK8sControllerIAMPolicy"
+}
 output "aoc_iam_role_name" {
   value = "aoc-e2e-iam-role"
 }

--- a/terraform/setup/appmesh.tf
+++ b/terraform/setup/appmesh.tf
@@ -1,7 +1,17 @@
-resource "aws_iam_policy" "appmesh_k8s_iam_policy" {
-  name = "AWSAppMeshK8sControllerIAMPolicy"
-  path = "/"
+data "external" "appmesh_k8s_iam_policy_exist" {
+  program = ["bash", "${path.root}/script/terraform-check-exist.sh"]
 
+  query = {
+    check_iam_policy= "true"
+    iam_policy_arn= "arn:aws:iam::${module.common.account_id}:policy/${module.common.appmesh_k8s_iam_policy}"
+  }
+}
+
+resource "aws_iam_policy" "appmesh_k8s_iam_policy" {
+  name = module.common.appmesh_k8s_iam_policy
+  path = "/"
+  count = data.external.appmesh_k8s_iam_policy_exist.result.iam_policy_exist == "false" ? 1 : 0
+  depends_on = [data.external.appmesh_k8s_iam_policy_exist]
   # Terraform's jsonencode function converts a
   # Terraform expression result to valid JSON syntax.
   policy = jsonencode({

--- a/terraform/setup/script/terraform-check-exist.sh
+++ b/terraform/setup/script/terraform-check-exist.sh
@@ -1,14 +1,20 @@
 #Define environment variables
-check_iam_role=true
+check_iam_role=false
 check_iam_policy=false
 check_ecr_repo=false
-iam_role_name="aoc-e2e-iam-role"
+
 function error_exit() {
   echo "$1" 1>&2
   exit 1
 }
 
+function check_deps() {
+  test -f $(which jq) || error_exit "jq command not detected in path, please install it"
+  test -f $(which aws) || error_exit "aws command not detected in path, please install it"
+}
+
 function parse_env_input() {
+  eval "$(jq -r '@sh "export check_sg=\(.check_sg) sg_name=\(.sg_name) check_iam_role=\(.check_iam_role) iam_role_name=\(.iam_role_name) check_iam_policy=\(.check_iam_policy) iam_policy_arn=\(.iam_policy_arn) check_ecr_repo=\(.check_ecr_repo) ecr_repo_name=\(.ecr_repo_name)"')"
 
   if [[ ${check_iam_role} == "true" ]] && [[ -z "${iam_role_name}" ]]; then
       error_exit "Missing IAM role name when flag check_iam_role is true";
@@ -20,6 +26,10 @@ function parse_env_input() {
 
   if [[ ${check_ecr_repo} == "true" ]] && [[ -z "${ecr_repo_name}" ]]; then
       error_exit "Missing ECR repo name when flag check_ecr_repo is true";
+  fi
+
+  if [[ ${check_sg} == "true" ]] && [[ -z "${sg_name}" ]]; then
+      error_exit "Missing Security Group name when flag check_sg is true";
   fi
 }
 
@@ -35,6 +45,10 @@ function check_if_resources_exist() {
     if [[ ${check_ecr_repo} == "true" ]]; then
         aws ecr describe-repositories --repository-names "${ecr_repo_name}" > /dev/null || ecr_repo_exist=false
     fi
+
+    if [[ ${check_sg} == "true" ]]; then
+        aws ec2 wait security-group-exists --filters Name=group-name,Values="${sg_name}" > /dev/null || sg_exist=false
+    fi
 }
 
 function produce_output() {
@@ -42,13 +56,20 @@ function produce_output() {
     --arg iam_role_exist "$iam_role_exist" \
     --arg iam_policy_exist "$iam_policy_exist" \
     --arg ecr_repo_exist "$ecr_repo_exist" \
-    '{"iam_policy_exist":$iam_policy_exist,"iam_role_exist":$iam_role_exist,"ecr_repo_exist":$ecr_repo_exist}'
+    --arg sg_exist "$sg_exist" \
+    '{"iam_policy_exist":$iam_policy_exist,"iam_role_exist":$iam_role_exist,"ecr_repo_exist":$ecr_repo_exist,"sg_exist":$sg_exist}'
 }
 
 #Execute functions
+check_deps
 parse_env_input
 check_if_resources_exist
 produce_output
+
+
+
+
+
 
 
 

--- a/terraform/setup/script/terraform-check-exist.sh
+++ b/terraform/setup/script/terraform-check-exist.sh
@@ -1,0 +1,55 @@
+#Define environment variables
+check_iam_role=true
+check_iam_policy=false
+check_ecr_repo=false
+iam_role_name="aoc-e2e-iam-role"
+function error_exit() {
+  echo "$1" 1>&2
+  exit 1
+}
+
+function parse_env_input() {
+
+  if [[ ${check_iam_role} == "true" ]] && [[ -z "${iam_role_name}" ]]; then
+      error_exit "Missing IAM role name when flag check_iam_role is true";
+  fi
+
+  if [[ ${check_iam_policy} == "true" ]] && [[ -z "${iam_policy_arn}" ]]; then
+      error_exit "Missing IAM policy arn when flag check_iam_policy is true";
+  fi
+
+  if [[ ${check_ecr_repo} == "true" ]] && [[ -z "${ecr_repo_name}" ]]; then
+      error_exit "Missing ECR repo name when flag check_ecr_repo is true";
+  fi
+}
+
+function check_if_resources_exist() {
+    if [[ ${check_iam_role} == "true" ]]; then
+        aws iam wait role-exists --role-name "${iam_role_name}" > /dev/null || iam_role_exist=false
+    fi
+
+    if [[ ${check_iam_policy} == "true" ]]; then
+        aws iam wait policy-exists --policy-arn "${iam_policy_arn}" > /dev/null || iam_policy_exist=false
+    fi
+
+    if [[ ${check_ecr_repo} == "true" ]]; then
+        aws ecr describe-repositories --repository-names "${ecr_repo_name}" > /dev/null || ecr_repo_exist=false
+    fi
+}
+
+function produce_output() {
+  jq -n \
+    --arg iam_role_exist "$iam_role_exist" \
+    --arg iam_policy_exist "$iam_policy_exist" \
+    --arg ecr_repo_exist "$ecr_repo_exist" \
+    '{"iam_policy_exist":$iam_policy_exist,"iam_role_exist":$iam_role_exist,"ecr_repo_exist":$ecr_repo_exist}'
+}
+
+#Execute functions
+parse_env_input
+check_if_resources_exist
+produce_output
+
+
+
+

--- a/terraform/setup/setup.tf
+++ b/terraform/setup/setup.tf
@@ -108,9 +108,19 @@ module "vpc" {
   }
 }
 
+data "external" "aoc_sg_exist" {
+  program = ["bash", "${path.root}/script/terraform-check-exist.sh"]
+
+  query = {
+    check_sg= "true"
+    sg_name= "${module.common.aoc_vpc_security_group}"
+  }
+}
+
 resource "aws_security_group" "aoc_sg" {
   name   = module.common.aoc_vpc_security_group
   vpc_id = module.vpc.vpc_id
+  count = data.external.aoc_sg_exist.result.sg_exist == "false" ? 1 : 0
 
   # Allow all TCP ingress within the VPC so prometheus scrape can work with private IP.
   # https://stackoverflow.com/questions/49995417/self-reference-not-allowed-in-security-group-definition


### PR DESCRIPTION
**Description:**
After setup all the resources we need with command ```cd terraform/setup && terraform apply```, we were not able to create the resources again in another region. There are two possible ways: 
- Using [data sources](https://www.terraform.io/language/data-sources) and [a variable](https://github.com/hashicorp/terraform/issues/16380#issuecomment-388501001) but it would not scalable since every resources created need to have this variable.
- Using [external data sources](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/data_source) and handling errors by ourself.
Currently, I am using option 2 and one negative side of this is: if the resources exist, [terraform cannot manage the exist resources and add it into terraform state.](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/data_source). However, the trade-off between scaling to multiple-regions resources and not-managed-resources by terraform is benefit enough for us. In this way, we can support the following:
* When the resources in us-west-2 is out, we can let the test in ADOT GitHub workflow to test it in us-west-1 and so on since the only thing customer needs to know is everything works as expected (increasing capacity)
* Let's each dev testing each test case in different regions instead of destroy over and over again.