### PR TITLE
Remove fmt from aotutil build and install

### DIFF
--- a/cmd/aotutil/Makefile
+++ b/cmd/aotutil/Makefile
@@ -7,7 +7,7 @@ fmt:
 build:
 	go build .
 
-install: fmt
+install:
 	go install .
 
 license:

--- a/cmd/aotutil/Makefile
+++ b/cmd/aotutil/Makefile
@@ -1,9 +1,10 @@
 all: license fmt build
 
 fmt:
+	go install golang.org/x/tools/cmd/goimports@latest
 	goimports -d -l -w .
 
-build: fmt
+build:
 	go build .
 
 install: fmt

--- a/docs/style.md
+++ b/docs/style.md
@@ -1,5 +1,9 @@
 # Style Guide
 
+## aotutil
+
+- run `make fmt` before committing
+
 ## Java
 
 - install `check style` plugin in your IDE


### PR DESCRIPTION
**Description:** Removes `fmt` from `build` and `install` step for `aotutil`. Adds documentation to run `make fmt` before committing for `aotutil` changes.