### PR TITLE
Catch client exepctions and add logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ tools/batchTestGenerator/batchTestGenerator
 # ignore any generated test-case-batch files
 test-case-batch
 
+# ignore java validator bin
+validator/bin
+

--- a/validator/src/main/java/com/amazon/aoc/validators/AbstractStructuredLogValidator.java
+++ b/validator/src/main/java/com/amazon/aoc/validators/AbstractStructuredLogValidator.java
@@ -24,6 +24,7 @@ import com.amazon.aoc.models.Context;
 import com.amazon.aoc.models.ValidationConfig;
 import com.amazon.aoc.services.CloudWatchService;
 import com.amazonaws.services.logs.model.OutputLogEvent;
+import com.amazonaws.AmazonClientException;
 import com.amazonaws.util.StringUtils;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -99,17 +100,25 @@ public abstract class AbstractStructuredLogValidator implements IValidator {
 
   protected void fetchAndValidateLogs(Instant startTime) throws Exception {
     for (String logStreamName : logStreamNames) {
-      List<OutputLogEvent> logEvents = cloudWatchService.getLogs(logGroupName, logStreamName,
-              startTime.toEpochMilli(), QUERY_LIMIT);
-      if (logEvents.isEmpty()) {
-        throw new BaseException(
-                ExceptionCode.LOG_FORMAT_NOT_MATCHED,
-                String.format("[StructuredLogValidator] no logs found under log stream %s",
-                        logStreamName));
+      try{
+        List<OutputLogEvent> logEvents = cloudWatchService.getLogs(logGroupName, logStreamName,
+        startTime.toEpochMilli(), QUERY_LIMIT);
+              
+        if (logEvents.isEmpty()) {
+          throw new BaseException(
+                  ExceptionCode.LOG_FORMAT_NOT_MATCHED,
+                  String.format("[StructuredLogValidator] no logs found under log stream %s",
+                          logStreamName));
+        }
+        for (OutputLogEvent logEvent : logEvents) {
+          validateJsonSchema(logEvent.getMessage());
+        }
+      }catch(AmazonClientException e){
+          log.info(String.format("[StructuredLogValidator] failed to retrieve log stream %s",
+          logStreamName));
+          throw e;
       }
-      for (OutputLogEvent logEvent : logEvents) {
-        validateJsonSchema(logEvent.getMessage());
-      }
+
     }
   }
 

--- a/validator/src/main/java/com/amazon/aoc/validators/AbstractStructuredLogValidator.java
+++ b/validator/src/main/java/com/amazon/aoc/validators/AbstractStructuredLogValidator.java
@@ -100,9 +100,9 @@ public abstract class AbstractStructuredLogValidator implements IValidator {
 
   protected void fetchAndValidateLogs(Instant startTime) throws Exception {
     for (String logStreamName : logStreamNames) {
-      try{
+      try {
         List<OutputLogEvent> logEvents = cloudWatchService.getLogs(logGroupName, logStreamName,
-        startTime.toEpochMilli(), QUERY_LIMIT);
+            startTime.toEpochMilli(), QUERY_LIMIT);
               
         if (logEvents.isEmpty()) {
           throw new BaseException(
@@ -112,11 +112,11 @@ public abstract class AbstractStructuredLogValidator implements IValidator {
         }
         for (OutputLogEvent logEvent : logEvents) {
           validateJsonSchema(logEvent.getMessage());
-        }
-      }catch(AmazonClientException e){
-          log.info(String.format("[StructuredLogValidator] failed to retrieve log stream %s",
-          logStreamName));
-          throw e;
+        } 
+      } catch (AmazonClientException e) {
+        log.info(String.format("[StructuredLogValidator] failed to retrieve log stream %s",
+            logStreamName));
+        throw e;
       }
 
     }


### PR DESCRIPTION
**Description:** Catches any [`AmazonClientExceptions`](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/java-dg-exceptions.html), logs them, and then throws the caught error. Currently these errors do not [emit any useful logs ](https://github.com/aws-observability/aws-otel-collector/runs/6178099444?check_suite_focus=true#step:6:4202)when they are thrown. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

