### PR TITLE
Update APPLY_EXIT on success and failure

### DIFF
--- a/terraform/executeTerraformTest.sh
+++ b/terraform/executeTerraformTest.sh
@@ -75,17 +75,15 @@ cd ${TEST_FOLDER};
 while [ $ATTEMPTS_LEFT -gt 0 ] && [ -z "${CACHE_HIT}" ]; do
     terraform init;
     if timeout -k 5m --signal=SIGINT -v 45m terraform apply -auto-approve -lock=false $opts  -var="testcase=../testcases/$2" ; then
+        APPLY_EXIT=$?
         echo "Exit code: $?" 
+        aws dynamodb put-item --region=us-west-2 --table-name ${DDB_TABLE_NAME} --item {\"TestId\":{\"S\":\"$1$2$3\"}\,\"aoc_version\":{\"S\":\"${TF_VAR_aoc_version}\"}\,\"TimeToExist\":{\"N\":\"${TTL_DATE}\"}} --return-consumed-capacity TOTAL
     else
+        APPLY_EXIT=$?
         echo "Terraform apply failed"
         echo "Exit code: $?"
         echo "AWS_service: $1"
         echo "Testcase: $2" 
-    fi
-    APPLY_EXIT=$?
-    # put cache if success 
-    if [ $APPLY_EXIT -eq 0 ]; then
-        aws dynamodb put-item --region=us-west-2 --table-name ${DDB_TABLE_NAME} --item {\"TestId\":{\"S\":\"$1$2$3\"}\,\"aoc_version\":{\"S\":\"${TF_VAR_aoc_version}\"}\,\"TimeToExist\":{\"N\":\"${TTL_DATE}\"}} --return-consumed-capacity TOTAL
     fi
 
     case "$service" in

--- a/terraform/executeTerraformTest.sh
+++ b/terraform/executeTerraformTest.sh
@@ -75,15 +75,19 @@ cd ${TEST_FOLDER};
 while [ $ATTEMPTS_LEFT -gt 0 ] && [ -z "${CACHE_HIT}" ]; do
     terraform init;
     if timeout -k 5m --signal=SIGINT -v 45m terraform apply -auto-approve -lock=false $opts  -var="testcase=../testcases/$2" ; then
-        echo "Exit code: $?"
-        aws dynamodb put-item --region=us-west-2 --table-name ${DDB_TABLE_NAME} --item {\"TestId\":{\"S\":\"$1$2$3\"}\,\"aoc_version\":{\"S\":\"${TF_VAR_aoc_version}\"}\,\"TimeToExist\":{\"N\":\"${TTL_DATE}\"}} --return-consumed-capacity TOTAL
+        echo "Exit code: $?" 
     else
         echo "Terraform apply failed"
         echo "Exit code: $?"
         echo "AWS_service: $1"
-        echo "Testcase: $2"
-        APPLY_EXIT=1
+        echo "Testcase: $2" 
     fi
+    APPLY_EXIT=$?
+    # put cache if success 
+    if [ $APPLY_EXIT -eq 0 ]; then
+        aws dynamodb put-item --region=us-west-2 --table-name ${DDB_TABLE_NAME} --item {\"TestId\":{\"S\":\"$1$2$3\"}\,\"aoc_version\":{\"S\":\"${TF_VAR_aoc_version}\"}\,\"TimeToExist\":{\"N\":\"${TTL_DATE}\"}} --return-consumed-capacity TOTAL
+    fi
+
     case "$service" in
         "EKS_FARGATE" | "EKS_ADOT_OPERATOR") terraform destroy --auto-approve $opts;
         ;;


### PR DESCRIPTION
**Description:** Fixes `executeTestFramework.sh` from erroneously exiting with a non-zero exit code. This would happen if the first attempt failed but second attempt was successful. `APPLY_EXIT` would not be properly updated after the second run of `terraform apply` which would cause `APPLY_EXIT` to remain at 1. 

`APPLY_EXIT` is duplicated inside conditionals so that is `$?` is not overwritten by the `echo` command. `echo` will always return 0. See below for an example
```
~ % false   
 ~ % echo $?     
1
 ~ % echo $?
0
```

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

