### PR TITLE
Update ECS  Expected metric template

### DIFF
--- a/validator/src/main/java/com/amazon/aoc/validators/CWMetricValidator.java
+++ b/validator/src/main/java/com/amazon/aoc/validators/CWMetricValidator.java
@@ -155,7 +155,7 @@ public class CWMetricValidator implements IValidator {
         throw new BaseException(
             ExceptionCode.EXPECTED_METRIC_NOT_FOUND,
             String.format(
-                "metric in toBeCheckedMetricList %s not found in baseMetricList: %s",
+                "metric in %ntoBeCheckedMetricList: %s is not found in %nbaseMetricList: %s %n",
                 metric, metricSet));
       }
     }

--- a/validator/src/main/resources/expected-data-template/ecsContainerExpectedMetric.mustache
+++ b/validator/src/main/resources/expected-data-template/ecsContainerExpectedMetric.mustache
@@ -6,6 +6,9 @@
       name: aws.ecs.cluster.name
       value: {{ecsContext.ecsClusterName}}
     -
+      name: aws.ecs.launchtype
+      value: {{ecsContext.ecsLaunchType}}
+    -
       name: aws.ecs.service.name
       value: undefined
     -
@@ -15,8 +18,11 @@
       name: aws.ecs.task.family
       value: {{ecsContext.ecsTaskDefFamily}}
     -
-      name: aws.ecs.task.version
+      name: aws.ecs.task.revision
       value: {{ecsContext.ecsTaskDefVersion}}
+    -
+      name: aws.ecs.task.version
+      value: SKIP
     -
       name: aws.ecs.task.id
       value: SKIP
@@ -31,6 +37,9 @@
       name: aws.ecs.cluster.name
       value: {{ecsContext.ecsClusterName}}
     -
+      name: aws.ecs.launchtype
+      value: {{ecsContext.ecsLaunchType}}
+    -
       name: aws.ecs.service.name
       value: undefined
     -
@@ -40,8 +49,11 @@
       name: aws.ecs.task.family
       value: {{ecsContext.ecsTaskDefFamily}}
     -
-      name: aws.ecs.task.version
+      name: aws.ecs.task.revision
       value: {{ecsContext.ecsTaskDefVersion}}
+    -
+      name: aws.ecs.task.version
+      value: SKIP
     -
       name: aws.ecs.task.id
       value: SKIP
@@ -56,6 +68,9 @@
       name: aws.ecs.cluster.name
       value: {{ecsContext.ecsClusterName}}
     -
+      name: aws.ecs.launchtype
+      value: {{ecsContext.ecsLaunchType}}
+    -
       name: aws.ecs.service.name
       value: undefined
     -
@@ -65,8 +80,11 @@
       name: aws.ecs.task.family
       value: {{ecsContext.ecsTaskDefFamily}}
     -
-      name: aws.ecs.task.version
+      name: aws.ecs.task.revision
       value: {{ecsContext.ecsTaskDefVersion}}
+    -
+      name: aws.ecs.task.version
+      value: SKIP
     -
       name: aws.ecs.task.id
       value: SKIP
@@ -81,6 +99,9 @@
       name: aws.ecs.cluster.name
       value: {{ecsContext.ecsClusterName}}
     -
+      name: aws.ecs.launchtype
+      value: {{ecsContext.ecsLaunchType}}
+    -
       name: aws.ecs.service.name
       value: undefined
     -
@@ -90,8 +111,11 @@
       name: aws.ecs.task.family
       value: {{ecsContext.ecsTaskDefFamily}}
     -
-      name: aws.ecs.task.version
+      name: aws.ecs.task.revision
       value: {{ecsContext.ecsTaskDefVersion}}
+    -
+      name: aws.ecs.task.version
+      value: SKIP
     -
       name: aws.ecs.task.id
       value: SKIP
@@ -106,6 +130,9 @@
       name: aws.ecs.cluster.name
       value: {{ecsContext.ecsClusterName}}
     -
+      name: aws.ecs.launchtype
+      value: {{ecsContext.ecsLaunchType}}
+    -
       name: aws.ecs.service.name
       value: undefined
     -
@@ -115,8 +142,11 @@
       name: aws.ecs.task.family
       value: {{ecsContext.ecsTaskDefFamily}}
     -
-      name: aws.ecs.task.version
+      name: aws.ecs.task.revision
       value: {{ecsContext.ecsTaskDefVersion}}
+    -
+      name: aws.ecs.task.version
+      value: SKIP
     -
       name: aws.ecs.task.id
       value: SKIP
@@ -131,6 +161,9 @@
       name: aws.ecs.cluster.name
       value: {{ecsContext.ecsClusterName}}
     -
+      name: aws.ecs.launchtype
+      value: {{ecsContext.ecsLaunchType}}
+    -
       name: aws.ecs.service.name
       value: undefined
     -
@@ -140,8 +173,11 @@
       name: aws.ecs.task.family
       value: {{ecsContext.ecsTaskDefFamily}}
     -
-      name: aws.ecs.task.version
+      name: aws.ecs.task.revision
       value: {{ecsContext.ecsTaskDefVersion}}
+    -
+      name: aws.ecs.task.version
+      value: SKIP
     -
       name: aws.ecs.task.id
       value: SKIP
@@ -156,6 +192,9 @@
       name: aws.ecs.cluster.name
       value: {{ecsContext.ecsClusterName}}
     -
+      name: aws.ecs.launchtype
+      value: {{ecsContext.ecsLaunchType}}
+    -
       name: aws.ecs.service.name
       value: undefined
     -
@@ -165,8 +204,11 @@
       name: aws.ecs.task.family
       value: {{ecsContext.ecsTaskDefFamily}}
     -
-      name: aws.ecs.task.version
+      name: aws.ecs.task.revision
       value: {{ecsContext.ecsTaskDefVersion}}
+    -
+      name: aws.ecs.task.version
+      value: SKIP
     -
       name: aws.ecs.task.id
       value: SKIP
@@ -181,6 +223,9 @@
       name: aws.ecs.cluster.name
       value: {{ecsContext.ecsClusterName}}
     -
+      name: aws.ecs.launchtype
+      value: {{ecsContext.ecsLaunchType}}
+    -
       name: aws.ecs.service.name
       value: undefined
     -
@@ -190,8 +235,11 @@
       name: aws.ecs.task.family
       value: {{ecsContext.ecsTaskDefFamily}}
     -
-      name: aws.ecs.task.version
+      name: aws.ecs.task.revision
       value: {{ecsContext.ecsTaskDefVersion}}
+    -
+      name: aws.ecs.task.version
+      value: SKIP
     -
       name: aws.ecs.task.id
       value: SKIP


### PR DESCRIPTION
**Description:**
This PR updates the expected data template for ECS Metrics, referring [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/7425/files) and fixes the CI tests for ECS Metrics

The old attribute name `aws.ecs.task.version` is changed to `SKIP` as per [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/7425/files#r795845981)

