### PR TITLE
Update terraform setup

### DIFF
--- a/docs/run-testing-framework.md
+++ b/docs/run-testing-framework.md
@@ -38,7 +38,10 @@ Refer to: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.h
 
 #### 2.1.2 Setup unique bucket ID
 
-First create a unique S3 bucket identifier. This needs to be globally unique. Change example to an UUID of your choice
+First create a unique S3 bucket identifier that will be appened to your S3 bucket names. This will
+ensure that the S3 bucket name is globally unique. The UUID can be generated with any method of your
+choosing.
+See [here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html) for S3 bucket naming rules.
 ```shell
 export TF_VAR_bucketUUID=$(dd if=/dev/urandom bs=1k count=1k | shasum | cut -b 1-8)
 ```

--- a/docs/run-testing-framework.md
+++ b/docs/run-testing-framework.md
@@ -35,8 +35,16 @@ In the case that you want to debug for a certain platform, you can also use this
  
 #### 2.1.1 Setup your aws credentials
 Refer to: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html
+
+#### 2.1.2 Setup unique bucket ID
+
+First create a unique S3 bucket identifier. This needs to be globally unique. Change example to an UUID of your choice
+```shell
+export TF_VAR_bucketId=**example**
+```
+
  
-#### 2.1.2 Run Setup
+#### 2.1.3 Run Setup
 Setup only needs to be run once, it creates:
  
 1. one iam role
@@ -60,7 +68,7 @@ this task will build and push the sample apps and mocked server images to the ec
  
 Remember, if you have changes on sample apps or the mocked server, you need to rerun this imagebuild task.
 
-#### 2.1.3 Share Setup resources (Optional)
+#### 2.1.4 Share Setup resources (Optional)
 **Prerequisite:**
 - you are required to run the [setup basic components](setup-basic-components-in-aws-account.md#2-setup-basic-components) once if you and other developers did not setup these components before.
 - Uncomment the [backend configuration](https://github.com/khanhntd/aws-otel-test-framework/blob/support_s3_bucket_setup/terraform/setup/backend.tf#L17-L25) to share the setup's terraform state
@@ -74,10 +82,10 @@ cd aws-otel-test-framework/terraform/setup
 terraform init
 terraform apply
 ```
-#### 2.1.4 Build AES Otel Collector Docker Image
+#### 2.1.5 Build AES Otel Collector Docker Image
 Please [build your image with the new component](https://github.com/aws-observability/aws-otel-collector/blob/main/docs/developers/build-docker.md), push this image to dockerhub, and record the image link, which will be used in your testing.
 
-#### 2.1.5 Documentation
+#### 2.1.6 Documentation
 - [Setup basic components in aws account](setup-basic-components-in-aws-account.md)
 
 ### 2.2 Run in EC2

--- a/docs/run-testing-framework.md
+++ b/docs/run-testing-framework.md
@@ -40,7 +40,7 @@ Refer to: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.h
 
 First create a unique S3 bucket identifier. This needs to be globally unique. Change example to an UUID of your choice
 ```shell
-export TF_VAR_bucketId=**example**
+export TF_VAR_bucketUUID=$(dd if=/dev/urandom bs=1k count=1k | shasum | cut -b 1-8)
 ```
 
  

--- a/docs/setup-basic-components-in-aws-account.md
+++ b/docs/setup-basic-components-in-aws-account.md
@@ -10,9 +10,12 @@ Please ensure the default profile in your ~/.aws/credentials has Admin permissio
 
 ## 2. Setup unique bucket ID
 
-First create a unique S3 bucket identifier. This needs to be globally unique
+First create a unique S3 bucket identifier that will be appened to your S3 bucket names. This will
+ensure that the S3 bucket name is globally unique. The UUID can be generated with any method of your
+choosing.
+See [here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html) for S3 bucket naming rules.
 ```shell
-export TF_VAR_bucketUUID=example
+export TF_VAR_bucketUUID=$(dd if=/dev/urandom bs=1k count=1k | shasum | cut -b 1-8)
 ```
 
 ## 3. Setup basic components

--- a/docs/setup-basic-components-in-aws-account.md
+++ b/docs/setup-basic-components-in-aws-account.md
@@ -8,7 +8,14 @@ Refer to: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.h
 
 Please ensure the default profile in your ~/.aws/credentials has Admin permission.
 
-## 2. Setup basic components
+## 2. Setup unique bucket ID
+
+First create a unique S3 bucket identifier. This needs to be globally unique
+```shell
+export TF_VAR_bucketId=example
+```
+
+## 3. Setup basic components
 Setup only needs to be run once, it creates:
 
 1. one iam role
@@ -18,13 +25,15 @@ Setup only needs to be run once, it creates:
 5. one amazon managed service for prometheus endpoint.
 6. one s3 bucket, one dynamodb table
 
+
+
 ```shell
 cd aws-otel-test-framework/terraform/setup 
 terraform init
 terraform apply
 ```
 
-###2.1 Share Setup resources (Optional)
+###3.1 Share Setup resources (Optional)
 **Prerequisite:** 
 - you are required to run the [setup basic components](setup-basic-components-in-aws-account.md#2-setup-basic-components) once if you and other developers did not setup these components before.
 - Uncomment the [backend configuration](https://github.com/khanhntd/aws-otel-test-framework/blob/support_s3_bucket_setup/terraform/setup/backend.tf#L17-L25) to share the setup's terraform state

--- a/docs/setup-basic-components-in-aws-account.md
+++ b/docs/setup-basic-components-in-aws-account.md
@@ -12,7 +12,7 @@ Please ensure the default profile in your ~/.aws/credentials has Admin permissio
 
 First create a unique S3 bucket identifier. This needs to be globally unique
 ```shell
-export TF_VAR_bucketId=example
+export TF_VAR_bucketUUID=example
 ```
 
 ## 3. Setup basic components

--- a/terraform/setup/backend.tf
+++ b/terraform/setup/backend.tf
@@ -30,7 +30,7 @@
 #Create S3 bucket to record terraform state for this setup in order to share the state for configuration setup when using integration test account
 #Document: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket
 resource "aws_s3_bucket" "setup-remote-state-s3-bucket" {
-  bucket = "setup-remote-state-s3-bucket-${var.bucketId}"
+  bucket = "setup-remote-state-s3-bucket-${var.bucketUUID}"
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "encrypt-setup-remote-state" {

--- a/terraform/setup/backend.tf
+++ b/terraform/setup/backend.tf
@@ -18,10 +18,10 @@
 #-Avoid creating duplicate resources when sharing the same account
 
 #terraform {
-#  backend "s3" {
-#    bucket           = "setup-remote-state-s3-bucket"
-#    dynamodb_table   = "setup-remote-state-dynamodb-table"
-#    key              = "terraform.tfstate"
+# backend "s3" {
+#   bucket           = "setup-remote-state-s3-bucket"
+#   dynamodb_table   = "setup-remote-state-dynamodb-table"
+#   key              = "terraform.tfstate"
 #    region           = "us-west-2"
 #    encrypt          = true
 #  }
@@ -31,21 +31,30 @@
 #Document: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket
 resource "aws_s3_bucket" "setup-remote-state-s3-bucket" {
   bucket = "setup-remote-state-s3-bucket"
-  acl    = "private"
+}
 
-  versioning {
-    enabled = true
-  }
-
-  #To encrypt the content
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
+resource "aws_s3_bucket_server_side_encryption_configuration" "encrypt-setup-remote-state" {
+  bucket = aws_s3_bucket.setup-remote-state-s3-bucket.bucket
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
     }
   }
 }
+
+resource "aws_s3_bucket_acl" "acl-setup-remote-state" {
+  bucket = aws_s3_bucket.setup-remote-state-s3-bucket.bucket
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_versioning" "versioning-setup-remote-state" {
+  bucket = aws_s3_bucket.setup-remote-state-s3-bucket.bucket
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+
 
 #Avoid multiple developers change the state at the same time since it would cause race condition
 #Document: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table

--- a/terraform/setup/backend.tf
+++ b/terraform/setup/backend.tf
@@ -30,7 +30,7 @@
 #Create S3 bucket to record terraform state for this setup in order to share the state for configuration setup when using integration test account
 #Document: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket
 resource "aws_s3_bucket" "setup-remote-state-s3-bucket" {
-  bucket = "setup-remote-state-s3-bucket-${var.bucketId}" 
+  bucket = "setup-remote-state-s3-bucket-${var.bucketId}"
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "encrypt-setup-remote-state" {

--- a/terraform/setup/backend.tf
+++ b/terraform/setup/backend.tf
@@ -30,7 +30,7 @@
 #Create S3 bucket to record terraform state for this setup in order to share the state for configuration setup when using integration test account
 #Document: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket
 resource "aws_s3_bucket" "setup-remote-state-s3-bucket" {
-  bucket = "setup-remote-state-s3-bucket"
+  bucket = "setup-remote-state-s3-bucket-${var.bucketId}" 
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "encrypt-setup-remote-state" {

--- a/terraform/setup/backend.tf
+++ b/terraform/setup/backend.tf
@@ -30,7 +30,7 @@
 #Create S3 bucket to record terraform state for this setup in order to share the state for configuration setup when using integration test account
 #Document: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket
 resource "aws_s3_bucket" "setup-remote-state-s3-bucket" {
-  bucket = "setup-remote-state-s3-bucket-${var.bucketUUID}"
+  bucket = "setup-remote-state-s3-bucket${var.bucketUUID}"
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "encrypt-setup-remote-state" {

--- a/terraform/setup/setup.tf
+++ b/terraform/setup/setup.tf
@@ -231,16 +231,16 @@ resource "aws_ecr_repository" "mocked_server_ecr_repo" {
 #the integration test
 #Document: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket
 resource "aws_s3_bucket" "terrafrom-state" {
-  bucket = "${module.common.terraform_state_s3_bucket_name}-${var.bucketId}"
+  bucket = "${module.common.terraform_state_s3_bucket_name}-${var.bucketUUID}"
 }
 
 resource "aws_s3_bucket_acl" "acl-terrafrom-state" {
-  bucket = "${module.common.terraform_state_s3_bucket_name}-${var.bucketId}"
+  bucket = "${module.common.terraform_state_s3_bucket_name}-${var.bucketUUID}"
   acl    = "private"
 }
 
 resource "aws_s3_bucket_versioning" "versioning-terrafrom-state" {
-  bucket = "${module.common.terraform_state_s3_bucket_name}-${var.bucketId}"
+  bucket = "${module.common.terraform_state_s3_bucket_name}-${var.bucketUUID}"
   versioning_configuration {
     status = "Enabled"
   }

--- a/terraform/setup/setup.tf
+++ b/terraform/setup/setup.tf
@@ -231,16 +231,16 @@ resource "aws_ecr_repository" "mocked_server_ecr_repo" {
 #the integration test
 #Document: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket
 resource "aws_s3_bucket" "terrafrom-state" {
-  bucket = module.common.terraform_state_s3_bucket_name
+  bucket = "${module.common.terraform_state_s3_bucket_name}-${var.bucketId}"
 }
 
 resource "aws_s3_bucket_acl" "acl-terrafrom-state" {
-  bucket = module.common.terraform_state_s3_bucket_name
+  bucket = "${module.common.terraform_state_s3_bucket_name}-${var.bucketId}"
   acl    = "private"
 }
 
 resource "aws_s3_bucket_versioning" "versioning-terrafrom-state" {
-  bucket = module.common.terraform_state_s3_bucket_name
+  bucket = "${module.common.terraform_state_s3_bucket_name}-${var.bucketId}"
   versioning_configuration {
     status = "Enabled"
   }

--- a/terraform/setup/setup.tf
+++ b/terraform/setup/setup.tf
@@ -232,22 +232,20 @@ resource "aws_ecr_repository" "mocked_server_ecr_repo" {
 #Document: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket
 resource "aws_s3_bucket" "terrafrom-state" {
   bucket = module.common.terraform_state_s3_bucket_name
+}
 
+resource "aws_s3_bucket_acl" "acl-terrafrom-state" {
+  bucket = module.common.terraform_state_s3_bucket_name
+  acl    = "private"
+}
 
-  #Allow multiple upload
-  versioning {
-    enabled = true
-  }
-
-  #To encrypt the content
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
-    }
+resource "aws_s3_bucket_versioning" "versioning-terrafrom-state" {
+  bucket = module.common.terraform_state_s3_bucket_name
+  versioning_configuration {
+    status = "Enabled"
   }
 }
+
 
 resource "aws_prometheus_workspace" "amp_testing_framework" {
   alias = module.common.amp_testing_framework

--- a/terraform/setup/setup.tf
+++ b/terraform/setup/setup.tf
@@ -19,6 +19,14 @@
 module "common" {
   source = "../common"
 }
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "4.8.0"
+    }
+  }
+}
 
 provider "aws" {
   region = var.region

--- a/terraform/setup/setup.tf
+++ b/terraform/setup/setup.tf
@@ -231,16 +231,16 @@ resource "aws_ecr_repository" "mocked_server_ecr_repo" {
 #the integration test
 #Document: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket
 resource "aws_s3_bucket" "terrafrom-state" {
-  bucket = "${module.common.terraform_state_s3_bucket_name}-${var.bucketUUID}"
+  bucket = "${module.common.terraform_state_s3_bucket_name}${var.bucketUUID}"
 }
 
 resource "aws_s3_bucket_acl" "acl-terrafrom-state" {
-  bucket = "${module.common.terraform_state_s3_bucket_name}-${var.bucketUUID}"
+  bucket = "${module.common.terraform_state_s3_bucket_name}${var.bucketUUID}"
   acl    = "private"
 }
 
 resource "aws_s3_bucket_versioning" "versioning-terrafrom-state" {
-  bucket = "${module.common.terraform_state_s3_bucket_name}-${var.bucketUUID}"
+  bucket = "${module.common.terraform_state_s3_bucket_name}${var.bucketUUID}"
   versioning_configuration {
     status = "Enabled"
   }

--- a/terraform/setup/vars.tf
+++ b/terraform/setup/vars.tf
@@ -17,6 +17,6 @@ variable "region" {
   default = "us-west-2"
 }
 
-variable "bucketId" {
+variable "bucketUUID" {
   default = ""
 }

--- a/terraform/setup/vars.tf
+++ b/terraform/setup/vars.tf
@@ -16,3 +16,7 @@
 variable "region" {
   default = "us-west-2"
 }
+
+variable "bucketId"{
+  default = ""
+}

--- a/terraform/setup/vars.tf
+++ b/terraform/setup/vars.tf
@@ -17,6 +17,6 @@ variable "region" {
   default = "us-west-2"
 }
 
-variable "bucketId"{
+variable "bucketId" {
   default = ""
 }


### PR DESCRIPTION
**Description:** The setup module was broken due to changes in the s3 bucket definitions post version `4.0.0`. This PR makes changes so that bucket definitions are now compliant with the aws version `4.8.0`. See documentation [here](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) for s3 reference. 

This script also failed due to the hard coded bucket names. S3 bucket names need to be globally unique. I added an env var which appends a `bucketId` which can be set by the user. 

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** Deployed setup to fresh AWS account

**Documentation:** Updated setup docs

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

