### PR TITLE
Add expected trace template for ruby rails app

### DIFF
--- a/validator/src/main/java/com/amazon/aoc/fileconfigs/PredefinedExpectedTemplate.java
+++ b/validator/src/main/java/com/amazon/aoc/fileconfigs/PredefinedExpectedTemplate.java
@@ -70,6 +70,9 @@ public enum PredefinedExpectedTemplate implements FileConfig {
   JS_SDK_AWSSDK_EXPECTED_TRACE(
     "/expected-data-template/js/jsAppExpectedAWSSDKTrace.mustache"
   ),
+  RAILS_SDK_AWSSDK_EXPECTED_TRACE(
+    "/expected-data-template/rails/railsAppExpectedAWSSDKTrace.mustache"
+  ),
 
   /**
    * Log structure template, defined in resources.

--- a/validator/src/main/resources/expected-data-template/rails/railsAppExpectedAWSSDKTrace.mustache
+++ b/validator/src/main/resources/expected-data-template/rails/railsAppExpectedAWSSDKTrace.mustache
@@ -1,0 +1,34 @@
+[{
+  "http": {
+    "request": {
+      "url": "{{endpoint}}/aws-sdk-call",
+      "method": "GET"
+    },
+    "response": {
+      "status": 200
+    }
+  },
+  "metadata": {
+    "default": {
+      "otel.resource.telemetry.sdk.name": "opentelemetry",
+      "otel.resource.telemetry.sdk.language": "ruby"
+    }
+  },
+  "subsegments": [
+    {
+      "name": "S3",
+      "aws": {
+        "operation": "ListBuckets"
+      },
+      "namespace": "aws"
+    }
+  ]
+},
+{
+  "name": "S3",
+  "inferred":true,
+  "aws": {
+      "operation": "ListBuckets"
+  },
+  "origin": "AWS::S3"
+}]

--- a/validator/src/main/resources/validations/rails-otel-trace-validation.yml
+++ b/validator/src/main/resources/validations/rails-otel-trace-validation.yml
@@ -1,0 +1,13 @@
+-
+  validationType: "trace"
+  httpPath: "/outgoing-http-call"
+  httpMethod: "get"
+  callingType: "http"
+  expectedTraceTemplate: "OTEL_SDK_HTTP_EXPECTED_TRACE"
+-
+  validationType: "trace"
+  httpPath: "/aws-sdk-call"
+  httpMethod: "get"
+  callingType: "http"
+  expectedTraceTemplate: "RAILS_SDK_AWSSDK_EXPECTED_TRACE"
+


### PR DESCRIPTION
**Description:**
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

In anticipation of add a sample app showcasing OpenTelemetry Ruby for AWS X-ray, we want to provide the templates we expect the traces a simple Ruby on Rails app would generate.

In our tests, we found that the standard `/outgoing-http-call` produces the correct _default_ OTel Trace we expect, but the AWS SDK `/aws-sdk-call` does not. So, we add an option just for this ruby discrepancy and it's expected trace template as a `.mustache` file.

The trace for `/aws-sdk-call` is found here, it is only missing the `[0].http.response.status=200,` attribute.

```
{
    [0].name=aws-otel-manual-rails-sample,
    [0].id=8b6937b40eef8505,
    [0].start_time=1642644356.856313,
    [0].trace_id=1-61e8c384-fe837006488e7e62b8624d01,
    [0].end_time=1642644357.2015743,
    [0].subsegments[0].name=S3,
    [0].subsegments[0].id=feb9914f56
9361b6,
    [0].subsegments[0].start_time=1642644356.887765,
    [0].subsegments[0].end_time=1642644357.200523,
    [0].subsegments[0].namespace=aws,
    [0].subsegments[0].aws.xray.auto_instrum
entation=false,
    [0].subsegments[0].aws.xray.sdk_version=1.0.2,
    [0].subsegments[0].aws.xray.sdk=opentelemetry for ruby,
    [0].subsegments[0].aws.region=us-west-2,
    [0].subsegments[0].aws.operation=ListBuckets,
    [0].subsegments[0].metadata.default[\"rpc.service\"]=S3,
    [0].subsegments[0].metadata.default[\"rpc.system\"]=aws-api,
    [0].http.request.url=http://app:8080/aws-sdk-call,
    [0].http.request.method=GET,
    [0].http.request.user_agent=okhttp/4.9.0,
    [0].http.response.status=200,
    [0].http.response.content_length=0,
    [0].aws.xray.auto_instrumentation=false,
    [0].aws.xray.sdk_version=1.0.2,
    [0].aws.xray.sdk=opentelemetry for ruby,
    [0].metadata.default[\"otel.resource.process.command\"]=bin/rails,
    [0].metadata.default[\"otel.resource.telemetry.sdk.name\"]=opentelemetry,
    [0].metadata.default[\"otel.resource.process.pid\"]=7,
    [0].metadata.default[\"otel.resource.process.runtime.description\"]=ruby 2.7.5p203 (2021-11-24 revision f69aeb8314) [x86_64-linux],
    [0].metadata.default[\"otel.resource.process.runtime.version\"]=2.7.5,
    [0].metadata.default[\"otel.resource.process.runtime.name\"]=ruby,
    [0].metadata.default[\"otel.resource.service.name\"]=aws-otel-manual-rails-sample,
    [0].metadata.default[\"otel.resource.telemetry.sdk.language\"]=ruby,
    [0].metadata.default[\"otel.resource.telemetry.sdk.version\"]=1.0.2,
    [1].name=S3,
    [1].id=18d5983800c4d704,
    [1].parent_id=feb9914f569361b6,
    [1].start_time=1642644356.887765,
    [1].origin=AWS::S3,
    [1].trace_id=1-61e8c384-fe837006488e7e62b8624d01,
    [1].end_time=1642644357.200523,
    [1].inferred=true,
    [1].aws.xray.auto_instrumentation=false,
    [1].aws.xray.sdk_version=1.0.2,
    [1].aws.xray.sdk=opentelemetry for ruby,
    [1].aws.region=us-west-2,
    [1].aws.operation=ListBuckets
}
```

~We should create an issue on OpenTelemetry Ruby to fix this.~ Created this issue: https://github.com/open-telemetry/opentelemetry-ruby/issues/1094

**Link to tracking Issue:** N/A

**Testing:** Passes locally, it will be tested in CI once we have the ADOT Ruby repo setup.

**Documentation:** 

No documentation needed for this right now, since the trace is almost there. However we should aim for parity soon.
