### PR TITLE
convert to public repo

### DIFF
--- a/terraform/common.tf
+++ b/terraform/common.tf
@@ -31,7 +31,7 @@ variable "sample_app_image" {
 }
 
 variable "aoc_image_repo" {
-  default = "611364707713.dkr.ecr.us-west-2.amazonaws.com/aws/aws-otel-collector"
+  default = "public.ecr.aws/aws-otel-test/adot-collector-integration-test"
 }
 
 variable "aoc_version" {


### PR DESCRIPTION
Description:

Currently, the CI publishes the image to private repo and we need to pull it from there for integration test. However, as we discussed with the adot team, converting from private to public ECR would give us two advantages:

More visibility for the customer and dev to pull down the image without having the credentials.
Able to use multiple regions later on.