### PR TITLE
Cherry pick build fix into release/v0.17.x

### DIFF
--- a/cmd/aotutil/Makefile
+++ b/cmd/aotutil/Makefile
@@ -1,12 +1,13 @@
 all: license fmt build
 
 fmt:
+	go install golang.org/x/tools/cmd/goimports@latest
 	goimports -d -l -w .
 
-build: fmt
+build:
 	go build .
 
-install: fmt
+install:
 	go install .
 
 license:

--- a/docs/style.md
+++ b/docs/style.md
@@ -1,5 +1,9 @@
 # Style Guide
 
+## aotutil
+
+- run `make fmt` before committing
+
 ## Java
 
 - install `check style` plugin in your IDE


### PR DESCRIPTION
**Description:** Cherry-picks `452230b` into `release/v0.17.x` branch so fmt does not need to be ran before build

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

