### PR TITLE
add initial support creating amp workspace

### DIFF
--- a/docs/run-testing-framework.md
+++ b/docs/run-testing-framework.md
@@ -43,7 +43,8 @@ Setup only needs to be run once, it creates:
 2. one vpc
 3. one security group
 4. two ecr repos, one for sample apps, one for mocked server
- 
+5. one amazon managed service for prometheus endpoint. 
+
 Run 
 ````
 cd terraform/setup && terraform init && terraform apply -auto-approve

--- a/terraform/basic_components/variables.tf
+++ b/terraform/basic_components/variables.tf
@@ -41,7 +41,7 @@ variable "mocked_server" {
 }
 
 variable "cortex_instance_endpoint" {
-  default = "https://aps-workspaces.us-west-2.amazonaws.com/workspaces/ws-cd278045-1d6e-4550-a207-c5046a1b40b8"
+  default = ""
 }
 
 variable "sample_app_listen_address_host" {

--- a/terraform/basic_components/variables.tf
+++ b/terraform/basic_components/variables.tf
@@ -41,7 +41,7 @@ variable "mocked_server" {
 }
 
 variable "cortex_instance_endpoint" {
-  default = ""
+  default = "https://aps-workspaces.us-west-2.amazonaws.com/workspaces/ws-cd278045-1d6e-4550-a207-c5046a1b40b8"
 }
 
 variable "sample_app_listen_address_host" {

--- a/terraform/common.tf
+++ b/terraform/common.tf
@@ -69,7 +69,7 @@ variable "sample_app_mode" {
 
 variable "cortex_instance_endpoint" {
   # change to your cortex endpoint
-  default = "https://aps-workspaces-gamma.us-west-2.amazonaws.com/workspaces/ws-31eb305d-3208-42d5-a7f4-32ce1191e699"
+  default = "https://aps-workspaces.us-west-2.amazonaws.com/workspaces/ws-cd278045-1d6e-4550-a207-c5046a1b40b8"
 }
 
 variable "aotutil" {

--- a/terraform/common/outputs.tf
+++ b/terraform/common/outputs.tf
@@ -105,3 +105,7 @@ output "sample_app_ecr_repo_name" {
 output "mocked_server_ecr_repo_name" {
   value = "otel-test/mocked-server"
 }
+
+output "amp_testing_framework" {
+  value = "amp_testing_framework"
+}

--- a/terraform/setup/appmesh.tf
+++ b/terraform/setup/appmesh.tf
@@ -1,3 +1,18 @@
+# ------------------------------------------------------------------------
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+# -------------------------------------------------------------------------
+
 resource "aws_iam_policy" "appmesh_k8s_iam_policy" {
   name = "AWSAppMeshK8sControllerIAMPolicy"
   path = "/"

--- a/terraform/setup/outputs.tf
+++ b/terraform/setup/outputs.tf
@@ -1,0 +1,18 @@
+# ------------------------------------------------------------------------
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+# -------------------------------------------------------------------------
+
+output "amp_testing_framework_endpoint" {
+  value = aws_prometheus_workspace.amp_testing_framework.prometheus_endpoint
+}

--- a/terraform/setup/setup.tf
+++ b/terraform/setup/setup.tf
@@ -214,3 +214,7 @@ resource "aws_ecr_repository" "sample_app_ecr_repo" {
 resource "aws_ecr_repository" "mocked_server_ecr_repo" {
   name = module.common.mocked_server_ecr_repo_name
 }
+
+resource "aws_prometheus_workspace" "amp_testing_framework" {
+  alias = module.common.amp_testing_framework
+}

--- a/terraform/testcases/otlp_grpc_exporter_cw_amp_xray_ecs/otconfig.tpl
+++ b/terraform/testcases/otlp_grpc_exporter_cw_amp_xray_ecs/otconfig.tpl
@@ -109,7 +109,7 @@ exporters:
     resource_to_telemetry_conversion:
       enabled: true
   awsprometheusremotewrite:
-    endpoint: https://aps-workspaces.us-west-2.amazonaws.com/workspaces/ws-cd278045-1d6e-4550-a207-c5046a1b40b8/api/v1/remote_write
+    endpoint: ${cortex_instance_endpoint}/api/v1/remote_write
     resource_to_telemetry_conversion:
       enabled: true
     aws_auth:

--- a/validator/src/main/java/com/amazon/aoc/clients/CortexClient.java
+++ b/validator/src/main/java/com/amazon/aoc/clients/CortexClient.java
@@ -91,7 +91,7 @@ public class CortexClient {
     URI uri = new URIBuilder()
             .setScheme(Objects.requireNonNull(rawUrl).scheme())
             .setHost(rawUrl.host())
-            .setPath(rawUrl.encodedPath() + "/api/v1/query_range")
+            .setPath(rawUrl.encodedPath() + "/api/v1/query")
             .addParameter("query", query)
             .addParameter("start", Long.toString(endEpochTime - 3600))
             .addParameter("end", Long.toString(endEpochTime))


### PR DESCRIPTION
**Description**:
Add initial setup for amp so some of the tests can hit the dev account instead of using the gamma one.