### PR TITLE
Changed method of setting `eks_cluster_name` for Operator tests, + other terraform variables

### DIFF
--- a/terraform/executeTerraformCleanup.sh
+++ b/terraform/executeTerraformCleanup.sh
@@ -35,21 +35,22 @@ service="$1"
 export AWS_REGION=us-west-2
 case "$service" in
     "EC2") TEST_FOLDER="./ec2/";
-        export TF_VAR_testing_ami=$3;
+        opts+=" -var=testing_ami=$3";
     ;;
     "EKS") TEST_FOLDER="./eks/";
     ;;
     "EKS_ARM64") TEST_FOLDER="./eks/"
         arm_64_region=$(echo $3 | cut -d \| -f 1);
-        export AWS_REGION=${arm_64_region}
-        export TF_VAR_region=${arm_64_region}
+        export AWS_REGION=${arm_64_region};
+        opts+=" -var=region=${arm_64_region}";
     ;;
     "EKS_FARGATE") TEST_FOLDER="./eks/";
     ;;
     "EKS_ADOT_OPERATOR") TEST_FOLDER="./eks/";
+        opts+=" -var=eks_cluster_name=adot-op-cluster";
     ;;
     "ECS") TEST_FOLDER="./ecs/";
-        export TF_VAR_ecs_launch_type=$3;
+        opts+=" -var=ecs_launch_type=$3";
     ;;
     *)
     echo "service ${service} is not valid";

--- a/terraform/executeTerraformTest.sh
+++ b/terraform/executeTerraformTest.sh
@@ -37,7 +37,7 @@ service="$1"
 export AWS_REGION=us-west-2
 case "$service" in
     "EC2") TEST_FOLDER="./ec2/";
-        export TF_VAR_testing_ami=$3;
+        opts+=" -var=testing_ami=$3";
     ;;
     "EKS") TEST_FOLDER="./eks/";
     ;;
@@ -45,17 +45,18 @@ case "$service" in
         arm_64_region=$(echo $3 | cut -d \| -f 1);
         arm_64_clustername=$(echo $3 | cut -d \| -f 2);
         arm_64_amp=$(echo $3 | cut -d \| -f 3);
-        export AWS_REGION=${arm_64_region}
-        export TF_VAR_region=${arm_64_region}
-        export TF_VAR_cortex_instance_endpoint=${arm_64_amp}
-        export TF_VAR_eks_cluster_name=${arm_64_clustername}
+        export AWS_REGION=${arm_64_region};
+        opts+=" -var=region=${arm_64_region}";
+        opts+=" -var=cortex_instance_endpoint=${arm_64_amp}";
+        opts+=" -var=eks_cluster_name=${arm_64_clustername}";
     ;;
     "EKS_FARGATE") TEST_FOLDER="./eks/";
     ;;
     "EKS_ADOT_OPERATOR") TEST_FOLDER="./eks/";
+        opts+=" -var=eks_cluster_name=adot-op-cluster";
     ;;
     "ECS") TEST_FOLDER="./ecs/";
-        export TF_VAR_ecs_launch_type=$3;
+        opts+=" -var=ecs_launch_type=$3";
     ;;
     *)
     echo "service ${service} is not valid";

--- a/terraform/testcases/otlp_metric_adot_operator/parameters.tfvars
+++ b/terraform/testcases/otlp_metric_adot_operator/parameters.tfvars
@@ -3,5 +3,3 @@ validation_config = "spark-otel-metric-validation.yml"
 sample_app = "spark"
 
 sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
-
-eks_cluster_name = "adot-op-cluster"

--- a/terraform/testcases/otlp_trace_adot_operator/parameters.tfvars
+++ b/terraform/testcases/otlp_trace_adot_operator/parameters.tfvars
@@ -3,9 +3,6 @@ validation_config = "spark-otel-trace-validation.yml"
 # data type will be emitted. Possible values: metric or trace
 soaking_data_mode = "trace"
 
-eks_cluster_name = "adot-op-cluster"
-
 sample_app = "spark"
 
 sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
-

--- a/terraform/testcases/prometheus_sd_adot_operator/parameters.tfvars
+++ b/terraform/testcases/prometheus_sd_adot_operator/parameters.tfvars
@@ -4,5 +4,3 @@ validation_config = "prometheus-sd-validation.yml"
 sample_app = "prometheus"
 
 sample_app_mode = "pull"
-
-eks_cluster_name = "adot-op-cluster"

--- a/terraform/testcases/prometheus_sd_adot_operator_awsprw/parameters.tfvars
+++ b/terraform/testcases/prometheus_sd_adot_operator_awsprw/parameters.tfvars
@@ -4,5 +4,3 @@ validation_config = "prometheus-sd-validation.yml"
 sample_app = "prometheus"
 
 sample_app_mode = "pull"
-
-eks_cluster_name = "adot-op-cluster"

--- a/terraform/testcases/prometheus_static_adot_operator/parameters.tfvars
+++ b/terraform/testcases/prometheus_static_adot_operator/parameters.tfvars
@@ -6,5 +6,3 @@ sample_app = "prometheus"
 soaking_data_type = "prometheus"
 
 sample_app_mode = "pull"
-
-eks_cluster_name = "adot-op-cluster"

--- a/terraform/testcases/prometheus_static_adot_operator_awsprw/parameters.tfvars
+++ b/terraform/testcases/prometheus_static_adot_operator_awsprw/parameters.tfvars
@@ -6,5 +6,3 @@ sample_app = "prometheus"
 soaking_data_type = "prometheus"
 
 sample_app_mode = "pull"
-
-eks_cluster_name = "adot-op-cluster"


### PR DESCRIPTION
**Description:** <Describe what has changed.>
This PR removes the definition of `eks_cluster_name` for operator tests, and instead sets `eks_cluster_name` in a `-var` option. This is to prepare for the addition of ARM64 Operator tests, which introduces another cluster where Operator tests can be run. `eks_cluster_name` is set for Operator tests in the terraform test script, and #767 will set `eks_cluster_name` for ARM64 Operator tests in the same script. Additionally, usage of exporting environment variables to set terraform variables has been changed to use the `-var` option for consistency.

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

