### PR TITLE
Update Load Generator Deps

### DIFF
--- a/load-generator/README.md
+++ b/load-generator/README.md
@@ -16,12 +16,12 @@
 
 ### OTLP Metrics Load Test Sample Command,
 ```
-./gradlew :load-generator:run --args="metric -r=10000 -u=localhost:4317 -d=otlp -f=10000"
+./gradlew :load-generator:run --args="metric -r=10000 -u=http://localhost:4317 -d=otlp -f=10000"
 ```
 
 ### OTLP Trace Load Test Sample Command,
 ```
-./gradlew :load-generator:run --args="trace -r=100 -u=localhost:4317 -d=otlp"
+./gradlew :load-generator:run --args="trace -r=100 -u=http://localhost:4317 -d=otlp"
 ```
 
 ### X-Ray Trace Load Test Sample Command,

--- a/load-generator/build.gradle
+++ b/load-generator/build.gradle
@@ -30,13 +30,13 @@ dependencies {
 
     implementation "io.grpc:grpc-netty-shaded:1.34.1"
 
-    implementation platform("io.opentelemetry:opentelemetry-bom:1.4.1")
+    implementation platform("io.opentelemetry:opentelemetry-bom:1.10.0")
     implementation "io.opentelemetry:opentelemetry-api"
-    implementation "io.opentelemetry:opentelemetry-sdk-metrics:1.4.1-alpha"
+    implementation "io.opentelemetry:opentelemetry-sdk-metrics:1.10.0-alpha"
     implementation "io.opentelemetry:opentelemetry-exporter-otlp:1.10.0"
-    implementation "io.opentelemetry:opentelemetry-exporter-otlp-metrics:1.4.1-alpha"
+    implementation "io.opentelemetry:opentelemetry-exporter-otlp-metrics:1.10.0-alpha"
     implementation "io.opentelemetry:opentelemetry-sdk-extension-aws"
-    implementation "io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:1.4.1-alpha"
+    implementation "io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:1.10.0-alpha"
 
     implementation "com.amazonaws:aws-xray-recorder-sdk-core:2.10.0"
     implementation "com.amazonaws:aws-xray-recorder-sdk-aws-sdk:2.10.0"

--- a/load-generator/src/main/java/com/amazon/opentelemetry/load/generator/emitter/OtlpTraceEmitter.java
+++ b/load-generator/src/main/java/com/amazon/opentelemetry/load/generator/emitter/OtlpTraceEmitter.java
@@ -15,14 +15,13 @@
 
 package com.amazon.opentelemetry.load.generator.emitter;
 
-import com.amazon.opentelemetry.load.generator.factory.AwsTracerConfigurer;
 import com.amazon.opentelemetry.load.generator.model.Parameter;
-import io.grpc.ManagedChannelBuilder;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.sdk.extension.aws.trace.AwsXrayIdGenerator;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
@@ -47,13 +46,12 @@ public class OtlpTraceEmitter extends TraceEmitter {
   @Override
   public void setupProvider() throws Exception {
     OtlpGrpcSpanExporter spanExporter = OtlpGrpcSpanExporter.builder()
-        .setChannel(
-            ManagedChannelBuilder.forTarget(param.getEndpoint()).usePlaintext().build())
+        .setEndpoint(param.getEndpoint())
         .setTimeout(Duration.ofMillis(10))
         .build();
 
     SdkTracerProviderBuilder builder = SdkTracerProvider.builder();
-    new AwsTracerConfigurer().configure(builder);
+    builder.setIdGenerator(AwsXrayIdGenerator.getInstance());
     builder.addSpanProcessor(SimpleSpanProcessor.create(spanExporter));
     TracerProvider tracerProvider = builder.build();
 

--- a/load-generator/src/main/java/com/amazon/opentelemetry/load/generator/factory/AwsTracerConfigurer.java
+++ b/load-generator/src/main/java/com/amazon/opentelemetry/load/generator/factory/AwsTracerConfigurer.java
@@ -15,8 +15,8 @@
 
 package com.amazon.opentelemetry.load.generator.factory;
 
-import io.opentelemetry.sdk.autoconfigure.spi.SdkTracerProviderConfigurer;
-import io.opentelemetry.sdk.extension.aws.trace.AwsXrayIdGenerator;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.traces.SdkTracerProviderConfigurer;
 import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
 
 public class AwsTracerConfigurer implements SdkTracerProviderConfigurer {
@@ -30,7 +30,6 @@ public class AwsTracerConfigurer implements SdkTracerProviderConfigurer {
   }
 
   @Override
-  public void configure(SdkTracerProviderBuilder sdkTracerProviderBuilder) {
-    sdkTracerProviderBuilder.setIdGenerator(AwsXrayIdGenerator.getInstance());
+  public void configure(SdkTracerProviderBuilder tracerProviderBuilder, ConfigProperties config) {
   }
 }


### PR DESCRIPTION
**Description:** 
After updating the load gen from dep bot. We were not able to generate proper otlp metrics and traces this fixes that. 

**Testing:** 
Ran the collector locally and ran the generator then saw traces and metrics in cloudwatch and xray. 
