### PR TITLE
Reorder cache step

### DIFF
--- a/terraform/executeTerraformTest.sh
+++ b/terraform/executeTerraformTest.sh
@@ -73,8 +73,8 @@ if [ -z "${CACHE_HIT}" ]; then
     terraform init;
     if terraform apply -auto-approve -lock=false $opts  -var="testcase=../testcases/$2" ${ADDITIONAL_VARS} ; then
         echo "Exit code: $?"
-        terraform destroy --auto-approve
         aws dynamodb put-item --table-name ${DDB_TABLE_NAME} --item {\"TestId\":{\"S\":\"$1$2$3${TF_VAR_aoc_version}\"}\,\"TimeToExist\":{\"N\":\"${TTL_DATE}\"}} --return-consumed-capacity TOTAL
+        terraform destroy --auto-approve
     else
         terraform destroy --auto-approve
         echo "Terraform apply failed"


### PR DESCRIPTION
**Description:** Cache before destroy command is sent. This way the cache will always be sent even if destroy is not successful. Since each job is in its own runner and statefiles are not being persisted we will leave hanging resources no matter what. It is better not to rerun the test if it was successful. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

