### PR TITLE
Update spark sample app target

### DIFF
--- a/terraform/testcases/otlp_grpc_exporter_cw_amp_xray_ecs/parameters.tfvars
+++ b/terraform/testcases/otlp_grpc_exporter_cw_amp_xray_ecs/parameters.tfvars
@@ -5,4 +5,4 @@ soaking_data_mode = "trace"
 
 sample_app = "spark"
 
-
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"

--- a/terraform/testcases/otlp_grpc_exporter_cw_amp_xray_ecs_awsprw/parameters.tfvars
+++ b/terraform/testcases/otlp_grpc_exporter_cw_amp_xray_ecs_awsprw/parameters.tfvars
@@ -5,4 +5,4 @@ soaking_data_mode = "trace"
 
 sample_app = "spark"
 
-
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"

--- a/terraform/testcases/otlp_metric/parameters.tfvars
+++ b/terraform/testcases/otlp_metric/parameters.tfvars
@@ -2,3 +2,4 @@ validation_config = "spark-otel-metric-validation.yml"
 
 sample_app = "spark"
 
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"

--- a/terraform/testcases/otlp_metric_adot_operator/parameters.tfvars
+++ b/terraform/testcases/otlp_metric_adot_operator/parameters.tfvars
@@ -2,4 +2,6 @@ validation_config = "spark-otel-metric-validation.yml"
 
 sample_app = "spark"
 
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
+
 eks_cluster_name = "adot-op-cluster"

--- a/terraform/testcases/otlp_metric_amp/parameters.tfvars
+++ b/terraform/testcases/otlp_metric_amp/parameters.tfvars
@@ -5,3 +5,5 @@ validation_config = "otlp-prometheus-validation.yml"
 soaking_data_mode = "metric"
 
 sample_app = "spark"
+
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"

--- a/terraform/testcases/otlp_metric_amp_awsprw/parameters.tfvars
+++ b/terraform/testcases/otlp_metric_amp_awsprw/parameters.tfvars
@@ -5,3 +5,5 @@ validation_config = "otlp-prometheus-validation.yml"
 soaking_data_mode = "metric"
 
 sample_app = "spark"
+
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"

--- a/terraform/testcases/otlp_trace/parameters.tfvars
+++ b/terraform/testcases/otlp_trace/parameters.tfvars
@@ -4,3 +4,5 @@ validation_config = "spark-otel-trace-validation.yml"
 soaking_data_mode = "trace"
 
 sample_app = "spark"
+
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"

--- a/terraform/testcases/otlp_trace_adot_operator/parameters.tfvars
+++ b/terraform/testcases/otlp_trace_adot_operator/parameters.tfvars
@@ -7,3 +7,4 @@ eks_cluster_name = "adot-op-cluster"
 
 sample_app = "spark"
 
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"

--- a/terraform/testcases/otlp_trace_resourcedetection_ec2/parameters.tfvars
+++ b/terraform/testcases/otlp_trace_resourcedetection_ec2/parameters.tfvars
@@ -5,3 +5,4 @@ soaking_data_mode = "trace"
 
 sample_app = "spark"
 
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"

--- a/terraform/testcases/otlp_trace_resourcedetection_ecs/parameters.tfvars
+++ b/terraform/testcases/otlp_trace_resourcedetection_ecs/parameters.tfvars
@@ -4,3 +4,5 @@ validation_config = "spark-otel-trace-ecs-validation.yml"
 soaking_data_mode = "trace"
 
 sample_app = "spark"
+
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"

--- a/terraform/testcases/otlp_trace_resourcedetection_eks/parameters.tfvars
+++ b/terraform/testcases/otlp_trace_resourcedetection_eks/parameters.tfvars
@@ -4,3 +4,5 @@ validation_config = "spark-otel-trace-eks-validation.yml"
 soaking_data_mode = "trace"
 
 sample_app = "spark"
+
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"


### PR DESCRIPTION
Reverts aws-observability/aws-otel-test-framework#647

Spark sample app needs to match with other test cases. Currently Spark sample app is published on merge to main in `aws-otel-java-instrumentation`. 

While this will update the sample app to  use the `latest` tag this may not be the best `tag` to target going forward. When a new image is published a `latest` tag and a tag for the `java-instrumentation` commit sha is published. We should instead be targetting the commit sha to avoid version drift in release branches. 