### PR TITLE
Use latest ghcr image for tests

### DIFF
--- a/terraform/eks/adot-operator/adot-operator-values.yaml
+++ b/terraform/eks/adot-operator/adot-operator-values.yaml
@@ -1,6 +1,6 @@
 manager:
   image:
-    repository: public.ecr.aws/aws-observability/adot-operator
+    repository: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
     tag: "latest"
 
 kubeRBACProxy:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Change Operator tests to use the ghcr Operator image instead of the ECR Operator image

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

