### PR TITLE
Add OTEL_METRICS_EXPORTER To ECS Environment

### DIFF
--- a/terraform/templates/defaults/ecs_taskdef.tpl
+++ b/terraform/templates/defaults/ecs_taskdef.tpl
@@ -48,6 +48,10 @@
         {
         "name": "ZIPKIN_RECEIVER_ENDPOINT",
         "value": "127.0.0.1:${http_port}"
+        },
+        {
+        "name": "OTEL_METRICS_EXPORTER",
+        "value": "otlp"
         }
       ],
       "dependsOn": [


### PR DESCRIPTION
**Description:** 
OTEL_METRICS_EXPORTER is required for spark app to produce metrics 