### PR TITLE
Add Dockerfile For Traffic Generator Image

### DIFF
--- a/terraform/eks/jmx/jmx.tf
+++ b/terraform/eks/jmx/jmx.tf
@@ -33,7 +33,7 @@ output "metric_dimension_namespace" {
 }
 
 locals {
-  traffic_generator_image = "ellerbrock/alpine-bash-curl-ssl"
+  traffic_generator_image = "${var.sample_app_image_repo}:traffic-generator"
   jmx_sample_app_image    = "${var.sample_app_image_repo}:tomcatapp"
 }
 

--- a/traffic-generator/Dockerfile
+++ b/traffic-generator/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:latest
+
+RUN apk --no-cache add curl bash git dumb-init openssl
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]

--- a/traffic-generator/README.md
+++ b/traffic-generator/README.md
@@ -1,0 +1,14 @@
+# This is a minimal alpine image
+
+## Requirements 
+* Run bash commands
+* Run curl
+* Container started with bash command
+
+## Build the container with amd and arm images
+
+docker buildx build --push --platform=linux/amd64,linux/arm64 -t 611364707713.dkr.ecr.us-west-2.amazonaws.com/otel-test/container-insight-samples:traffic-generator -f Dockerfile .
+
+## Example start command to curl google.com while true
+
+docker run 611364707713.dkr.ecr.us-west-2.amazonaws.com/otel-test/container-insight-samples:traffic-generator "/bin/bash" "-c" "while :; do curl http://google.com; sleep 1s; done"


### PR DESCRIPTION
**Description:**
Current traffic Generator does not support arm64
https://hub.docker.com/r/ellerbrock/alpine-bash-curl-ssl/tags

**Testing:** 
docker buildx build --push --platform=linux/amd64,linux/arm64 -t 611364707713.dkr.ecr.us-west-2.amazonaws.com/otel-test/container-insight-samples:traffic-generator -f Dockerfile .

docker run 611364707713.dkr.ecr.us-west-2.amazonaws.com/otel-test/container-insight-samples:traffic-generator "/bin/bash" "-c" "while :; do curl http://google.com; sleep 1s; done"