### PR TITLE
Add Env variable to docker-compose

### DIFF
--- a/terraform/templates/defaults/docker_compose.tpl
+++ b/terraform/templates/defaults/docker_compose.tpl
@@ -16,6 +16,7 @@ services:
       OTEL_RESOURCE_ATTRIBUTES: ${otel_resource_attributes}
       INSTANCE_ID: ${testing_id}
       OTEL_EXPORTER_OTLP_ENDPOINT: http://${grpc_endpoint}
+      OTEL_METRICS_EXPORTER: otlp
       AWS_XRAY_DAEMON_ADDRESS: ${udp_endpoint}
       COLLECTOR_UDP_ADDRESS: ${udp_endpoint}
       AWS_REGION: ${region}

--- a/terraform/templates/local/docker_compose.tpl
+++ b/terraform/templates/local/docker_compose.tpl
@@ -45,5 +45,6 @@ services:
       - COLLECTOR_UDP_ADDRESS=aws-ot-collector:${udp_port}
       - JAEGER_RECEIVER_ENDPOINT=aws-ot-collector:${http_port}
       - ZIPKIN_RECEIVER_ENDPOINT=aws-ot-collector:${http_port}
+      - OTEL_METRICS_EXPORTER=otlp
     depends_on:
       - aws-ot-collector


### PR DESCRIPTION
This PR will add the environment variable  `OTEL_METRICS_EXPORTER` that is required to get metrics while working with api.


