### PR TITLE
Add EKS_ARM64 to non parallel test set

### DIFF
--- a/tools/batchTestGenerator/internal/githubGenerator.go
+++ b/tools/batchTestGenerator/internal/githubGenerator.go
@@ -63,6 +63,7 @@ func createBatchMap(maxBatches int, testCases []TestCaseInfo) (map[string][]stri
 		"EKS_ADOT_OPERATOR":       {},
 		"EKS_ADOT_OPERATOR_ARM64": {},
 		"EKS_FARGATE":             {},
+		"EKS_ARM64":               {},
 	}
 
 	if numBatches == 1 {


### PR DESCRIPTION
**Description:** Adds `EKS_ARM64` test types to nonParallelTestSet struct. This will ensure that all `EKS_ARM64` tests are ran synchronously. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

