### PR TITLE
Changed cert-manager version to v1.8.1

### DIFF
--- a/terraform/eks_adot_operator_cluster_setup/main.tf
+++ b/terraform/eks_adot_operator_cluster_setup/main.tf
@@ -153,7 +153,7 @@ resource "helm_release" "adot-operator-cert-manager" {
 
   repository = "https://charts.jetstack.io"
   chart      = "cert-manager"
-  version    = "v1.4.3"
+  version    = "v1.8.1"
 
   create_namespace = true
 


### PR DESCRIPTION
**Description:** 

From operator version v0.52.0, the cert-manager should be in version v1. This PR updates the cert-manager helm chart to the latest version to follow this requirement 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

