### PR TITLE
Add timeout and retry to terraform apply

### DIFF
--- a/terraform/executeTerraformTest.sh
+++ b/terraform/executeTerraformTest.sh
@@ -74,7 +74,7 @@ ATTEMPTS_LEFT=2
 cd ${TEST_FOLDER};
 while [ $ATTEMPTS_LEFT -gt 0 ] && [ -z "${CACHE_HIT}" ]; do
     terraform init;
-    if timeout -k 5m --signal=SIGINT -v 1m terraform apply -auto-approve -lock=false $opts  -var="testcase=../testcases/$2" ; then
+    if timeout -k 5m --signal=SIGINT -v 45m terraform apply -auto-approve -lock=false $opts  -var="testcase=../testcases/$2" ; then
         echo "Exit code: $?"
         aws dynamodb put-item --region=us-west-2 --table-name ${DDB_TABLE_NAME} --item {\"TestId\":{\"S\":\"$1$2$3\"}\,\"aoc_version\":{\"S\":\"${TF_VAR_aoc_version}\"}\,\"TimeToExist\":{\"N\":\"${TTL_DATE}\"}} --return-consumed-capacity TOTAL
     else


### PR DESCRIPTION
**Description:** Adds timeout and retry functionality to `terraform apply` steps. By default this will only retry once but that can be tweaked if necssary. 

Timeout was displaying a weird behavior where two interrupt signals were sent despite only logging one. This can be seen through this log during testing.
```
timeout: sending signal INT to command ‘terraform’
Stopping operation...

Interrupt received.
Please wait for Terraform to exit or data loss may occur.
Gracefully shutting down...


Two interrupts received. Exiting immediately. Note that data loss may have occurred.

╷
│ Error: operation canceled
│ 
│ 
```
I have found correspondence that this may be due to the version I am using for `coreutils` [here](https://stackoverflow.com/questions/66518048/double-signal-send-with-command-timeout). This could cause an issue since the ubuntu vm uses `coreutils` version `8.30-3ubuntu2` but it is unknown without testing on the workflow itself. 

**Testing:** Tested on local machine with tests that were guaranteed to fail. Set timeout very low to test timeout and retry mechanic at the same time. 

Fixes #668


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

