### PR TITLE
Updating the Canary Windows AMI IDs

### DIFF
--- a/terraform/canary/amis.tf
+++ b/terraform/canary/amis.tf
@@ -54,7 +54,7 @@ variable "amis" {
       os_family          = "windows"
       ami_search_pattern = "Windows_Server-2019-English-Full-Base-*"
       ami_owner          = "amazon"
-      ami_id             = "ami-0297fbf7e83dd1209"
+      ami_id             = "ami-01f14dc60171d8d7b"
       ami_product_code   = []
       family             = "windows"
       arch               = "amd64"

--- a/terraform/ec2/amis.tf
+++ b/terraform/ec2/amis.tf
@@ -395,7 +395,7 @@ EOF
       os_family          = "windows"
       ami_search_pattern = "Windows_Server-2019-English-Full-Base-*"
       ami_owner          = "amazon"
-      ami_id             = "ami-0297fbf7e83dd1209"
+      ami_id             = "ami-01f14dc60171d8d7b"
       ami_product_code   = []
       family             = "windows"
       arch               = "amd64"
@@ -413,7 +413,7 @@ EOF
       os_family          = "windows"
       ami_search_pattern = "Windows_Server-2019-English-Full-Base-*"
       ami_owner          = "amazon"
-      ami_id             = "ami-0297fbf7e83dd1209"
+      ami_id             = "ami-01f14dc60171d8d7b"
       ami_product_code   = []
       family             = "windows"
       arch               = "amd64"


### PR DESCRIPTION
**Description:** 

After #773 the canary tests started getting flaky. The [failures](https://github.com/aws-observability/aws-otel-collector/actions/workflows/canary.yml?page=4) seems to be associated with the `canary_window` tests. This seems to be because of using a different AMI ID to the one used [before](https://github.com/aws-observability/aws-otel-collector/runs/7448776796?check_suite_focus=true#step:8:1331) the PR change. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

