### PR TITLE
Fix JS HTTP template

### DIFF
--- a/validator/src/main/resources/expected-data-template/js/jsAppExpectedHTTPTrace.mustache
+++ b/validator/src/main/resources/expected-data-template/js/jsAppExpectedHTTPTrace.mustache
@@ -22,7 +22,7 @@
           "method": "GET"
         },
         "response": {
-          "status": 200
+          "status": 301
         }
       },
       "namespace": "remote"

--- a/validator/src/main/resources/expected-data-template/js/jsAppExpectedHTTPTrace.mustache
+++ b/validator/src/main/resources/expected-data-template/js/jsAppExpectedHTTPTrace.mustache
@@ -3,6 +3,9 @@
     "request": {
       "url": "{{endpoint}}/outgoing-http-call",
       "method": "GET"
+    },
+    "response": {
+      "status": 200
     }
   },
   "metadata": {
@@ -17,6 +20,9 @@
         "request": {
           "url": "http://aws.amazon.com/",
           "method": "GET"
+        },
+        "response": {
+          "status": 200
         }
       },
       "namespace": "remote"

--- a/validator/src/main/resources/expected-data-template/js/jsAppExpectedHTTPTrace.mustache
+++ b/validator/src/main/resources/expected-data-template/js/jsAppExpectedHTTPTrace.mustache
@@ -3,8 +3,6 @@
     "request": {
       "url": "{{endpoint}}/outgoing-http-call",
       "method": "GET"
-    },
-    "response": {
     }
   },
   "metadata": {
@@ -19,8 +17,6 @@
         "request": {
           "url": "http://aws.amazon.com/",
           "method": "GET"
-        },
-        "response": {
         }
       },
       "namespace": "remote"


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Bug: 
original JS HTTP template has empty http response where as the retrieved trace would definitely have a non empty response.  

Fix:

add `Status` http response fields in JS HTTP template to have parity with other languages template.

JS integration tests are failing since in expected template we are trying to compare against 
`[0].http.response={},` which is never present in retrieved trace

**Link to tracking Issue:** <Issue number if applicable>
https://github.com/aws-observability/aws-otel-js/runs/5041312760?check_suite_focus=true#step:8:182

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
