### PR TITLE
Fix imagebuild terraform module

### DIFF
--- a/docs/run-testing-framework.md
+++ b/docs/run-testing-framework.md
@@ -32,6 +32,10 @@ terraform destroy
 In the case that you want to debug for a certain platform, you can also use this testing framework to run your test case locally in multiple AWS platforms including EC2, ECS, and EKS.
  
 ### 2.1 Prerequisite
+
+#### 2.1.0
+- docker installed locally
+- awscli installed locally
  
 #### 2.1.1 Setup your aws credentials
 Refer to: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html

--- a/terraform/imagebuild/main.tf
+++ b/terraform/imagebuild/main.tf
@@ -47,7 +47,7 @@ locals {
 # login ecr
 resource "null_resource" "login_ecr" {
   provisioner "local-exec" {
-    command = "docker run --rm -v ~/.aws:/root/.aws amazon/aws-cli ecr get-login-password --region ${var.region} | docker login --username AWS --password-stdin ${local.ecr_login_domain}"
+    command = "aws ecr get-login-password --region ${var.region} | docker login --username AWS --password-stdin ${local.ecr_login_domain}"
   }
 }
 


### PR DESCRIPTION
**Description:** Previous implementation ran `awscli` within a docker container but this can cause failures for local development depending on aws credential configuration. This PR adds `awscli` as a prerequisite and adjusts the `local-exec` accordingly. 

**Testing:** Deployed to personal account



<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

