### PR TITLE
Append placeholder string for empty eks vars

### DIFF
--- a/tools/batchTestGenerator/cmd/root.go
+++ b/tools/batchTestGenerator/cmd/root.go
@@ -180,10 +180,10 @@ func transformEKSvars(fields eksFields) (string, error) {
 	if !matched {
 		// not an error to provide no values to field
 		if outputStr == "||" {
-			return "", nil
+			return "nil", nil
 		} else {
 			// it is an erorr if 0 < # of provided values < 3
-			return "", fmt.Errorf("must provide all three eks field values: %w", err)
+			return "nil", fmt.Errorf("must provide all three eks field values: %w", err)
 		}
 	}
 	return outputStr, nil


### PR DESCRIPTION
**Description:** For some reason `test-case-batch` files are not correctly getting newlines appended for 2 value test cases such as `eks` or `eks_adot_operator`. See examples [here](https://github.com/aws-observability/aws-otel-collector/runs/6168242248?check_suite_focus=true#step:7:31) and [here](https://github.com/aws-observability/aws-otel-collector/runs/6168242324?check_suite_focus=true#step:6:32). It is working for batches containing 3 value test cases such as EC2 and ECS. See example [here](https://github.com/aws-observability/aws-otel-collector/runs/6168240758?check_suite_focus=true#step:6:32). I believe this is an issue with the encoding during the JSON marshaling or the `sprintf` call. The quickest way around this is just to attach placeholder string which the batch execution script will ignore. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

