### PR TITLE
Changed usage of `awsprometheusremotewriteexporter` to `prometheusremotewriteexporter` and `sigv4authextension`

### DIFF
--- a/terraform/testcases/otlp_grpc_exporter_cw_amp_xray_ecs/otconfig.tpl
+++ b/terraform/testcases/otlp_grpc_exporter_cw_amp_xray_ecs/otconfig.tpl
@@ -1,6 +1,10 @@
 extensions:
   pprof:
     endpoint: 0.0.0.0:1777
+  sigv4auth:
+    region: ${region}
+    service: "aps"
+
 receivers:
   awsecscontainermetrics:
   otlp:
@@ -108,13 +112,10 @@ exporters:
     region: '${region}'
     resource_to_telemetry_conversion:
       enabled: true
-  awsprometheusremotewrite:
+  prometheusremotewrite:
     endpoint: ${cortex_instance_endpoint}/api/v1/remote_write
     resource_to_telemetry_conversion:
       enabled: true
-    aws_auth:
-      region: ${region}
-      service: "aps"
   awsxray:
     local_mode: true
     region: '${region}'
@@ -130,7 +131,7 @@ service:
     metrics/container/amp:
       receivers: [ awsecscontainermetrics ]
       processors: [ filter, metricstransform, resource, batch ]
-      exporters: [ awsprometheusremotewrite,logging ]
+      exporters: [ prometheusremotewrite,logging ]
     metrics/application/cw:
       receivers: [ otlp ]
       processors: [ resourcedetection, batch ]
@@ -138,12 +139,12 @@ service:
     metrics/application/amp:
       receivers: [ otlp ]
       processors: [ resourcedetection, batch ]
-      exporters: [ awsprometheusremotewrite,logging]
+      exporters: [ prometheusremotewrite,logging]
     traces/application/xray:
       receivers: [ otlp ]
       processors: [ resourcedetection, batch ]
       exporters: [ awsxray ]
-  extensions: [pprof]
+  extensions: [pprof, sigv4auth]
   telemetry:
     logs:
       level: debug

--- a/terraform/testcases/otlp_grpc_exporter_cw_amp_xray_ecs/otconfig.tpl
+++ b/terraform/testcases/otlp_grpc_exporter_cw_amp_xray_ecs/otconfig.tpl
@@ -123,6 +123,8 @@ exporters:
     endpoint: ${cortex_instance_endpoint}/api/v1/remote_write
     resource_to_telemetry_conversion:
       enabled: true
+    auth:
+      authenticator: sigv4auth
   awsxray:
     local_mode: true
     region: '${region}'

--- a/terraform/testcases/otlp_grpc_exporter_cw_amp_xray_ecs/otconfig.tpl
+++ b/terraform/testcases/otlp_grpc_exporter_cw_amp_xray_ecs/otconfig.tpl
@@ -112,6 +112,13 @@ exporters:
     region: '${region}'
     resource_to_telemetry_conversion:
       enabled: true
+  awsprometheusremotewrite:
+    endpoint: ${cortex_instance_endpoint}/api/v1/remote_write
+    resource_to_telemetry_conversion:
+      enabled: true
+    aws_auth:
+      region: ${region}
+      service: "aps"
   prometheusremotewrite:
     endpoint: ${cortex_instance_endpoint}/api/v1/remote_write
     resource_to_telemetry_conversion:
@@ -131,7 +138,7 @@ service:
     metrics/container/amp:
       receivers: [ awsecscontainermetrics ]
       processors: [ filter, metricstransform, resource, batch ]
-      exporters: [ prometheusremotewrite,logging ]
+      exporters: [ awsprometheusremotewrite,prometheusremotewrite,logging ]
     metrics/application/cw:
       receivers: [ otlp ]
       processors: [ resourcedetection, batch ]
@@ -139,7 +146,7 @@ service:
     metrics/application/amp:
       receivers: [ otlp ]
       processors: [ resourcedetection, batch ]
-      exporters: [ prometheusremotewrite,logging]
+      exporters: [ awsprometheusremotewrite,prometheusremotewrite,logging]
     traces/application/xray:
       receivers: [ otlp ]
       processors: [ resourcedetection, batch ]

--- a/terraform/testcases/otlp_grpc_exporter_cw_amp_xray_ecs_awsprw/otconfig.tpl
+++ b/terraform/testcases/otlp_grpc_exporter_cw_amp_xray_ecs_awsprw/otconfig.tpl
@@ -1,10 +1,6 @@
 extensions:
   pprof:
     endpoint: 0.0.0.0:1777
-  sigv4auth:
-    region: ${region}
-    service: "aps"
-
 receivers:
   awsecscontainermetrics:
   otlp:
@@ -112,12 +108,13 @@ exporters:
     region: '${region}'
     resource_to_telemetry_conversion:
       enabled: true
-  prometheusremotewrite:
+  awsprometheusremotewrite:
     endpoint: ${cortex_instance_endpoint}/api/v1/remote_write
     resource_to_telemetry_conversion:
       enabled: true
-    auth:
-      authenticator: sigv4auth
+    aws_auth:
+      region: ${region}
+      service: "aps"
   awsxray:
     local_mode: true
     region: '${region}'
@@ -133,7 +130,7 @@ service:
     metrics/container/amp:
       receivers: [ awsecscontainermetrics ]
       processors: [ filter, metricstransform, resource, batch ]
-      exporters: [ prometheusremotewrite, logging ]
+      exporters: [ awsprometheusremotewrite,logging ]
     metrics/application/cw:
       receivers: [ otlp ]
       processors: [ resourcedetection, batch ]
@@ -141,12 +138,12 @@ service:
     metrics/application/amp:
       receivers: [ otlp ]
       processors: [ resourcedetection, batch ]
-      exporters: [ prometheusremotewrite, logging ]
+      exporters: [ awsprometheusremotewrite,logging]
     traces/application/xray:
       receivers: [ otlp ]
       processors: [ resourcedetection, batch ]
       exporters: [ awsxray ]
-  extensions: [pprof, sigv4auth]
+  extensions: [pprof]
   telemetry:
     logs:
       level: debug

--- a/terraform/testcases/otlp_grpc_exporter_cw_amp_xray_ecs_awsprw/parameters.tfvars
+++ b/terraform/testcases/otlp_grpc_exporter_cw_amp_xray_ecs_awsprw/parameters.tfvars
@@ -1,0 +1,8 @@
+validation_config = "ecs-container-cw-amp-xray-validation.yml"
+
+# data type will be emitted. Possible values: metric or trace
+soaking_data_mode = "trace"
+
+sample_app = "spark"
+
+

--- a/terraform/testcases/otlp_metric_amp/otconfig.tpl
+++ b/terraform/testcases/otlp_metric_amp/otconfig.tpl
@@ -1,6 +1,9 @@
 extensions:
   pprof:
     endpoint: 0.0.0.0:1777
+  sigv4auth:
+    region: ${region}
+    service: "aps"
 receivers:
   otlp:
     protocols:
@@ -13,11 +16,8 @@ processors:
 exporters:
   logging:
     loglevel: debug
-  awsprometheusremotewrite:
+  prometheusremotewrite:
     endpoint: ${cortex_instance_endpoint}/api/v1/remote_write
-    aws_auth:
-      region: ${region}
-      service: "aps"
     timeout: 10s
 
 service:
@@ -25,8 +25,8 @@ service:
     metrics:
       receivers: [otlp]
       processors: [batch]
-      exporters: [awsprometheusremotewrite,logging]
-  extensions: [pprof]
+      exporters: [prometheusremotewrite,logging]
+  extensions: [pprof, sigv4auth]
   telemetry:
     logs:
       level: debug

--- a/terraform/testcases/otlp_metric_amp/otconfig.tpl
+++ b/terraform/testcases/otlp_metric_amp/otconfig.tpl
@@ -16,6 +16,12 @@ processors:
 exporters:
   logging:
     loglevel: debug
+  awsprometheusremotewrite:
+    endpoint: ${cortex_instance_endpoint}/api/v1/remote_write
+    aws_auth:
+      region: ${region}
+      service: "aps"
+    timeout: 10s
   prometheusremotewrite:
     endpoint: ${cortex_instance_endpoint}/api/v1/remote_write
     timeout: 10s
@@ -25,7 +31,7 @@ service:
     metrics:
       receivers: [otlp]
       processors: [batch]
-      exporters: [prometheusremotewrite,logging]
+      exporters: [awsprometheusremotewrite,prometheusremotewrite,logging]
   extensions: [pprof, sigv4auth]
   telemetry:
     logs:

--- a/terraform/testcases/otlp_metric_amp/otconfig.tpl
+++ b/terraform/testcases/otlp_metric_amp/otconfig.tpl
@@ -25,6 +25,8 @@ exporters:
   prometheusremotewrite:
     endpoint: ${cortex_instance_endpoint}/api/v1/remote_write
     timeout: 10s
+    auth:
+      authenticator: sigv4auth
 
 service:
   pipelines:

--- a/terraform/testcases/otlp_metric_amp_awsprw/otconfig.tpl
+++ b/terraform/testcases/otlp_metric_amp_awsprw/otconfig.tpl
@@ -1,9 +1,6 @@
 extensions:
   pprof:
     endpoint: 0.0.0.0:1777
-  sigv4auth:
-    region: ${region}
-    service: "aps"
 receivers:
   otlp:
     protocols:
@@ -16,19 +13,20 @@ processors:
 exporters:
   logging:
     loglevel: debug
-  prometheusremotewrite:
+  awsprometheusremotewrite:
     endpoint: ${cortex_instance_endpoint}/api/v1/remote_write
+    aws_auth:
+      region: ${region}
+      service: "aps"
     timeout: 10s
-    auth:
-      authenticator: sigv4auth
 
 service:
   pipelines:
     metrics:
       receivers: [otlp]
       processors: [batch]
-      exporters: [prometheusremotewrite,logging]
-  extensions: [pprof, sigv4auth]
+      exporters: [awsprometheusremotewrite,logging]
+  extensions: [pprof]
   telemetry:
     logs:
       level: debug

--- a/terraform/testcases/otlp_metric_amp_awsprw/parameters.tfvars
+++ b/terraform/testcases/otlp_metric_amp_awsprw/parameters.tfvars
@@ -1,0 +1,7 @@
+# this file is defined in validator/src/main/resources/validations
+validation_config = "otlp-prometheus-validation.yml"
+
+# data type will be emitted. Possible values: metric or trace
+soaking_data_mode = "metric"
+
+sample_app = "spark"

--- a/terraform/testcases/prometheus_mock/otconfig.tpl
+++ b/terraform/testcases/prometheus_mock/otconfig.tpl
@@ -11,13 +11,17 @@ receivers:
         static_configs:
         - targets: [ ${sample_app_listen_address_host}:${sample_app_listen_address_port} ]
 exporters:
+  awsprometheusremotewrite:
+    endpoint: "https://${mock_endpoint}"
+    aws_auth:
+      region: "us-west-2"
   prometheusremotewrite:
     endpoint: "https://${mock_endpoint}"
 service:
   pipelines:
     metrics:
      receivers: [prometheus]
-     exporters: [prometheusremotewrite]
+     exporters: [awsprometheusremotewrite,prometheusremotewrite]
   extensions: [sigv4auth]
   telemetry:
     logs:

--- a/terraform/testcases/prometheus_mock/otconfig.tpl
+++ b/terraform/testcases/prometheus_mock/otconfig.tpl
@@ -17,6 +17,8 @@ exporters:
       region: "us-west-2"
   prometheusremotewrite:
     endpoint: "https://${mock_endpoint}"
+    auth:
+      authenticator: sigv4auth
 service:
   pipelines:
     metrics:

--- a/terraform/testcases/prometheus_mock/otconfig.tpl
+++ b/terraform/testcases/prometheus_mock/otconfig.tpl
@@ -1,3 +1,6 @@
+extensions:
+  sigv4auth:
+    region: "us-west-2"
 receivers:
   prometheus:
     config:
@@ -8,15 +11,14 @@ receivers:
         static_configs:
         - targets: [ ${sample_app_listen_address_host}:${sample_app_listen_address_port} ]
 exporters:
-  awsprometheusremotewrite:
+  prometheusremotewrite:
     endpoint: "https://${mock_endpoint}"
-    aws_auth:
-      region: "us-west-2"
 service:
   pipelines:
     metrics:
      receivers: [prometheus]
-     exporters: [awsprometheusremotewrite]
+     exporters: [prometheusremotewrite]
+  extensions: [sigv4auth]
   telemetry:
     logs:
       level: debug

--- a/terraform/testcases/prometheus_mock_awsprw/otconfig.tpl
+++ b/terraform/testcases/prometheus_mock_awsprw/otconfig.tpl
@@ -1,6 +1,3 @@
-extensions:
-  sigv4auth:
-    region: "us-west-2"
 receivers:
   prometheus:
     config:
@@ -11,16 +8,15 @@ receivers:
         static_configs:
         - targets: [ ${sample_app_listen_address_host}:${sample_app_listen_address_port} ]
 exporters:
-  prometheusremotewrite:
+  awsprometheusremotewrite:
     endpoint: "https://${mock_endpoint}"
-    auth:
-      authenticator: sigv4auth
+    aws_auth:
+      region: "us-west-2"
 service:
   pipelines:
     metrics:
      receivers: [prometheus]
-     exporters: [prometheusremotewrite]
-  extensions: [sigv4auth]
+     exporters: [awsprometheusremotewrite]
   telemetry:
     logs:
       level: debug

--- a/terraform/testcases/prometheus_mock_awsprw/parameters.tfvars
+++ b/terraform/testcases/prometheus_mock_awsprw/parameters.tfvars
@@ -1,0 +1,12 @@
+# this file is defined in validator/src/main/resources/validations
+validation_config = "default-mocked-server-prometheus-validation.yml"
+
+sample_app = "prometheus"
+
+soaking_sample_app = "prometheus"
+
+soaking_data_type = "prometheus"
+
+sample_app_mode = "pull"
+
+ecs_taskdef_directory = "prometheus"

--- a/terraform/testcases/prometheus_sd/otconfig.tpl
+++ b/terraform/testcases/prometheus_sd/otconfig.tpl
@@ -1,3 +1,7 @@
+extensions:
+  sigv4auth:
+    region: ${region}
+    service: "aps"
 receivers:
   prometheus:
     config:
@@ -13,11 +17,8 @@ receivers:
           action: keep
           regex: "sample-app"
 exporters:
-  awsprometheusremotewrite:
+  prometheusremotewrite:
     endpoint: ${cortex_instance_endpoint}/api/v1/remote_write
-    aws_auth:
-      region: ${region}
-      service: "aps"
     timeout: 10s
   logging:
     loglevel: debug
@@ -25,7 +26,8 @@ service:
   pipelines:
     metrics:
      receivers: [prometheus]
-     exporters: [awsprometheusremotewrite, logging]
+     exporters: [prometheusremotewrite, logging]
+  extensions: [sigv4auth]
   telemetry:
     logs:
       level: debug

--- a/terraform/testcases/prometheus_sd/otconfig.tpl
+++ b/terraform/testcases/prometheus_sd/otconfig.tpl
@@ -17,6 +17,12 @@ receivers:
           action: keep
           regex: "sample-app"
 exporters:
+  awsprometheusremotewrite:
+    endpoint: ${cortex_instance_endpoint}/api/v1/remote_write
+    aws_auth:
+      region: ${region}
+      service: "aps"
+    timeout: 10s
   prometheusremotewrite:
     endpoint: ${cortex_instance_endpoint}/api/v1/remote_write
     timeout: 10s
@@ -26,7 +32,7 @@ service:
   pipelines:
     metrics:
      receivers: [prometheus]
-     exporters: [prometheusremotewrite, logging]
+     exporters: [awsprometheusremotewrite, prometheusremotewrite, logging]
   extensions: [sigv4auth]
   telemetry:
     logs:

--- a/terraform/testcases/prometheus_sd/otconfig.tpl
+++ b/terraform/testcases/prometheus_sd/otconfig.tpl
@@ -26,6 +26,8 @@ exporters:
   prometheusremotewrite:
     endpoint: ${cortex_instance_endpoint}/api/v1/remote_write
     timeout: 10s
+    auth:
+      authenticator: sigv4auth
   logging:
     loglevel: debug
 service:

--- a/terraform/testcases/prometheus_sd_adot_operator/otconfig.tpl
+++ b/terraform/testcases/prometheus_sd_adot_operator/otconfig.tpl
@@ -1,3 +1,7 @@
+extensions:
+  sigv4auth:
+    region: ${region}
+    service: "aps"
 receivers:
       prometheus:
         config:
@@ -13,11 +17,8 @@ receivers:
               action: keep
               regex: "sample-app"
     exporters:
-      awsprometheusremotewrite:
+      prometheusremotewrite:
         endpoint: ${cortex_instance_endpoint}/api/v1/remote_write
-        aws_auth:
-          region: ${region}
-          service: "aps"
         timeout: 10s
       logging:
         loglevel: debug
@@ -25,7 +26,8 @@ receivers:
       pipelines:
         metrics:
           receivers: [prometheus]
-          exporters: [awsprometheusremotewrite, logging]
+          exporters: [prometheusremotewrite, logging]
+      extensions: [sigv4auth]
       telemetry:
         logs:
           level: debug

--- a/terraform/testcases/prometheus_sd_adot_operator/otconfig.tpl
+++ b/terraform/testcases/prometheus_sd_adot_operator/otconfig.tpl
@@ -17,6 +17,12 @@ receivers:
               action: keep
               regex: "sample-app"
     exporters:
+      awsprometheusremotewrite:
+        endpoint: ${cortex_instance_endpoint}/api/v1/remote_write
+        aws_auth:
+          region: ${region}
+          service: "aps"
+        timeout: 10s
       prometheusremotewrite:
         endpoint: ${cortex_instance_endpoint}/api/v1/remote_write
         timeout: 10s
@@ -26,7 +32,7 @@ receivers:
       pipelines:
         metrics:
           receivers: [prometheus]
-          exporters: [prometheusremotewrite, logging]
+          exporters: [awsprometheusremotewrite, prometheusremotewrite, logging]
       extensions: [sigv4auth]
       telemetry:
         logs:

--- a/terraform/testcases/prometheus_sd_adot_operator/otconfig.tpl
+++ b/terraform/testcases/prometheus_sd_adot_operator/otconfig.tpl
@@ -26,6 +26,8 @@ receivers:
       prometheusremotewrite:
         endpoint: ${cortex_instance_endpoint}/api/v1/remote_write
         timeout: 10s
+        auth:
+          authenticator: sigv4auth
       logging:
         loglevel: debug
     service:

--- a/terraform/testcases/prometheus_sd_adot_operator_awsprw/otconfig.tpl
+++ b/terraform/testcases/prometheus_sd_adot_operator_awsprw/otconfig.tpl
@@ -1,7 +1,3 @@
-extensions:
-  sigv4auth:
-    region: ${region}
-    service: "aps"
 receivers:
       prometheus:
         config:
@@ -17,19 +13,19 @@ receivers:
               action: keep
               regex: "sample-app"
     exporters:
-      prometheusremotewrite:
+      awsprometheusremotewrite:
         endpoint: ${cortex_instance_endpoint}/api/v1/remote_write
+        aws_auth:
+          region: ${region}
+          service: "aps"
         timeout: 10s
-        auth:
-          authenticator: sigv4auth
       logging:
         loglevel: debug
     service:
       pipelines:
         metrics:
           receivers: [prometheus]
-          exporters: [prometheusremotewrite, logging]
-      extensions: [sigv4auth]
+          exporters: [awsprometheusremotewrite, logging]
       telemetry:
         logs:
           level: debug

--- a/terraform/testcases/prometheus_sd_adot_operator_awsprw/parameters.tfvars
+++ b/terraform/testcases/prometheus_sd_adot_operator_awsprw/parameters.tfvars
@@ -1,0 +1,8 @@
+# this file is defined in validator/src/main/resources/validations
+validation_config = "prometheus-sd-validation.yml"
+
+sample_app = "prometheus"
+
+sample_app_mode = "pull"
+
+eks_cluster_name = "adot-op-cluster"

--- a/terraform/testcases/prometheus_sd_awsprw/otconfig.tpl
+++ b/terraform/testcases/prometheus_sd_awsprw/otconfig.tpl
@@ -1,7 +1,3 @@
-extensions:
-  sigv4auth:
-    region: ${region}
-    service: "aps"
 receivers:
   prometheus:
     config:
@@ -17,19 +13,19 @@ receivers:
           action: keep
           regex: "sample-app"
 exporters:
-  prometheusremotewrite:
+  awsprometheusremotewrite:
     endpoint: ${cortex_instance_endpoint}/api/v1/remote_write
+    aws_auth:
+      region: ${region}
+      service: "aps"
     timeout: 10s
-    auth:
-      authenticator: sigv4auth
   logging:
     loglevel: debug
 service:
   pipelines:
     metrics:
      receivers: [prometheus]
-     exporters: [prometheusremotewrite, logging]
-  extensions: [sigv4auth]
+     exporters: [awsprometheusremotewrite, logging]
   telemetry:
     logs:
       level: debug

--- a/terraform/testcases/prometheus_sd_awsprw/parameters.tfvars
+++ b/terraform/testcases/prometheus_sd_awsprw/parameters.tfvars
@@ -1,0 +1,6 @@
+# this file is defined in validator/src/main/resources/validations
+validation_config = "prometheus-sd-validation.yml"
+
+sample_app = "prometheus"
+
+sample_app_mode = "pull"

--- a/terraform/testcases/prometheus_static/otconfig.tpl
+++ b/terraform/testcases/prometheus_static/otconfig.tpl
@@ -12,12 +12,6 @@ receivers:
         static_configs:
         - targets: [ ${sample_app_listen_address_host}:${sample_app_listen_address_port} ]
 exporters:
-  awsprometheusremotewrite:
-    endpoint: ${cortex_instance_endpoint}/api/v1/remote_write
-    aws_auth:
-      region: ${region}
-      service: "aps"
-    timeout: 15s
   prometheusremotewrite:
     endpoint: ${cortex_instance_endpoint}/api/v1/remote_write
     timeout: 15s
@@ -27,7 +21,7 @@ service:
   pipelines:
     metrics:
      receivers: [prometheus]
-     exporters: [awsprometheusremotewrite, prometheusremotewrite]
+     exporters: [prometheusremotewrite]
   extensions: [sigv4auth]
   telemetry:
     logs:

--- a/terraform/testcases/prometheus_static/otconfig.tpl
+++ b/terraform/testcases/prometheus_static/otconfig.tpl
@@ -1,3 +1,7 @@
+extensions:
+  sigv4auth:
+    region: ${region}
+    service: "aps"
 receivers:
   prometheus:
     config:
@@ -8,17 +12,15 @@ receivers:
         static_configs:
         - targets: [ ${sample_app_listen_address_host}:${sample_app_listen_address_port} ]
 exporters:
-  awsprometheusremotewrite:
+  prometheusremotewrite:
     endpoint: ${cortex_instance_endpoint}/api/v1/remote_write
-    aws_auth:
-      region: ${region}
-      service: "aps"
     timeout: 15s
 service:
   pipelines:
     metrics:
      receivers: [prometheus]
-     exporters: [awsprometheusremotewrite]
+     exporters: [prometheusremotewrite]
+  extensions: [sigv4auth]
   telemetry:
     logs:
       level: debug

--- a/terraform/testcases/prometheus_static/otconfig.tpl
+++ b/terraform/testcases/prometheus_static/otconfig.tpl
@@ -12,6 +12,12 @@ receivers:
         static_configs:
         - targets: [ ${sample_app_listen_address_host}:${sample_app_listen_address_port} ]
 exporters:
+  awsprometheusremotewrite:
+    endpoint: ${cortex_instance_endpoint}/api/v1/remote_write
+    aws_auth:
+      region: ${region}
+      service: "aps"
+    timeout: 15s
   prometheusremotewrite:
     endpoint: ${cortex_instance_endpoint}/api/v1/remote_write
     timeout: 15s
@@ -19,7 +25,7 @@ service:
   pipelines:
     metrics:
      receivers: [prometheus]
-     exporters: [prometheusremotewrite]
+     exporters: [awsprometheusremotewrite, prometheusremotewrite]
   extensions: [sigv4auth]
   telemetry:
     logs:

--- a/terraform/testcases/prometheus_static/otconfig.tpl
+++ b/terraform/testcases/prometheus_static/otconfig.tpl
@@ -21,6 +21,8 @@ exporters:
   prometheusremotewrite:
     endpoint: ${cortex_instance_endpoint}/api/v1/remote_write
     timeout: 15s
+    auth:
+      authenticator: sigv4auth
 service:
   pipelines:
     metrics:

--- a/terraform/testcases/prometheus_static_adot_operator/otconfig.tpl
+++ b/terraform/testcases/prometheus_static_adot_operator/otconfig.tpl
@@ -12,6 +12,12 @@ receivers:
             static_configs:
             - targets: [ ${sample_app_listen_address_host}:${sample_app_listen_address_port} ]
     exporters:
+      awsprometheusremotewrite:
+        endpoint: ${cortex_instance_endpoint}/api/v1/remote_write
+        aws_auth:
+          region: ${region}
+          service: "aps"
+        timeout: 15s
       prometheusremotewrite:
         endpoint: ${cortex_instance_endpoint}/api/v1/remote_write
         timeout: 15s
@@ -19,7 +25,7 @@ receivers:
       pipelines:
         metrics:
           receivers: [prometheus]
-          exporters: [prometheusremotewrite]
+          exporters: [awsprometheusremotewrite, prometheusremotewrite]
       extensions: [sigv4auth]
       telemetry:
         logs:

--- a/terraform/testcases/prometheus_static_adot_operator/otconfig.tpl
+++ b/terraform/testcases/prometheus_static_adot_operator/otconfig.tpl
@@ -21,6 +21,8 @@ receivers:
       prometheusremotewrite:
         endpoint: ${cortex_instance_endpoint}/api/v1/remote_write
         timeout: 15s
+        auth:
+          authenticator: sigv4auth
     service:
       pipelines:
         metrics:

--- a/terraform/testcases/prometheus_static_adot_operator/otconfig.tpl
+++ b/terraform/testcases/prometheus_static_adot_operator/otconfig.tpl
@@ -1,3 +1,7 @@
+extensions:
+  sigv4auth:
+    region: ${region}
+    service: "aps"
 receivers:
       prometheus:
         config:
@@ -8,17 +12,15 @@ receivers:
             static_configs:
             - targets: [ ${sample_app_listen_address_host}:${sample_app_listen_address_port} ]
     exporters:
-      awsprometheusremotewrite:
+      prometheusremotewrite:
         endpoint: ${cortex_instance_endpoint}/api/v1/remote_write
-        aws_auth:
-          region: ${region}
-          service: "aps"
         timeout: 15s
     service:
       pipelines:
         metrics:
           receivers: [prometheus]
-          exporters: [awsprometheusremotewrite]
+          exporters: [prometheusremotewrite]
+      extensions: [sigv4auth]
       telemetry:
         logs:
           level: debug

--- a/terraform/testcases/prometheus_static_adot_operator_awsprw/otconfig.tpl
+++ b/terraform/testcases/prometheus_static_adot_operator_awsprw/otconfig.tpl
@@ -1,7 +1,3 @@
-extensions:
-  sigv4auth:
-    region: ${region}
-    service: "aps"
 receivers:
       prometheus:
         config:
@@ -12,17 +8,17 @@ receivers:
             static_configs:
             - targets: [ ${sample_app_listen_address_host}:${sample_app_listen_address_port} ]
     exporters:
-      prometheusremotewrite:
+      awsprometheusremotewrite:
         endpoint: ${cortex_instance_endpoint}/api/v1/remote_write
+        aws_auth:
+          region: ${region}
+          service: "aps"
         timeout: 15s
-        auth:
-          authenticator: sigv4auth
     service:
       pipelines:
         metrics:
           receivers: [prometheus]
-          exporters: [prometheusremotewrite]
-      extensions: [sigv4auth]
+          exporters: [awsprometheusremotewrite]
       telemetry:
         logs:
           level: debug

--- a/terraform/testcases/prometheus_static_adot_operator_awsprw/parameters.tfvars
+++ b/terraform/testcases/prometheus_static_adot_operator_awsprw/parameters.tfvars
@@ -1,0 +1,10 @@
+# this file is defined in validator/src/main/resources/validations
+validation_config = "prometheus-metric-validation.yml"
+
+sample_app = "prometheus"
+
+soaking_data_type = "prometheus"
+
+sample_app_mode = "pull"
+
+eks_cluster_name = "adot-op-cluster"

--- a/terraform/testcases/prometheus_static_awsprw/otconfig.tpl
+++ b/terraform/testcases/prometheus_static_awsprw/otconfig.tpl
@@ -1,26 +1,24 @@
-extensions:
-  sigv4auth:
-    region: "us-west-2"
 receivers:
   prometheus:
     config:
       global:
         scrape_interval: 15s
       scrape_configs:
-      - job_name: "test-pipeline-job"
+      - job_name: "test-prometheus-sample-app"
         static_configs:
         - targets: [ ${sample_app_listen_address_host}:${sample_app_listen_address_port} ]
 exporters:
-  prometheusremotewrite:
-    endpoint: "https://${mock_endpoint}"
-    auth:
-      authenticator: sigv4auth
+  awsprometheusremotewrite:
+    endpoint: ${cortex_instance_endpoint}/api/v1/remote_write
+    aws_auth:
+      region: ${region}
+      service: "aps"
+    timeout: 15s
 service:
   pipelines:
     metrics:
      receivers: [prometheus]
-     exporters: [prometheusremotewrite]
-  extensions: [sigv4auth]
+     exporters: [awsprometheusremotewrite]
   telemetry:
     logs:
       level: debug

--- a/terraform/testcases/prometheus_static_awsprw/parameters.tfvars
+++ b/terraform/testcases/prometheus_static_awsprw/parameters.tfvars
@@ -1,0 +1,12 @@
+# this file is defined in validator/src/main/resources/validations
+validation_config = "prometheus-metric-validation.yml"
+
+sample_app = "prometheus"
+
+soaking_sample_app = "prometheus"
+
+soaking_data_type = "prometheus"
+
+sample_app_mode = "pull"
+
+ecs_taskdef_directory = "prometheus"


### PR DESCRIPTION
**Description:**
This PR is aligned with the [PR](https://github.com/aws-observability/aws-otel-collector/pull/1066) to add the sigv4 extension to the ADOT Collector. 


**Testing:** 
Note that testing has NOT been able to be performed; see #605 for more information

