### PR TITLE
Set instance type for performance tests back to m5.2xlarge.

### DIFF
--- a/terraform/canary/amis.tf
+++ b/terraform/canary/amis.tf
@@ -3,7 +3,7 @@ variable "ami_family" {
     amazon_linux = {
       login_user               = "ec2-user"
       install_package          = "aws-otel-collector.rpm"
-      instance_type            = "t2.micro"
+      instance_type            = "t3.small"
       otconfig_destination     = "/tmp/ot-default.yml"
       download_command_pattern = "wget %s"
       install_command          = "sudo rpm -Uvh aws-otel-collector.rpm"

--- a/terraform/ec2/main.tf
+++ b/terraform/ec2/main.tf
@@ -87,7 +87,7 @@ locals {
 ## launch a sidecar instance to install data emitter and the mocked server
 resource "aws_instance" "sidecar" {
   ami                         = data.aws_ami.amazonlinux2.id
-  instance_type               = "t2.micro"
+  instance_type               = var.sidecar_instance_type
   subnet_id                   = local.instance_subnet
   vpc_security_group_ids      = [module.basic_components.aoc_security_group_id]
   associate_public_ip_address = true

--- a/terraform/ec2/variables.tf
+++ b/terraform/ec2/variables.tf
@@ -24,6 +24,10 @@ variable "testing_ami" {
   default = "amazonlinux2"
 }
 
+variable "sidecar_instance_type" {
+  default = "t3.medium"
+}
+
 variable "soaking_compose_file" {
   default = ""
 }
@@ -110,7 +114,7 @@ variable "ssm_package_name" {
   default = "AWSDistroOTel-Collector"
 }
 
-# Base64 value of ADOT Collector YMAL configuration
+# Base64 value of ADOT Collector YAML configuration
 variable "ssm_config" {
   default = ""
 }

--- a/terraform/ec2_setup/amis.tf
+++ b/terraform/ec2_setup/amis.tf
@@ -3,7 +3,7 @@ variable "ami_family" {
     amazon_linux = {
       login_user                         = "ec2-user"
       install_package                    = "aws-otel-collector.rpm"
-      instance_type                      = "t2.micro"
+      instance_type                      = "m5.2xlarge"
       otconfig_destination               = "/tmp/ot-default.yml"
       download_command_pattern           = "wget %s"
       install_command                    = "sudo rpm -Uvh aws-otel-collector.rpm && sudo chmod 777 /opt/aws/aws-otel-collector/etc/.env && sudo echo 'GODEBUG=madvdontneed=1' >> /opt/aws/aws-otel-collector/etc/.env"

--- a/terraform/ec2_setup/main.tf
+++ b/terraform/ec2_setup/main.tf
@@ -31,14 +31,15 @@ data "aws_ecr_repository" "sample_apps" {
 module "ec2_setup" {
   source = "../ec2"
 
-  ami_family       = var.ami_family
-  amis             = var.amis
-  testing_ami      = var.testing_ami
-  aoc_version      = var.aoc_version
-  region           = var.region
-  testcase         = var.testcase
-  sample_app_image = var.soaking_sample_app != "" ? "${data.aws_ecr_repository.sample_apps.repository_url}:${var.soaking_sample_app}-latest" : var.soaking_sample_app_image
-  skip_validation  = true
+  ami_family            = var.ami_family
+  amis                  = var.amis
+  testing_ami           = var.testing_ami
+  aoc_version           = var.aoc_version
+  region                = var.region
+  testcase              = var.testcase
+  sample_app_image      = var.soaking_sample_app != "" ? "${data.aws_ecr_repository.sample_apps.repository_url}:${var.soaking_sample_app}-latest" : var.soaking_sample_app_image
+  sidecar_instance_type = var.sidecar_instance_type
+  skip_validation       = true
 
   # soaking test config
   # StatsD use its own docker compose for udp port

--- a/terraform/ec2_setup/variables.tf
+++ b/terraform/ec2_setup/variables.tf
@@ -16,6 +16,10 @@
 variable "testing_ami" {
 }
 
+variable "sidecar_instance_type" {
+  default = "t3.medium"
+}
+
 variable "soaking_sample_app_image" {
   default = "public.ecr.aws/aws-otel-test/aws-otel-load-generator:v0.11.0"
 }

--- a/terraform/performance/main.tf
+++ b/terraform/performance/main.tf
@@ -25,11 +25,12 @@ module "ec2_setup" {
   testcase    = var.testcase
   testing_ami = var.testing_ami
 
-  sample_app_mode    = var.sample_app_mode
-  soaking_sample_app = var.soaking_sample_app
-  soaking_data_rate  = var.data_rate
-  soaking_data_type  = var.soaking_data_type
-  soaking_data_mode  = var.soaking_data_mode
+  sample_app_mode       = var.sample_app_mode
+  soaking_sample_app    = var.soaking_sample_app
+  soaking_data_rate     = var.data_rate
+  soaking_data_type     = var.soaking_data_type
+  soaking_data_mode     = var.soaking_data_mode
+  sidecar_instance_type = var.sidecar_instance_type
 
   cortex_instance_endpoint = var.cortex_instance_endpoint
 

--- a/terraform/performance/variables.tf
+++ b/terraform/performance/variables.tf
@@ -62,3 +62,7 @@ variable "commit_id" {
 variable "soaking_sample_app" {
   default = ""
 }
+
+variable "sidecar_instance_type" {
+  default = "m5.2xlarge"
+}


### PR DESCRIPTION
**Description:** Added variable for sidecar instance type so the performance tests can run with a different configuration.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
