### PR TITLE
Pass in options for fargate and operator destroy

### DIFF
--- a/terraform/executeTerraformTest.sh
+++ b/terraform/executeTerraformTest.sh
@@ -76,7 +76,14 @@ if [ -z "${CACHE_HIT}" ]; then
         aws dynamodb put-item --region=us-west-2 --table-name ${DDB_TABLE_NAME} --item {\"TestId\":{\"S\":\"$1$2$3\"}\,\"aoc_version\":{\"S\":\"${TF_VAR_aoc_version}\"}\,\"TimeToExist\":{\"N\":\"${TTL_DATE}\"}} --return-consumed-capacity TOTAL
         terraform destroy --auto-approve
     else
-        terraform destroy --auto-approve
+        case "$service" in
+            "EKS_FARGATE" | "EKS_ADOT_OPERATOR") terraform destroy --auto-approve $opts;
+            ;;
+            *)
+            terraform destroy --auto-approve;
+            ;;
+        esac
+        
         echo "Terraform apply failed"
         echo "Exit code: $?"
         echo "AWS_service: $1"


### PR DESCRIPTION
**Description:** Pass in `$opts` for the `terraform destroy` only if it is an `EKS_FARGATE` or `EKS_ADOT_OPERATOR` test. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

