### PR TITLE
Add test cases for Coralogix exporter

### DIFF
--- a/terraform/testcases/coralogix_exporter_metrics_mock/otconfig.tpl
+++ b/terraform/testcases/coralogix_exporter_metrics_mock/otconfig.tpl
@@ -1,0 +1,35 @@
+extensions:
+  pprof:
+    endpoint: 0.0.0.0:1777
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:${grpc_port}
+
+processors:
+  batch:
+
+exporters:
+  logging:
+    loglevel: debug
+  coralogix:
+    endpoint: "${mock_endpoint}"
+    metrics:
+      endpoint: "${mock_endpoint}"
+      compression: none
+      tls:
+        insecure: true
+    private_key: "e83138ae-fe21-11ec-b939-0242ac120002"
+    application_name: "APP_NAME"
+    subsystem_name: "SUBSYSTEM"
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [coralogix]
+  extensions: [pprof]
+  telemetry:
+    logs:
+      level: debug

--- a/terraform/testcases/coralogix_exporter_metrics_mock/parameters.tfvars
+++ b/terraform/testcases/coralogix_exporter_metrics_mock/parameters.tfvars
@@ -1,0 +1,9 @@
+# data type will be emitted. Possible values: metric or trace
+soaking_data_mode = "metric"
+
+sample_app = "spark"
+
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
+
+mocked_server = "grpc_metrics"
+mock_endpoint = "mocked-server:55671"


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Enable Coralogix exporter metrics integration test case

**Link to tracking Issue:** <Issue number if applicable>

Ref: https://github.com/aws-observability/aws-otel-collector/pull/1358
**Testing:** <Describe what testing was performed and which tests were added.>

Testing:

Tested on local with aws-otel-test-framework
```
cd terraform/mock; terraform init && terraform apply -var="testcase=../testcases/coralogix_exporter_metrics_mock"
```

**Documentation:** <Describe the documentation added.>

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

