### PR TITLE
Add sample-app image for the testcases

### DIFF
--- a/terraform/testcases/otlp_grpc_exporter_cw_amp_xray_ecs/parameters.tfvars
+++ b/terraform/testcases/otlp_grpc_exporter_cw_amp_xray_ecs/parameters.tfvars
@@ -5,4 +5,4 @@ soaking_data_mode = "trace"
 
 sample_app = "spark"
 
-
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"

--- a/terraform/testcases/otlp_grpc_exporter_cw_amp_xray_ecs_awsprw/parameters.tfvars
+++ b/terraform/testcases/otlp_grpc_exporter_cw_amp_xray_ecs_awsprw/parameters.tfvars
@@ -5,4 +5,4 @@ soaking_data_mode = "trace"
 
 sample_app = "spark"
 
-
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"

--- a/terraform/testcases/otlp_metric/parameters.tfvars
+++ b/terraform/testcases/otlp_metric/parameters.tfvars
@@ -2,3 +2,4 @@ validation_config = "spark-otel-metric-validation.yml"
 
 sample_app = "spark"
 
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"

--- a/terraform/testcases/otlp_metric_adot_operator/parameters.tfvars
+++ b/terraform/testcases/otlp_metric_adot_operator/parameters.tfvars
@@ -2,4 +2,6 @@ validation_config = "spark-otel-metric-validation.yml"
 
 sample_app = "spark"
 
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
+
 eks_cluster_name = "adot-op-cluster"

--- a/terraform/testcases/otlp_metric_amp/parameters.tfvars
+++ b/terraform/testcases/otlp_metric_amp/parameters.tfvars
@@ -5,3 +5,5 @@ validation_config = "otlp-prometheus-validation.yml"
 soaking_data_mode = "metric"
 
 sample_app = "spark"
+
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"

--- a/terraform/testcases/otlp_metric_amp_awsprw/parameters.tfvars
+++ b/terraform/testcases/otlp_metric_amp_awsprw/parameters.tfvars
@@ -5,3 +5,5 @@ validation_config = "otlp-prometheus-validation.yml"
 soaking_data_mode = "metric"
 
 sample_app = "spark"
+
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"

--- a/terraform/testcases/otlp_trace/parameters.tfvars
+++ b/terraform/testcases/otlp_trace/parameters.tfvars
@@ -4,3 +4,5 @@ validation_config = "spark-otel-trace-validation.yml"
 soaking_data_mode = "trace"
 
 sample_app = "spark"
+
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"

--- a/terraform/testcases/otlp_trace_adot_operator/parameters.tfvars
+++ b/terraform/testcases/otlp_trace_adot_operator/parameters.tfvars
@@ -7,3 +7,4 @@ eks_cluster_name = "adot-op-cluster"
 
 sample_app = "spark"
 
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"

--- a/terraform/testcases/otlp_trace_resourcedetection_ec2/parameters.tfvars
+++ b/terraform/testcases/otlp_trace_resourcedetection_ec2/parameters.tfvars
@@ -5,3 +5,4 @@ soaking_data_mode = "trace"
 
 sample_app = "spark"
 
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"

--- a/terraform/testcases/otlp_trace_resourcedetection_ecs/parameters.tfvars
+++ b/terraform/testcases/otlp_trace_resourcedetection_ecs/parameters.tfvars
@@ -4,3 +4,5 @@ validation_config = "spark-otel-trace-ecs-validation.yml"
 soaking_data_mode = "trace"
 
 sample_app = "spark"
+
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"

--- a/terraform/testcases/otlp_trace_resourcedetection_eks/parameters.tfvars
+++ b/terraform/testcases/otlp_trace_resourcedetection_eks/parameters.tfvars
@@ -4,3 +4,5 @@ validation_config = "spark-otel-trace-eks-validation.yml"
 soaking_data_mode = "trace"
 
 sample_app = "spark"
+
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"


### PR DESCRIPTION
**Description:**

This PR ensures to use the appropriate sample app for the test cases.

Context: The spark-app is removed locally from the test framework to avoid dedup and changes were made accordingly to use the [image](https://github.com/aws-observability/aws-otel-java-instrumentation/tree/main/sample-apps/spark) from `aws-otel-java-instrumentation`. 


The Existing CI workflow is using the `private ecr` image that was added at the time of setup in the `intel-test` account.

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

