### PR TITLE
Fix jaeger/zipkin mock configs

### DIFF
--- a/terraform/testcases/jaeger_mock/otconfig.tpl
+++ b/terraform/testcases/jaeger_mock/otconfig.tpl
@@ -20,7 +20,6 @@ exporters:
 
 
 service:
-  extensions:
   pipelines:
     traces:
       receivers: [jaeger]

--- a/terraform/testcases/zipkin_mock/otconfig.tpl
+++ b/terraform/testcases/zipkin_mock/otconfig.tpl
@@ -18,7 +18,6 @@ exporters:
 
 
 service:
-  extensions:
   pipelines:
     traces:
       receivers: [zipkin]


### PR DESCRIPTION
Signed-off-by: Anthony J Mirabella <a9@aneurysm9.com>

**Description:** Fixes duplicate key errors in mock collector configs that now result in config resolution failure.

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

