### PR TITLE
Add OTLP metric mock.

### DIFF
--- a/terraform/testcases/otlp_metric_mock/otconfig.tpl
+++ b/terraform/testcases/otlp_metric_mock/otconfig.tpl
@@ -1,0 +1,29 @@
+extensions:
+  pprof:
+    endpoint: 0.0.0.0:1777
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:${grpc_port}
+
+processors:
+  batch:
+
+exporters:
+  logging:
+    loglevel: debug
+  awsemf:
+    region: ${region}
+    endpoint: "https://${mock_endpoint}"
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [logging, awsemf]
+  extensions: [pprof]
+  telemetry:
+    logs:
+      level: debug

--- a/terraform/testcases/otlp_metric_mock/parameters.tfvars
+++ b/terraform/testcases/otlp_metric_mock/parameters.tfvars
@@ -1,0 +1,2 @@
+# data type will be emitted. Possible values: metric or trace
+soaking_data_mode = "metric"


### PR DESCRIPTION
**Description:** Adds a test case for the OTLP metric mock backend. This will be used in the performance tests instead of the current `otlp_metric`.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** Ran the mock test.

**Documentation:** <Describe the documentation added.>