### PR TITLE
Scope down cluster roles for container insights agent

### DIFF
--- a/terraform/eks/container-insights-agent/cluster_role.tpl
+++ b/terraform/eks/container-insights-agent/cluster_role.tpl
@@ -22,3 +22,4 @@ rules:
     resources: ["configmaps"]
     resourceNames: ["otel-container-insight-clusterleader"]
     verbs: ["get","update", "create", "patch"]
+    

--- a/terraform/eks/container-insights-agent/cluster_role.tpl
+++ b/terraform/eks/container-insights-agent/cluster_role.tpl
@@ -22,4 +22,3 @@ rules:
     resources: ["configmaps"]
     resourceNames: ["otel-container-insight-clusterleader"]
     verbs: ["get","update", "create", "patch"]
-    

--- a/terraform/eks/container-insights-agent/cluster_role.tpl
+++ b/terraform/eks/container-insights-agent/cluster_role.tpl
@@ -5,10 +5,10 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["pods", "nodes", "endpoints"]
-    verbs: ["list", "watch"]
+    verbs: ["list", "watch", "get"]
   - apiGroups: ["apps"]
     resources: ["replicasets"]
-    verbs: ["list", "watch"]
+    verbs: ["list", "watch", "get"]
   - apiGroups: ["batch"]
     resources: ["jobs"]
     verbs: ["list", "watch"]
@@ -21,10 +21,4 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     resourceNames: ["otel-container-insight-clusterleader"]
-    verbs: ["get","update"]
-  - apiGroups:
-      - coordination.k8s.io
-    resources:
-      - leases
-    verbs:
-      - '*'
+    verbs: ["get","update", "create", "patch"]


### PR DESCRIPTION
**Description:** Scopes down container insights cluster roles. 

**Testing:** Tested on local cluster and saw `Cluster`, `ClusterService` and `ClusterNamespace` metric types. 


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

