### PR TITLE
Locking AMI ID for Performance and Soaking tests

### DIFF
--- a/terraform/canary/amis.tf
+++ b/terraform/canary/amis.tf
@@ -54,6 +54,7 @@ variable "amis" {
       os_family          = "windows"
       ami_search_pattern = "Windows_Server-2019-English-Full-Base-*"
       ami_owner          = "amazon"
+      ami_id             = "ami-0297fbf7e83dd1209"
       ami_product_code   = []
       family             = "windows"
       arch               = "amd64"
@@ -62,6 +63,7 @@ variable "amis" {
       os_family          = "amazon_linux"
       ami_search_pattern = "amzn2-ami-hvm-2.0.????????.?-x86_64-gp2"
       ami_owner          = "amazon"
+      ami_id             = "ami-0d08ef957f0e4722b"
       ami_product_code   = []
       family             = "amazon_linux"
       arch               = "amd64"

--- a/terraform/ec2/amis.tf
+++ b/terraform/ec2/amis.tf
@@ -391,6 +391,24 @@ EOF
 sudo snap refresh amazon-ssm-agent
 EOF
     }
+    canary_windows = {
+      os_family          = "windows"
+      ami_search_pattern = "Windows_Server-2019-English-Full-Base-*"
+      ami_owner          = "amazon"
+      ami_id             = "ami-0297fbf7e83dd1209"
+      ami_product_code   = []
+      family             = "windows"
+      arch               = "amd64"
+    }
+    canary_linux = {
+      os_family          = "amazon_linux"
+      ami_search_pattern = "amzn2-ami-hvm-2.0.????????.?-x86_64-gp2"
+      ami_owner          = "amazon"
+      ami_id             = "ami-0d08ef957f0e4722b"
+      ami_product_code   = []
+      family             = "amazon_linux"
+      arch               = "amd64"
+    }
   }
 }
 

--- a/terraform/ec2/amis.tf
+++ b/terraform/ec2/amis.tf
@@ -391,6 +391,7 @@ EOF
 sudo snap refresh amazon-ssm-agent
 EOF
     }
+    # AMIs for Canary tests
     canary_windows = {
       os_family          = "windows"
       ami_search_pattern = "Windows_Server-2019-English-Full-Base-*"
@@ -401,6 +402,24 @@ EOF
       arch               = "amd64"
     }
     canary_linux = {
+      os_family          = "amazon_linux"
+      ami_search_pattern = "amzn2-ami-hvm-2.0.????????.?-x86_64-gp2"
+      ami_owner          = "amazon"
+      ami_id             = "ami-0d08ef957f0e4722b"
+      ami_product_code   = []
+      family             = "amazon_linux"
+      arch               = "amd64"
+    }
+    soaking_windows = {
+      os_family          = "windows"
+      ami_search_pattern = "Windows_Server-2019-English-Full-Base-*"
+      ami_owner          = "amazon"
+      ami_id             = "ami-0297fbf7e83dd1209"
+      ami_product_code   = []
+      family             = "windows"
+      arch               = "amd64"
+    }
+    soaking_linux = {
       os_family          = "amazon_linux"
       ami_search_pattern = "amzn2-ami-hvm-2.0.????????.?-x86_64-gp2"
       ami_owner          = "amazon"

--- a/terraform/ec2/amis.tf
+++ b/terraform/ec2/amis.tf
@@ -410,6 +410,7 @@ EOF
       family             = "amazon_linux"
       arch               = "amd64"
     }
+    # AMIs for performance and Soaking tests
     soaking_windows = {
       os_family          = "windows"
       ami_search_pattern = "Windows_Server-2019-English-Full-Base-*"

--- a/terraform/ec2_setup/amis.tf
+++ b/terraform/ec2_setup/amis.tf
@@ -66,6 +66,7 @@ variable "amis" {
       os_family          = "windows"
       ami_search_pattern = "Windows_Server-2019-English-Full-Base-*"
       ami_owner          = "amazon"
+      ami_id             = "ami-0297fbf7e83dd1209"
       ami_product_code   = []
       family             = "windows"
       arch               = "amd64"
@@ -74,6 +75,7 @@ variable "amis" {
       os_family          = "amazon_linux"
       ami_search_pattern = "amzn2-ami-hvm-2.0.????????.?-x86_64-gp2"
       ami_owner          = "amazon"
+      ami_id             = "ami-0d08ef957f0e4722b"
       ami_product_code   = []
       family             = "amazon_linux"
       arch               = "amd64"


### PR DESCRIPTION
**Description:** 

This PR is a follow up to #755 and #773 where we lock in the AMI Ids for performance and soaking tests.

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

