### PR TITLE
Set DDB cache region

### DIFF
--- a/terraform/executeTerraformTest.sh
+++ b/terraform/executeTerraformTest.sh
@@ -65,7 +65,7 @@ case "$service" in
 esac
 
 
-CACHE_HIT=$(aws dynamodb get-item --table-name ${DDB_TABLE_NAME} --key {\"TestId\":{\"S\":\"$1$2$3${TF_VAR_aoc_version}\"}})
+CACHE_HIT=$(aws dynamodb get-item --region=us-west-2 --table-name ${DDB_TABLE_NAME} --key {\"TestId\":{\"S\":\"$1$2$3${TF_VAR_aoc_version}\"}})
 
 
 if [ -z "${CACHE_HIT}" ]; then
@@ -73,7 +73,7 @@ if [ -z "${CACHE_HIT}" ]; then
     terraform init;
     if terraform apply -auto-approve -lock=false $opts  -var="testcase=../testcases/$2" ${ADDITIONAL_VARS} ; then
         echo "Exit code: $?"
-        aws dynamodb put-item --table-name ${DDB_TABLE_NAME} --item {\"TestId\":{\"S\":\"$1$2$3${TF_VAR_aoc_version}\"}\,\"TimeToExist\":{\"N\":\"${TTL_DATE}\"}} --return-consumed-capacity TOTAL
+        aws dynamodb put-item --region=us-west-2 --table-name ${DDB_TABLE_NAME} --item {\"TestId\":{\"S\":\"$1$2$3${TF_VAR_aoc_version}\"}\,\"TimeToExist\":{\"N\":\"${TTL_DATE}\"}} --return-consumed-capacity TOTAL
         terraform destroy --auto-approve
     else
         terraform destroy --auto-approve


### PR DESCRIPTION
**Description:** Set DDB calls to use `us-west-2` which is where the DDB cache will be deployed to. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

