### PR TITLE
Remove extra include definition

### DIFF
--- a/tools/batchTestGenerator/cmd/root.go
+++ b/tools/batchTestGenerator/cmd/root.go
@@ -165,7 +165,6 @@ func init() {
 	comCfg.rootCommand.PersistentFlags().StringVar(&comCfg.eksFlags.ampEndpoint, "eksamp", "", "AMP endpoint for EKS tests")
 	comCfg.rootCommand.PersistentFlags().StringVar(&comCfg.eksFlags.clusterName, "ekscluster", "", "Cluster name for EKS tests")
 	comCfg.rootCommand.PersistentFlags().StringVar(&comCfg.eksFlags.region, "eksregion", "", "Region for EKS tests")
-	comCfg.rootCommand.PersistentFlags().StringSliceVar(&comCfg.includeFlags, "include", []string{}, "list of commma separated services to include. See README for list of valid values.")
 
 	// githubflags only
 	comCfg.githubCommand.Flags().IntVar(&comCfg.runConfig.MaxBatches, "maxBatch", 40, "Maxium number of batches allowed.")


### PR DESCRIPTION
**Description:** Removed extraneous definition of `include`. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

