### PR TITLE
Specify operator helm chart version

### DIFF
--- a/terraform/eks/adot-operator/adot_operator.tf
+++ b/terraform/eks/adot-operator/adot_operator.tf
@@ -25,7 +25,9 @@ variable "kubeconfig" {
 
 resource "helm_release" "adot-operator" {
   name = "adot-operator-${var.testing_id}"
-
+  // currently adot operator is at 0.41.0
+  // helm charts >-0.5.4 require 0.43.0
+  version = "0.5.3"
   repository = "https://open-telemetry.github.io/opentelemetry-helm-charts"
   chart      = "opentelemetry-operator"
 

--- a/terraform/eks/adot-operator/adot_operator.tf
+++ b/terraform/eks/adot-operator/adot_operator.tf
@@ -27,7 +27,7 @@ resource "helm_release" "adot-operator" {
   name = "adot-operator-${var.testing_id}"
   // currently adot operator is at 0.41.0
   // helm charts >-0.5.4 require 0.43.0
-  version = "0.5.3"
+  version    = "0.5.3"
   repository = "https://open-telemetry.github.io/opentelemetry-helm-charts"
   chart      = "opentelemetry-operator"
 


### PR DESCRIPTION
**Description:** The current ADOT operator is at version `0.41.0`. Currently the latest helm chart is at `v0.6.3` which may be introducing breaking changes with the current operator version. This PR forces the helm chart version to the last known compatible version. 

**Link to tracking Issue:** n/a

**Testing:** n/a

