### PR TITLE
Change Operator repository and tag to variables

### DIFF
--- a/terraform/eks/adot-operator/adot-operator-values.yaml
+++ b/terraform/eks/adot-operator/adot-operator-values.yaml
@@ -1,8 +1,3 @@
-manager:
-  image:
-    repository: public.ecr.aws/aws-observability/adot-operator
-    tag: "latest"
-
 kubeRBACProxy:
   image:
     repository: public.ecr.aws/aws-observability/mirror-kube-rbac-proxy

--- a/terraform/eks/adot-operator/adot_operator.tf
+++ b/terraform/eks/adot-operator/adot_operator.tf
@@ -42,13 +42,13 @@ resource "helm_release" "adot-operator" {
   ]
 
   set {
-    name = "manager.image.repository"
-    value = "${var.operator_repository}"
+    name  = "manager.image.repository"
+    value = var.operator_repository
   }
 
   set {
-    name = "manager.image.tag"
-    value = "${var.operator_tag}"
+    name  = "manager.image.tag"
+    value = var.operator_tag
   }
 
   provisioner "local-exec" {

--- a/terraform/eks/adot-operator/adot_operator.tf
+++ b/terraform/eks/adot-operator/adot_operator.tf
@@ -23,6 +23,14 @@ variable "kubeconfig" {
   default = "kubeconfig"
 }
 
+variable "operator_repository" {
+  default = "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator"
+}
+
+variable "operator_tag" {
+  default = "latest"
+}
+
 resource "helm_release" "adot-operator" {
   name = "adot-operator-${var.testing_id}"
 
@@ -32,6 +40,16 @@ resource "helm_release" "adot-operator" {
   values = [
     file("./adot-operator/adot-operator-values.yaml")
   ]
+
+  set {
+    name = "manager.image.repository"
+    value = "${var.operator_repository}"
+  }
+
+  set {
+    name = "manager.image.tag"
+    value = "${var.operator_tag}"
+  }
 
   provisioner "local-exec" {
     command = "kubectl wait --kubeconfig=${var.kubeconfig} --timeout=5m --for=condition=available deployment opentelemetry-operator-controller-manager"


### PR DESCRIPTION
**Description:** <Describe what has changed.>
This PR changes the way operator images are set during the helm chart deployment and allows for it to be set as a variable.

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

