### PR TITLE
Revert #725 and update ADOT Operator test cases

### DIFF
--- a/terraform/testcases/otlp_grpc_exporter_cw_amp_xray_ecs/parameters.tfvars
+++ b/terraform/testcases/otlp_grpc_exporter_cw_amp_xray_ecs/parameters.tfvars
@@ -5,4 +5,4 @@ soaking_data_mode = "trace"
 
 sample_app = "spark"
 
-sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
+

--- a/terraform/testcases/otlp_grpc_exporter_cw_amp_xray_ecs_awsprw/parameters.tfvars
+++ b/terraform/testcases/otlp_grpc_exporter_cw_amp_xray_ecs_awsprw/parameters.tfvars
@@ -5,4 +5,4 @@ soaking_data_mode = "trace"
 
 sample_app = "spark"
 
-sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
+

--- a/terraform/testcases/otlp_metric/parameters.tfvars
+++ b/terraform/testcases/otlp_metric/parameters.tfvars
@@ -2,4 +2,3 @@ validation_config = "spark-otel-metric-validation.yml"
 
 sample_app = "spark"
 
-sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"

--- a/terraform/testcases/otlp_metric_adot_operator/parameters.tfvars
+++ b/terraform/testcases/otlp_metric_adot_operator/parameters.tfvars
@@ -2,6 +2,4 @@ validation_config = "spark-otel-metric-validation.yml"
 
 sample_app = "spark"
 
-sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
-
 eks_cluster_name = "adot-op-cluster"

--- a/terraform/testcases/otlp_metric_adot_operator/parameters.tfvars
+++ b/terraform/testcases/otlp_metric_adot_operator/parameters.tfvars
@@ -2,4 +2,6 @@ validation_config = "spark-otel-metric-validation.yml"
 
 sample_app = "spark"
 
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
+
 eks_cluster_name = "adot-op-cluster"

--- a/terraform/testcases/otlp_metric_amp/parameters.tfvars
+++ b/terraform/testcases/otlp_metric_amp/parameters.tfvars
@@ -5,5 +5,3 @@ validation_config = "otlp-prometheus-validation.yml"
 soaking_data_mode = "metric"
 
 sample_app = "spark"
-
-sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"

--- a/terraform/testcases/otlp_metric_amp_awsprw/parameters.tfvars
+++ b/terraform/testcases/otlp_metric_amp_awsprw/parameters.tfvars
@@ -5,5 +5,3 @@ validation_config = "otlp-prometheus-validation.yml"
 soaking_data_mode = "metric"
 
 sample_app = "spark"
-
-sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"

--- a/terraform/testcases/otlp_trace/parameters.tfvars
+++ b/terraform/testcases/otlp_trace/parameters.tfvars
@@ -4,5 +4,3 @@ validation_config = "spark-otel-trace-validation.yml"
 soaking_data_mode = "trace"
 
 sample_app = "spark"
-
-sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"

--- a/terraform/testcases/otlp_trace_adot_operator/parameters.tfvars
+++ b/terraform/testcases/otlp_trace_adot_operator/parameters.tfvars
@@ -7,4 +7,3 @@ eks_cluster_name = "adot-op-cluster"
 
 sample_app = "spark"
 
-sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"

--- a/terraform/testcases/otlp_trace_adot_operator/parameters.tfvars
+++ b/terraform/testcases/otlp_trace_adot_operator/parameters.tfvars
@@ -7,3 +7,5 @@ eks_cluster_name = "adot-op-cluster"
 
 sample_app = "spark"
 
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
+

--- a/terraform/testcases/otlp_trace_resourcedetection_ec2/parameters.tfvars
+++ b/terraform/testcases/otlp_trace_resourcedetection_ec2/parameters.tfvars
@@ -5,4 +5,3 @@ soaking_data_mode = "trace"
 
 sample_app = "spark"
 
-sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"

--- a/terraform/testcases/otlp_trace_resourcedetection_ecs/parameters.tfvars
+++ b/terraform/testcases/otlp_trace_resourcedetection_ecs/parameters.tfvars
@@ -4,5 +4,3 @@ validation_config = "spark-otel-trace-ecs-validation.yml"
 soaking_data_mode = "trace"
 
 sample_app = "spark"
-
-sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"

--- a/terraform/testcases/otlp_trace_resourcedetection_eks/parameters.tfvars
+++ b/terraform/testcases/otlp_trace_resourcedetection_eks/parameters.tfvars
@@ -4,5 +4,3 @@ validation_config = "spark-otel-trace-eks-validation.yml"
 soaking_data_mode = "trace"
 
 sample_app = "spark"
-
-sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"


### PR DESCRIPTION
**Description:** 

#725 resulted in the CI workflow to fail a lot of its test-cases. This PR reverts the `test-cases` to use an older version of the `spark sample app` and also updates the ADOT Operator tests to use the latest version of the sample app

This PR is a temporary fix to fix the CI workflow. Further evaluation of the latest spark sample app in is progress. The issue is tracked [here](https://github.com/aws-observability/aws-otel-java-instrumentation/issues/187)
<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

