### PR TITLE
Added AMI Ids for Canary linux and Canary Windows Tests

### DIFF
--- a/terraform/canary/amis.tf
+++ b/terraform/canary/amis.tf
@@ -54,6 +54,7 @@ variable "amis" {
       os_family          = "windows"
       ami_search_pattern = "Windows_Server-2019-English-Full-Base-*"
       ami_owner          = "amazon"
+      ami_id             = "ami-0297fbf7e83dd1209"
       ami_product_code   = []
       family             = "windows"
       arch               = "amd64"
@@ -62,6 +63,7 @@ variable "amis" {
       os_family          = "amazon_linux"
       ami_search_pattern = "amzn2-ami-hvm-2.0.????????.?-x86_64-gp2"
       ami_owner          = "amazon"
+      ami_id             = "ami-0d08ef957f0e4722b"
       ami_product_code   = []
       family             = "amazon_linux"
       arch               = "amd64"

--- a/terraform/ec2/amis.tf
+++ b/terraform/ec2/amis.tf
@@ -391,6 +391,24 @@ EOF
 sudo snap refresh amazon-ssm-agent
 EOF
     }
+    canary_windows = {
+      os_family          = "windows"
+      ami_search_pattern = "Windows_Server-2019-English-Full-Base-*"
+      ami_owner          = "amazon"
+      ami_id             = "ami-0297fbf7e83dd1209"
+      ami_product_code   = []
+      family             = "windows"
+      arch               = "amd64"
+    }
+    canary_linux = {
+      os_family          = "amazon_linux"
+      ami_search_pattern = "amzn2-ami-hvm-2.0.????????.?-x86_64-gp2"
+      ami_owner          = "amazon"
+      ami_id             = "ami-0d08ef957f0e4722b"
+      ami_product_code   = []
+      family             = "amazon_linux"
+      arch               = "amd64"
+    }
   }
 }
 


### PR DESCRIPTION
**Description:** 

This PR fixes the the failing canary tests after #755. This was because the `canary_linux` and `canary_windows ` didn't have their respective `ami_id`

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

