### PR TITLE
Support uploading setup's terraform state to s3 bucket 

### DIFF
--- a/docs/run-testing-framework.md
+++ b/docs/run-testing-framework.md
@@ -43,7 +43,7 @@ Setup only needs to be run once, it creates:
 2. one vpc
 3. one security group
 4. two ecr repos, one for sample apps, one for mocked server
- 
+5. one s3 bucket, one dynamodb table
 Run 
 ````
 cd terraform/setup && terraform init && terraform apply -auto-approve
@@ -60,6 +60,9 @@ Remember, if you have changes on sample apps or the mocked server, you need to r
  
 #### 2.1.3 Build Image
 Please follow https://github.com/aws-observability/aws-otel-collector/blob/main/docs/developers/build-docker.md to build your image with the new component, and push this image to dockerhub, record the image link, which will be used in your testing.
+
+#### 2.1.4 Documentation
+- [Setup basic components in aws account](setup-basic-components-in-aws-account.md)
 
 ### 2.2 Run in EC2
 ````

--- a/docs/run-testing-framework.md
+++ b/docs/run-testing-framework.md
@@ -59,11 +59,25 @@ this task will build and push the sample apps and mocked server images to the ec
  so that the following test could use them.
  
 Remember, if you have changes on sample apps or the mocked server, you need to rerun this imagebuild task.
- 
-#### 2.1.3 Build Image
-Please follow https://github.com/aws-observability/aws-otel-collector/blob/main/docs/developers/build-docker.md to build your image with the new component, and push this image to dockerhub, record the image link, which will be used in your testing.
 
-#### 2.1.4 Documentation
+#### 2.1.3 Share Setup resources (Optional)
+**Prerequisite:**
+- you are required to run the [setup basic components](setup-basic-components-in-aws-account.md#2-setup-basic-components) once if you and other developers did not setup these components before.
+- Uncomment the [backend configuration](https://github.com/khanhntd/aws-otel-test-framework/blob/support_s3_bucket_setup/terraform/setup/backend.tf#L17-L25) to share the setup's terraform state
+
+**Advantage:**
+- Avoid creating duplicate resources on the same account and having duplicate-resources error when running test case such as VPC.
+- Sharing up-to-date resource with other developers instead of creating required resources from scratch.
+
+```shell
+cd aws-otel-test-framework/terraform/setup 
+terraform init
+terraform apply
+```
+#### 2.1.4 Build AES Otel Collector Docker Image
+Please [build your image with the new component](https://github.com/aws-observability/aws-otel-collector/blob/main/docs/developers/build-docker.md), push this image to dockerhub, and record the image link, which will be used in your testing.
+
+#### 2.1.5 Documentation
 - [Setup basic components in aws account](setup-basic-components-in-aws-account.md)
 
 ### 2.2 Run in EC2
@@ -96,7 +110,7 @@ terraform destroy -auto-approve
 ````
  
 ### 2.4 Run in EKS
-Prerequisite: you are required to create an EKS cluster in your account
+**Prerequisite:** you are required to create an EKS cluster in your account
 ````
 cd terraform/eks && terraform init && terraform apply -auto-approve \
     -var="aoc_image_repo={{the docker image you just pushed}}" \
@@ -106,7 +120,7 @@ cd terraform/eks && terraform init && terraform apply -auto-approve \
     -var="eks_cluster_name={{the eks cluster name in your account}}" 
 ````
 
-Don't forget to clean up your resources:
+ Don't forget to clean up your resources:
 ````
 terraform destroy -auto-approve \
     -var="eks_cluster_name={the eks cluster name in your account}"
@@ -146,7 +160,7 @@ terraform destroy -auto-approve \
     -var="deployment_type=fargate"
 ````
 ### 2.5 Run in soaking
-Prerequisite: you are required to build aotutil for checking patch status
+**Prerequisite:** you are required to build aotutil for checking patch status
 ```
 make build-aotutil
 ```

--- a/docs/setup-basic-components-in-aws-account.md
+++ b/docs/setup-basic-components-in-aws-account.md
@@ -15,7 +15,8 @@ Setup only needs to be run once, it creates:
 2. one vpc
 3. one security group
 4. two ecr repos, one for sample apps, one for mocked server
-5. one s3 bucket, one dynamodb table
+5. one amazon managed service for prometheus endpoint.
+6. one s3 bucket, one dynamodb table
 
 ```shell
 cd aws-otel-test-framework/terraform/setup 

--- a/docs/setup-basic-components-in-aws-account.md
+++ b/docs/setup-basic-components-in-aws-account.md
@@ -9,8 +9,13 @@ Refer to: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.h
 Please ensure the default profile in your ~/.aws/credentials has Admin permission.
 
 ## 2. Setup basic components
+Setup only needs to be run once, it creates:
 
-Setup only needs to be run once
+1. one iam role
+2. one vpc
+3. one security group
+4. two ecr repos, one for sample apps, one for mocked server
+5. one s3 bucket, one dynamodb table
 
 ```shell
 cd aws-otel-test-framework/terraform/setup 
@@ -18,6 +23,16 @@ terraform init
 terraform apply
 ```
 
+###2.1 Upload setup's terraform state to s3 bucket
+Prerequisite: 
+- you are required to run the [setup basic components](setup-basic-components-in-aws-account.md#2-setup-basic-components) once if you did not setup those components before.
+- Uncomment the [backend configuration](https://github.com/khanhntd/aws-otel-test-framework/blob/support_s3_bucket_setup/terraform/setup/backend.tf#L17-L25)
+
+```shell
+cd aws-otel-test-framework/terraform/setup 
+terraform init
+terraform apply
+```
 ## 3. Build sample app images
 
 this step might take 20 minutes, it builds and pushes the sample apps and mocked server images to the ecr repos, so that the following test could use them.

--- a/docs/setup-basic-components-in-aws-account.md
+++ b/docs/setup-basic-components-in-aws-account.md
@@ -24,10 +24,14 @@ terraform init
 terraform apply
 ```
 
-###2.1 Upload setup's terraform state to s3 bucket
-Prerequisite: 
-- you are required to run the [setup basic components](setup-basic-components-in-aws-account.md#2-setup-basic-components) once if you did not setup those components before.
-- Uncomment the [backend configuration](https://github.com/khanhntd/aws-otel-test-framework/blob/support_s3_bucket_setup/terraform/setup/backend.tf#L17-L25)
+###2.1 Share Setup resources (Optional)
+**Prerequisite:** 
+- you are required to run the [setup basic components](setup-basic-components-in-aws-account.md#2-setup-basic-components) once if you and other developers did not setup these components before.
+- Uncomment the [backend configuration](https://github.com/khanhntd/aws-otel-test-framework/blob/support_s3_bucket_setup/terraform/setup/backend.tf#L17-L25) to share the setup's terraform state
+
+**Advantage:**
+- Avoid creating duplicate resources on the same account and having duplicate-resources error when running test case such as VPC.
+- Sharing up-to-date resource with other developers instead of creating required resources from scratch. 
 
 ```shell
 cd aws-otel-test-framework/terraform/setup 

--- a/terraform/setup/backend.tf
+++ b/terraform/setup/backend.tf
@@ -13,7 +13,10 @@
 # permissions and limitations under the License.
 # -------------------------------------------------------------------------
 
-#In this module, we are uploading
+#In this module, we are uploading setup's terraform state to s3 bucket for two reasons:
+#-Share the setup configuration with others dev
+#-Avoid creating duplicate resources when sharing the same account
+
 #terraform {
 #  backend "s3" {
 #    bucket           = "setup-remote-state-s3-bucket"

--- a/terraform/setup/backend.tf
+++ b/terraform/setup/backend.tf
@@ -30,8 +30,8 @@
 #Create S3 bucket to record terraform state for this setup in order to share the state for configuration setup when using integration test account
 #Document: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket
 resource "aws_s3_bucket" "setup-remote-state-s3-bucket" {
-  bucket  = "setup-remote-state-s3-bucket"
-  acl     = "private"
+  bucket = "setup-remote-state-s3-bucket"
+  acl    = "private"
 
   versioning {
     enabled = true
@@ -50,11 +50,11 @@ resource "aws_s3_bucket" "setup-remote-state-s3-bucket" {
 #Avoid multiple developers change the state at the same time since it would cause race condition
 #Document: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table
 resource "aws_dynamodb_table" "setup-remote-state-dynamodb-table" {
-  name            = "setup-remote-state-dynamodb-table"
-  hash_key        = "LockID"
-  billing_mode    = "PAY_PER_REQUEST"
-  read_capacity   = "8"
-  write_capacity  = "8"
+  name           = "setup-remote-state-dynamodb-table"
+  hash_key       = "LockID"
+  billing_mode   = "PAY_PER_REQUEST"
+  read_capacity  = "8"
+  write_capacity = "8"
 
   attribute {
     name = "LockID"

--- a/terraform/setup/setup.tf
+++ b/terraform/setup/setup.tf
@@ -211,6 +211,8 @@ resource "aws_security_group" "aoc_sg" {
 resource "aws_ecr_repository" "sample_app_ecr_repo" {
   name = module.common.sample_app_ecr_repo_name
 }
+
 resource "aws_ecr_repository" "mocked_server_ecr_repo" {
   name = module.common.mocked_server_ecr_repo_name
 }
+


### PR DESCRIPTION
**Description**
Currently, if devs shared the accounts with others and setup again, they will run into some issues when creating resources such as the Elastic IP Address problem. Therefore, it would be better to share the terraform state with one-time setup.
- Share the setup configuration with others dev
- Avoid creating duplicate resources when sharing the same account

**Disadvantages: **
- Instead of dynamic variables, this approach is supporting only hard code variables since [https://www.terraform.io/language/settings/backends/configuration#using-a-backend-block]
- We need to un-comment backend manually and run terraform apply again since we cannot control the creation of backend (terraform checkout backend before any modules, resources,..)

**How to test**:
**Step 1:** Following the instructions in https://github.com/aws-observability/aws-otel-test-framework/blob/terraform/docs/setup-basic-components-in-aws-account.md
**Step 2:** Uncomment the [backend configuration](https://github.com/khanhntd/aws-otel-test-framework/blob/support_s3_bucket_setup/terraform/setup/backend.tf#L17-L25) 
**Step 3:** Run terraform init && terraform apply