### PR TITLE
Use JDK 11 For Docker Builds

### DIFF
--- a/load-generator/Dockerfile
+++ b/load-generator/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:7.3.3 as builder
+FROM gradle:7.3.3-jdk11 as builder
 
 # build
 WORKDIR /app

--- a/sample-apps/jaeger-zipkin-sample-app/Dockerfile
+++ b/sample-apps/jaeger-zipkin-sample-app/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:7.3.3 as builder
+FROM gradle:7.3.3-jdk11 as builder
 
 WORKDIR /app
 COPY ./build.gradle ./build.gradle

--- a/sample-apps/spark/Dockerfile
+++ b/sample-apps/spark/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:7.3.3 as build
+FROM gradle:7.3.3-jdk11 as build
 
 WORKDIR /app
 COPY ./build.gradle ./build.gradle

--- a/validator/Dockerfile
+++ b/validator/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:7.3.3 as build
+FROM gradle:7.3.3-jdk11 as build
 
 WORKDIR /app
 COPY ./build.gradle ./build.gradle


### PR DESCRIPTION
**Description:** 
Our builds use jdk 11 not the gradle 7 default of 17