### PR TITLE
Force eks/vpc module version

### DIFF
--- a/terraform/eks_adot_operator_cluster_setup/main.tf
+++ b/terraform/eks_adot_operator_cluster_setup/main.tf
@@ -31,7 +31,7 @@ provider "aws" {
 }
 
 module "vpc" {
-  source = "terraform-aws-modules/vpc/aws"
+  source  = "terraform-aws-modules/vpc/aws"
   version = "3.11.0"
 
   name = "${var.eks_cluster_name}-vpc"
@@ -47,7 +47,7 @@ module "vpc" {
 }
 
 module "eks" {
-  source = "terraform-aws-modules/eks/aws"
+  source  = "terraform-aws-modules/eks/aws"
   version = "17.24.0"
 
   cluster_version = "1.21"

--- a/terraform/eks_adot_operator_cluster_setup/main.tf
+++ b/terraform/eks_adot_operator_cluster_setup/main.tf
@@ -32,6 +32,7 @@ provider "aws" {
 
 module "vpc" {
   source = "terraform-aws-modules/vpc/aws"
+  version = "3.11.0"
 
   name = "${var.eks_cluster_name}-vpc"
   cidr = "10.0.0.0/16"
@@ -47,6 +48,7 @@ module "vpc" {
 
 module "eks" {
   source = "terraform-aws-modules/eks/aws"
+  version = "17.24.0"
 
   cluster_version = "1.21"
   cluster_name    = var.eks_cluster_name


### PR DESCRIPTION
**Description:** When trying to initially deploy the `adot_operator_cluster_setup` I was running into several issues relating to `unsupported arguments`. @sethAmazon  was able successfully destroy and deploy this terraform config on his machine. After some troubleshooting it turned out that @sethAmazon had a different version of the `eks` and `vpc` modules cached in his directory. When I attempted to deploy it pulled the latest versions which were not backwards compatible. Forcing these versions will alleviate this issue for any new users. 

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** deployed `eks_adot_operator_cluster_setup` successfully to test account. 

**Documentation:** n/a
