### PR TITLE
Remove ADOT Operator namespace check during helm deployment

### DIFF
--- a/terraform/eks/adot-operator/adot_operator.tf
+++ b/terraform/eks/adot-operator/adot_operator.tf
@@ -25,7 +25,9 @@ variable "kubeconfig" {
 
 resource "helm_release" "adot-operator" {
   name = "adot-operator-${var.testing_id}"
-
+  // currently adot operator is at 0.41.0
+  // helm charts >-0.5.4 require 0.43.0
+  version = "0.5.3"
   repository = "https://open-telemetry.github.io/opentelemetry-helm-charts"
   chart      = "opentelemetry-operator"
 

--- a/terraform/eks/adot-operator/adot_operator.tf
+++ b/terraform/eks/adot-operator/adot_operator.tf
@@ -25,8 +25,7 @@ variable "kubeconfig" {
 
 resource "helm_release" "adot-operator" {
   name = "adot-operator-${var.testing_id}"
-  // currently adot operator is at 0.41.0
-  // helm charts >-0.5.4 require 0.43.0
+
   repository = "https://open-telemetry.github.io/opentelemetry-helm-charts"
   chart      = "opentelemetry-operator"
 

--- a/terraform/eks/adot-operator/adot_operator.tf
+++ b/terraform/eks/adot-operator/adot_operator.tf
@@ -27,7 +27,6 @@ resource "helm_release" "adot-operator" {
   name = "adot-operator-${var.testing_id}"
   // currently adot operator is at 0.41.0
   // helm charts >-0.5.4 require 0.43.0
-  version    = "0.5.3"
   repository = "https://open-telemetry.github.io/opentelemetry-helm-charts"
   chart      = "opentelemetry-operator"
 

--- a/terraform/eks/adot-operator/adot_operator.tf
+++ b/terraform/eks/adot-operator/adot_operator.tf
@@ -36,6 +36,6 @@ resource "helm_release" "adot-operator" {
   ]
 
   provisioner "local-exec" {
-    command = "kubectl wait --kubeconfig=${var.kubeconfig} --timeout=5m --for=condition=available deployment opentelemetry-operator-controller-manager -n opentelemetry-operator-system"
+    command = "kubectl wait --kubeconfig=${var.kubeconfig} --timeout=5m --for=condition=available deployment opentelemetry-operator-controller-manager"
   }
 }

--- a/terraform/eks/adot-operator/adot_operator.tf
+++ b/terraform/eks/adot-operator/adot_operator.tf
@@ -27,7 +27,7 @@ resource "helm_release" "adot-operator" {
   name = "adot-operator-${var.testing_id}"
   // currently adot operator is at 0.41.0
   // helm charts >-0.5.4 require 0.43.0
-  version = "0.5.3"
+  version    = "0.5.3"
   repository = "https://open-telemetry.github.io/opentelemetry-helm-charts"
   chart      = "opentelemetry-operator"
 


### PR DESCRIPTION
**Description:** The ADOT Operator was failing to deploy during the CI tests due to this error 

```Error running command 'kubectl wait --kubeconfig=kubeconfig --timeout=5m
--for=condition=available deployment
opentelemetry-operator-controller-manager -n
opentelemetry-operator-system': exit status 1. Output: Error from server (NotFound): namespaces "opentelemetry-operator-system" not found 
``` 

After some testing it was discovered that helm chart `v0.6.0` no longer created the `opentelemetry-operator-system` namespace automatically. See [this](https://github.com/open-telemetry/opentelemetry-helm-charts/compare/opentelemetry-operator-0.5.4...opentelemetry-operator-0.6.0) comparison between `0.5.4`and `0.6.0` in the helm chart releases. 

To solve this issue the namespace requirement was removed from the `kubectl wait` command in the operator helm release deployment. 


**Link to tracking Issue:** n/a

**Testing:** I tested these changes locally and my commands can be seen below. I deployed the `adot-operator-cluster-setup` to a personal account then installed the helm chart manually.

```
bryaag@147ddac12c15 eks % helm install operator open-telemetry/opentelemetry-operator \
--set manager.image.repository="public.ecr.aws/aws-observability/adot-operator" \
--set manager.image.tag="latest" \
--set kubeRBACProxy.image.repository="public.ecr.aws/aws-observability/mirror-kube-rbac-proxy" \
--set kubeRBACProxy.image.tag="v0.8.0" \
--version="0.5.4"
NAME: operator
LAST DEPLOYED: Fri Feb 18 09:33:34 2022
NAMESPACE: default
STATUS: deployed
REVISION: 1
bryaag@147ddac12c15 eks % kubectl get ns
NAME                            STATUS   AGE
cert-manager                    Active   21m
default                         Active   29m
kube-node-lease                 Active   29m
kube-public                     Active   29m
kube-system                     Active   29m
opentelemetry-operator-system   Active   6s
bryaag@147ddac12c15 eks % helm uninstall operator                                      
release "operator" uninstalled
bryaag@147ddac12c15 eks % helm install operator open-telemetry/opentelemetry-operator \
--set manager.image.repository="public.ecr.aws/aws-observability/adot-operator" \
--set manager.image.tag="latest" \
--set kubeRBACProxy.image.repository="public.ecr.aws/aws-observability/mirror-kube-rbac-proxy" \
--set kubeRBACProxy.image.tag="v0.8.0" \
--version="0.6.0"
NAME: operator
LAST DEPLOYED: Fri Feb 18 09:34:14 2022
NAMESPACE: default
STATUS: deployed
REVISION: 1
bryaag@147ddac12c15 eks % kubectl get ns
NAME              STATUS   AGE
cert-manager      Active   21m
default           Active   29m
kube-node-lease   Active   29m
kube-public       Active   29m
kube-system       Active   29m
bryaag@147ddac12c15 eks % kubectl wait --timeout=5m --for=condition=available deployment opentelemetry-operator-controller-manager 
deployment.apps/opentelemetry-operator-controller-manager condition met
bryaag@147ddac12c15 aws-otel-test-framework % kubectl wait --timeout=5m --for=condition=available deployment opentelemetry-operator-controller-manager -n opentelemetry-operator-system 
Error from server (NotFound): namespaces "opentelemetry-operator-system" not found
```
The kubectl wait comand is successful if the namespace requirement is removed but will fail if it is present with a helm chart >= v0.6.0
**Documentation:** N/A
