### PR TITLE
Set exporter compression to none

### DIFF
--- a/terraform/testcases/otlp_grpc_exporter_metric_mock/otconfig.tpl
+++ b/terraform/testcases/otlp_grpc_exporter_metric_mock/otconfig.tpl
@@ -17,6 +17,7 @@ exporters:
     endpoint: ${mock_endpoint}
     tls:
       insecure: true
+    compression: none
 
 service:
   pipelines:

--- a/terraform/testcases/otlp_grpc_exporter_trace_mock/otconfig.tpl
+++ b/terraform/testcases/otlp_grpc_exporter_trace_mock/otconfig.tpl
@@ -17,6 +17,7 @@ exporters:
     endpoint: ${mock_endpoint}
     tls:
       insecure: true
+    compression: none
 
 service:
   pipelines:


### PR DESCRIPTION
**Description:** Currently the `PR-Build` workflow is failing in the `aws-otel-collector` repository. `otlp_grpc_exporter` metric and trace tests are failing. I was able to reproduce this issue on my local machine and identified the root cause due to the enabling of compression by default in `v0.45.0` of the collector. See this [PR](https://github.com/open-telemetry/opentelemetry-collector/pull/4632) for the upstream change. Disabling compression allowed the test cases to pass. 

**Link to tracking Issue:** n/a

**Testing:** Followed [these](https://github.com/aws-observability/aws-otel-test-framework/blob/terraform/docs/run-mock-test.md) steps in current repo. Was able to replicate fault reliably. 

**Documentation:** n/a
