### PR TITLE
Add batch execution of tests

### DIFF
--- a/docs/run-testing-framework.md
+++ b/docs/run-testing-framework.md
@@ -213,6 +213,44 @@ Don't forget to clean up your resources:
 terraform destroy -auto-approve
 ````
 
+### 2.7 Run batch tests
+
+Batch testing allows a set of tests to be ran synchronously. To do this,
+a `test-case-batch` file is required in the `./terraform` directory. 
+The format of the `test-case-batch` file is as such. The `test-case-batch` 
+file can contain an infinite amount of test cases as
+long as the file follows this format.
+
+```
+serviceName1 testCase1 additionalValues1
+serviceName2 testCase2 additionalValues2
+serviceName3 testCase3 additionalValues3
+serviceNameN testCaseN additionalValuesN
+```
+
+The values for these fiels are as follows
+`serviceName`: `EKS` `EKS-arm64` `EKS-fargate` `EKS-operator` `ECS` `EC2`
+`testCase`: Must be an applicable test case in the `terraform/testcases` directory
+`additionalValues`: For `EC2` tests it is expected that the `testing_ami` value is provided.
+For ECS tests the `launch_type` variable is expected. For `EKS-arm64` tests it is expected that
+a pipe delimited string of `region|clustername|amp_endoint` is provided.
+
+It is also expected that the `TF_VAR_aoc_version` and `TF_VAR_aoc_image_repo` is set to valid values
+pointing to a Collector image and repository to utilize. Default `aoc_image_repo` values can be utilized 
+but the `TF_VAR_aoc_version` must be specified. 
+
+To execute the test run
+```
+make exectute-batch-test
+```
+
+To clean up the successful test cache run
+```
+make postBatchClean
+```
+
+
+
 ##3. Optional add-on
 ####3.1. Upload test case's terraform state to s3 bucket 
 **Prerequisite:** you are required to run the test case before uploading any terraform state to s3

--- a/docs/run-testing-framework.md
+++ b/docs/run-testing-framework.md
@@ -217,9 +217,7 @@ terraform destroy -auto-approve
 
 Batch testing allows a set of tests to be ran synchronously. To do this,
 a `test-case-batch` file is required in the `./terraform` directory. 
-The format of the `test-case-batch` file is as such. The `test-case-batch` 
-file can contain an infinite amount of test cases as
-long as the file follows this format.
+The format of the `test-case-batch` file is as such. 
 
 ```
 serviceName1 testCase1 additionalValues1

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -12,8 +12,10 @@ fmt:
 check-fmt:
 > terraform fmt -recursive -check
 
-
-
 .PHONY: execute-batch-test
 execute-batch-test: test-case-batch
 > xargs -L1 -P1 -a test-case-batch ./executeTerraformTest.sh
+
+.PHONY: postBatchClean
+postBatchClean:
+> rm -rf ./tmp

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -1,5 +1,19 @@
-fmt:
-	terraform fmt -recursive
+ifeq ($(origin .RECIPEPREFIX), undefined)
+  $(error This Make does not support .RECIPEPREFIX. Please use GNU Make 4.0 or later)
+endif
+.RECIPEPREFIX = >
 
+
+.PHONY: fmt
+fmt:
+> terraform fmt -recursive
+
+.PHONY: check-fmt
 check-fmt:
-	terraform fmt -recursive -check
+> terraform fmt -recursive -check
+
+
+
+.PHONY: execute-batch-test
+execute-batch-test: test-case-batch
+> xargs -L1 -P1 -a test-case-batch ./executeTerraformTest.sh

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -1,17 +1,17 @@
 
 .PHONY: fmt
 fmt:
-  terraform fmt -recursive
+	terraform fmt -recursive
 
 .PHONY: check-fmt
 check-fmt:
-  terraform fmt -recursive -check
+	terraform fmt -recursive -check
 
 .PHONY: execute-batch-test
 execute-batch-test: test-case-batch
-  xargs -L1 -P1 -a test-case-batch ./executeTerraformTest.sh
+	xargs -L1 -P1 -a test-case-batch ./executeTerraformTest.sh
 
 .PHONY: postBatchClean
 postBatchClean:
-  rm -rf ./tmp
+	rm -rf ./tmp
  

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -1,22 +1,17 @@
-ifeq ($(origin .RECIPEPREFIX), undefined)
-  $(error This Make does not support .RECIPEPREFIX. Please use GNU Make 4.0 or later)
-endif
-.RECIPEPREFIX = >
-
 
 .PHONY: fmt
 fmt:
-> terraform fmt -recursive
+  terraform fmt -recursive
 
 .PHONY: check-fmt
 check-fmt:
-> terraform fmt -recursive -check
+  terraform fmt -recursive -check
 
 .PHONY: execute-batch-test
 execute-batch-test: test-case-batch
-> xargs -L1 -P1 -a test-case-batch ./executeTerraformTest.sh
+  xargs -L1 -P1 -a test-case-batch ./executeTerraformTest.sh
 
 .PHONY: postBatchClean
 postBatchClean:
-> rm -rf ./tmp
+  rm -rf ./tmp
  

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -19,3 +19,4 @@ execute-batch-test: test-case-batch
 .PHONY: postBatchClean
 postBatchClean:
 > rm -rf ./tmp
+ 

--- a/terraform/executeTerraformTest.sh
+++ b/terraform/executeTerraformTest.sh
@@ -22,29 +22,25 @@ echo $3
 
 
 opts=""
-if [[ -f ./testcases/${2}/parameters.tfvars ]] ; then 
-    opts="-var-file=../testcases/${2}/parameters.tfvars" ; 
+if [[ -f ./testcases/$2/parameters.tfvars ]] ; then 
+    opts="-var-file=../testcases/$2/parameters.tfvars" ; 
 fi
 
-
-
-US_EAST_2_AMP_ENDPOINT="https://aps-workspaces.us-east-2.amazonaws.com/workspaces/ws-1de68e95-0680-42bb-8e55-67e7fd5d0861";
 APPLY_EXIT=0
 TEST_FOLDER=""
-REGION="us-west-2"
 ADDITIONAL_VARS=""
 
-service="${1}"
+service="$1"
 case "$service" in
     "EC2") TEST_FOLDER="./ec2/";
-    ADDITIONAL_VARS="-var=\"testing_ami=${3}\"";
+    ADDITIONAL_VARS="-var=\"testing_ami=$3\"";
     ;;
     "EKS") TEST_FOLDER="./eks/";
     ;;
     "EKS-arm64") TEST_FOLDER="./eks/"
-        arm_64_region=$(echo ${3} | cut -d \| -f 1);
-        arm_64_clustername=$(echo ${3} | cut -d \| -f 2);
-        arm_64_amp=$(echo ${3} | cut -d \| -f 3);
+        arm_64_region=$(echo $3 | cut -d \| -f 1);
+        arm_64_clustername=$(echo $3 | cut -d \| -f 2);
+        arm_64_amp=$(echo $3 | cut -d \| -f 3);
         ADDITIONAL_VARS="-var=\"region=${arm_64_region}\" -var=\"eks_cluster_name=${arm_64_clustername}\" -var=\"cortex_instance_endpoint=${arm_64_amp}\"";
     ;;
     "EKS-fargate") TEST_FOLDER="./eks/";
@@ -52,7 +48,7 @@ case "$service" in
     "EKS-operator") TEST_FOLDER="./eks/";
     ;;
     "ECS") TEST_FOLDER="./ecs/";
-        ADDITIONAL_VARS="-var=\"ecs_launch_type=${3}\"";
+        ADDITIONAL_VARS="-var=\"ecs_launch_type=$3\"";
     ;;
     *)
     echo "service ${service} is not valid";
@@ -65,16 +61,18 @@ esac
 
 cd ${folder};
 terraform init;
-if [ ! -f "tmp/${2}" ]; then
-    if terraform apply -auto-approve -lock=false $opts  -var="testcase=./testcases/$2" $ADDITIONAL_VARS ; then
+if [ ! -f "tmp/$2" ]; then
+    if terraform apply -auto-approve -lock=false $opts  -var="testcase=./testcases/$2" ${ADDITIONAL_VARS} ; then
         echo "Terraform apply failed"
-        echo "AWS_service: ${1}"
-        echo "Testcase: ${2}"
+        echo "AWS_service: $1"
+        echo "Testcase: $2"
         echo "Additional var: ${ADDITIONAL_VARS}"
+        APPLY_EXIT=1
     else
-        touch "tmp/${2}" 
+        touch "tmp/$2" 
     fi
 fi
 
 
 terraform destroy --auto-approve
+exit $APPLY_EXIT

--- a/terraform/executeTerraformTest.sh
+++ b/terraform/executeTerraformTest.sh
@@ -1,0 +1,69 @@
+##########################################
+# This script is used to execute a
+# terraform test. A destroy will 
+# alway be ran no matter if terraform was 
+# successful or not. 
+#
+# ENV:
+# TF_VAR_aoc_version
+#
+# Inputs
+# $1: aws_service
+# $2: testcase 
+# $3: ECS/EC2 only - ami/ecs launch type 
+# $3: For EKS-arm64 we expect region|clustername|amp_endoint
+##########################################
+
+set -e
+
+echo $1
+echo $2
+echo $3
+
+
+opts=""
+if [[ -f ./testcases/${2}/parameters.tfvars ]] ; then 
+    opts="-var-file=../testcases/${2}/parameters.tfvars" ; 
+fi
+
+
+US_EAST_2_AMP_ENDPOINT="https://aps-workspaces.us-east-2.amazonaws.com/workspaces/ws-1de68e95-0680-42bb-8e55-67e7fd5d0861";
+APPLY_EXIT=0
+TEST_FOLDER=""
+REGION="us-west-2"
+ADDITIONAL_VARS=""
+
+service="${1}"
+case "$service" in
+    "EC2") TEST_FOLDER="./ec2/"
+    ADDITIONAL_VARS="-var=\"testing_ami=${3}\""
+    ;;
+    "EKS") TEST_FOLDER="./eks/"
+    ;;
+    "EKS-arm64") TEST_FOLDER="./eks/"
+        arm_64_region=$(echo ${3} | cut -d \| -f 1)
+        arm_64_clustername=$(echo ${3} | cut -d \| -f 2)
+        arm_64_amp=$(echo ${3} | cut -d \| -f 3)
+        ADDITIONAL_VARS="-var=\"region=${arm_64_region}\" -var=\"eks_cluster_name=${arm_64_clustername}\" -var=\"cortex_instance_endpoint=${arm_64_amp}\""
+    ;;
+    "EKS-fargate") # do stuff
+    ;;
+    "EKS-operator") # do stuff
+    ;;
+    "ECS") # do stuff
+    ;;
+    *)
+    echo "service ${service} is not valid"
+    exit 1
+    ;;
+esac
+
+
+cd ${folder};
+terraform init;
+if terraform apply -auto-approve -lock=false $opts  -var="testcase=./testcases/$2" ${ADDITIONAL_VARS} -var="region=${REGION}" ; then
+    #exit 1
+else
+    #touch cache
+fi
+terraform destroy --auto-approve


### PR DESCRIPTION
**Description:** 
**Please do not merge this PR**
This will be a multi PR change to add the ability to generate and execute a batch of test cases for the ADOT Collector. I would like to merge them all at once in case we have to cherry pick this into previous release branches. Having a single merge commit with all changes will reduce the chance that anything is missed. We could also merge this into a dev branch if it is easier that way.

This is Part 1 of N.

This PR adds a make target to execute the tests along with a shell script to parse the `test-case-batch` file 
and execute the `terraform apply`. 

A tool to automatically generate the `test-case-batch` file will be added in subsequent PRs.

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

