### PR TITLE
Revert "Bump opentelemetry-bom from 1.4.1 to 1.12.0 in /load-generator"

### DIFF
--- a/load-generator/build.gradle
+++ b/load-generator/build.gradle
@@ -30,7 +30,7 @@ dependencies {
 
     implementation "io.grpc:grpc-netty-shaded:1.44.1"
 
-    implementation platform("io.opentelemetry:opentelemetry-bom:1.12.0")
+    implementation platform("io.opentelemetry:opentelemetry-bom:1.4.1")
     implementation "io.opentelemetry:opentelemetry-api"
     implementation "io.opentelemetry:opentelemetry-sdk-metrics:1.4.1-alpha"
     implementation "io.opentelemetry:opentelemetry-exporter-otlp:1.10.0"


### PR DESCRIPTION
Reverts aws-observability/aws-otel-test-framework#576