### PR TITLE
Switch to aoc_version for cache key

### DIFF
--- a/terraform/executeTerraformTest.sh
+++ b/terraform/executeTerraformTest.sh
@@ -65,7 +65,7 @@ case "$service" in
 esac
 
 
-CACHE_HIT=$(aws dynamodb get-item --table-name ${DDB_TABLE_NAME} --key {\"TestId\":{\"S\":\"$1$2$3${GITHUB_RUN_ID}\"}})
+CACHE_HIT=$(aws dynamodb get-item --table-name ${DDB_TABLE_NAME} --key {\"TestId\":{\"S\":\"$1$2$3${TF_VAR_aoc_version}\"}})
 
 
 if [ -z "${CACHE_HIT}" ]; then
@@ -74,7 +74,7 @@ if [ -z "${CACHE_HIT}" ]; then
     if terraform apply -auto-approve -lock=false $opts  -var="testcase=../testcases/$2" ${ADDITIONAL_VARS} ; then
         echo "Exit code: $?"
         terraform destroy --auto-approve
-        aws dynamodb put-item --table-name ${DDB_TABLE_NAME} --item {\"TestId\":{\"S\":\"$1$2$3${GITHUB_RUN_ID}\"}\,\"TimeToExist\":{\"N\":\"${TTL_DATE}\"}} --return-consumed-capacity TOTAL
+        aws dynamodb put-item --table-name ${DDB_TABLE_NAME} --item {\"TestId\":{\"S\":\"$1$2$3${TF_VAR_aoc_version}\"}\,\"TimeToExist\":{\"N\":\"${TTL_DATE}\"}} --return-consumed-capacity TOTAL
     else
         terraform destroy --auto-approve
         echo "Terraform apply failed"


### PR DESCRIPTION
**Description:** Change cache key to use `TF_VAR_aoc_version` instead of `github.run_id`. This will allow us to use cache hits cross run. See links below on where `TF_VAR_aoc_version` comes from. 

[Export to env](https://github.com/aws-observability/aws-otel-collector/blob/3c017dd0169373bfb8bedbfb667d4276163535ff/.github/workflows/CI-Batched.yml#L597)
[Creation of `VERSION`.](https://github.com/aws-observability/aws-otel-collector/blob/3c017dd0169373bfb8bedbfb667d4276163535ff/.github/workflows/CI-Batched.yml#L431)

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

