### PR TITLE
Revert "Bump picocli-codegen from 4.6.2 to 4.6.3 in /load-generator"

### DIFF
--- a/load-generator/build.gradle
+++ b/load-generator/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 
     // Command cli
     implementation 'info.picocli:picocli:4.6.3'
-    compileOnly 'info.picocli:picocli-codegen:4.6.3'
+    compileOnly 'info.picocli:picocli-codegen:4.6.2'
 
     // log
     implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.17.2'


### PR DESCRIPTION
Reverts aws-observability/aws-otel-test-framework#567