### PR TITLE
Get TTL_DATE from env

### DIFF
--- a/terraform/executeTerraformTest.sh
+++ b/terraform/executeTerraformTest.sh
@@ -9,6 +9,8 @@
 # TF_VAR_aoc_version
 # GITHUB_RUN_ID
 # DDB_TABLE_NAME
+# TTL_TIME time insert for TTL item in cache
+# on mac TTL_DATE=$(date -v +7d +%s)
 # for local use. command line vars will override this env var
 # TF_VAR_cortex_instance_endpoint
 #
@@ -72,8 +74,6 @@ if [ -z "${CACHE_HIT}" ]; then
     if terraform apply -auto-approve -lock=false $opts  -var="testcase=../testcases/$2" ${ADDITIONAL_VARS} ; then
         echo "Exit code: $?"
         terraform destroy --auto-approve
-        # push onto cache
-        TTL_DATE=$(date -v +7d +%s)
         aws dynamodb put-item --table-name ${DDB_TABLE_NAME} --item {\"TestId\":{\"S\":\"$1$2$3${GITHUB_RUN_ID}\"}\,\"TimeToExist\":{\"N\":\"${TTL_DATE}\"}} --return-consumed-capacity TOTAL
     else
         terraform destroy --auto-approve

--- a/terraform/executeTerraformTest.sh
+++ b/terraform/executeTerraformTest.sh
@@ -9,7 +9,7 @@
 # TF_VAR_aoc_version
 # GITHUB_RUN_ID
 # DDB_TABLE_NAME
-# TTL_TIME time insert for TTL item in cache
+# TTL_DATE time insert for TTL item in cache
 # on mac TTL_DATE=$(date -v +7d +%s)
 # for local use. command line vars will override this env var
 # TF_VAR_cortex_instance_endpoint


### PR DESCRIPTION
**Description:** Remove call to `date` in shell script. Instead expect `TTL_DATE` from environment. This will stop `date` from breaking us in GHA workflow. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

