### PR TITLE
Add Platform To Otel Mock Test Build

### DIFF
--- a/terraform/templates/local/docker_compose.tpl
+++ b/terraform/templates/local/docker_compose.tpl
@@ -8,6 +8,7 @@ services:
       - 55671:55671
 
   aws-ot-collector:
+    platform: linux/amd64
     build:
       context: ../../../aws-otel-collector
       dockerfile: cmd/awscollector/Dockerfile

--- a/terraform/templates/local/docker_compose_from_source.tpl
+++ b/terraform/templates/local/docker_compose_from_source.tpl
@@ -8,6 +8,7 @@ services:
       - 55671:55671
 
   aws-ot-collector:
+    platform: linux/amd64
     build:
       context: ../../../aws-otel-collector
       dockerfile: cmd/awscollector/Dockerfile


### PR DESCRIPTION
**Description:** 
Need to add platform to docker build

**Testing:** 
terraform apply -auto-approve -var-file="../testcases/jaeger_mock/parameters.tfvars" -var="aoc_image_repo=public.ecr.aws/aws-observability/aws-otel-collector" -var="testcase=../testcases/jaeger_mock" -var="aoc_version=v0.15.0"


See https://github.com/aws-observability/aws-otel-collector/pull/870/files
