### PR TITLE
Add BUILDMODE copy to build args in docker compose for mock tests.

### DIFF
--- a/terraform/templates/local/docker_compose.tpl
+++ b/terraform/templates/local/docker_compose.tpl
@@ -12,6 +12,8 @@ services:
     build:
       context: ../../../aws-otel-collector
       dockerfile: cmd/awscollector/Dockerfile
+      args:
+        BUILDMODE: copy
 
     command: ["--config=/tmp/otconfig.yaml"]
     volumes:

--- a/terraform/templates/local/docker_compose_from_source.tpl
+++ b/terraform/templates/local/docker_compose_from_source.tpl
@@ -12,6 +12,8 @@ services:
     build:
       context: ../../../aws-otel-collector
       dockerfile: cmd/awscollector/Dockerfile
+      args:
+        BUILDMODE: copy
 
     command: ["--config=/tmp/otconfig.yaml"]
     volumes:


### PR DESCRIPTION
**Description:** Necessary for changes made to Dockerfile in PR https://github.com/aws-observability/aws-otel-collector/pull/956
Tells the docker compose to copy in the built binaries instead of rebuilding them.

**Testing**: Ran `otlp_mock`.
