### PR TITLE
Specify /traces tag in logzio exporter

### DIFF
--- a/terraform/testcases/logzio_exporter_trace_mock/otconfig.tpl
+++ b/terraform/testcases/logzio_exporter_trace_mock/otconfig.tpl
@@ -15,7 +15,7 @@ exporters:
     loglevel: debug
   logzio/traces:
     account_token: testToken
-    custom_endpoint: "https://${mock_endpoint}"
+    endpoint: "https://${mock_endpoint}"
 
 service:
   pipelines:

--- a/terraform/testcases/logzio_exporter_trace_mock/otconfig.tpl
+++ b/terraform/testcases/logzio_exporter_trace_mock/otconfig.tpl
@@ -13,7 +13,7 @@ processors:
 exporters:
   logging:
     loglevel: debug
-  logzio:
+  logzio/traces:
     account_token: testToken
     custom_endpoint: "https://${mock_endpoint}"
 


### PR DESCRIPTION
**Description:** 

The upstream collector-contrib repo for release `v0.55.0` has introduced `logging` as a beta feature in the `Logzio Exporter`. This will require us to specify `/traces` along side `logzio` in the `.tpl` file. Example can be found [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/10821/files#diff-9d7048cfbb1ef8e4d2f802df4da56d88542d9d4047e348efd74c49ddf854ee90)

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

