### PR TITLE
Saving terraform state file to a s3 bucket

### DIFF
--- a/terraform/eks_adot_operator_cluster_setup/main.tf
+++ b/terraform/eks_adot_operator_cluster_setup/main.tf
@@ -20,11 +20,10 @@ terraform {
       version = ">= 1.7.0"
     }
   }
-
   ## comment out the backend block if you want the terraform state file to be locally saved on the computer (or) change the name of the s3 bucket if you are testing out on your personal AWS account
-  backend "s3"{
+  backend "s3" {
     bucket = "adot-op-cluster-terraform-statefile"
-    key = "global/s3/terraform.tfstate"
+    key    = "global/s3/terraform.tfstate"
     region = "us-west-2"
   }
 }

--- a/terraform/eks_adot_operator_cluster_setup/main.tf
+++ b/terraform/eks_adot_operator_cluster_setup/main.tf
@@ -23,7 +23,7 @@ terraform {
 
   ## comment out the backend block if you want the terraform state file to be locally saved on the computer (or) change the name of the s3 bucket if you are testing out on your personal AWS account
   backend "s3"{
-    bucket = "adot-cluster-terraform-statefile"
+    bucket = "adot-op-cluster-terraform-statefile"
     key = "global/s3/terraform.tfstate"
     region = "us-west-2"
   }

--- a/terraform/eks_adot_operator_cluster_setup/main.tf
+++ b/terraform/eks_adot_operator_cluster_setup/main.tf
@@ -14,13 +14,13 @@
 # -------------------------------------------------------------------------
 
 terraform {
+  required_version = "=1.1.6"
   required_providers {
     kubectl = {
       source  = "gavinbunney/kubectl"
       version = ">= 1.7.0"
     }
   }
-  ## comment out the backend block if you want the terraform state file to be locally saved on the computer (or) change the name of the s3 bucket if you are testing out on your personal AWS account
   backend "s3" {
     bucket = "adot-op-cluster-terraform-statefile"
     key    = "global/s3/terraform.tfstate"

--- a/terraform/eks_adot_operator_cluster_setup/main.tf
+++ b/terraform/eks_adot_operator_cluster_setup/main.tf
@@ -20,6 +20,13 @@ terraform {
       version = ">= 1.7.0"
     }
   }
+
+  ## comment out the backend block if you want the terraform state file to be locally saved on the computer (or) change the name of the s3 bucket if you are testing out on your personal AWS account
+  backend "s3"{
+    bucket = "adot-cluster-terraform-statefile"
+    key = "global/s3/terraform.tfstate"
+    region = "us-west-2"
+  }
 }
 
 module "common" {


### PR DESCRIPTION
**Description:** 
This Saves the terraform state file to a s3 bucket rather than local machine


**Testing:** Attached in the document

**Documentation:** 
