### PR TITLE
Changed path to s3 bucket

### DIFF
--- a/terraform/eks_adot_operator_cluster_setup/main.tf
+++ b/terraform/eks_adot_operator_cluster_setup/main.tf
@@ -23,7 +23,7 @@ terraform {
   }
   backend "s3" {
     bucket = "adot-op-cluster-terraform-statefile"
-    key    = "global/s3/terraform.tfstate"
+    key    = "eks_adot_operator_cluster/terraform.tfstate"
     region = "us-west-2"
   }
 }


### PR DESCRIPTION
**Description:**

This PR changed the key path for S3 bucket in eks_op_cluster

**Testing:**

Deployed the terraform script using personal AWS account and verified that the terraform state file is saved at the intended path.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.