### PR TITLE
Adding code to allow multi-arch imagebuild

### DIFF
--- a/docs/run-testing-framework.md
+++ b/docs/run-testing-framework.md
@@ -75,6 +75,8 @@ this task will build and push the sample apps and mocked server images to the ec
 
 Remember, if you have changes on sample apps or the mocked server, you need to rerun this imagebuild task.
 
+Note: imagebuild publishes multi-arch images to ECR that are compatible with linux/amd64 and linux/amr64 architectures.
+
 #### 2.1.4 Share Setup resources (Optional)
 **Prerequisite:**
 - you are required to run the [setup basic components](setup-basic-components-in-aws-account.md#2-setup-basic-components) once if you and other developers did not setup these components before.

--- a/docs/run-testing-framework.md
+++ b/docs/run-testing-framework.md
@@ -75,8 +75,6 @@ this task will build and push the sample apps and mocked server images to the ec
 
 Remember, if you have changes on sample apps or the mocked server, you need to rerun this imagebuild task.
 
-Note: Before building the sample apps and mocked server images, you may need to update variable `platform_os` at `/terraform/imagebuild/common.auto.tf` in accordance with the infrastructure's operating system/architecture where the test-suite is deployed. This is required to allow multi-arch image build.
-
 #### 2.1.4 Share Setup resources (Optional)
 **Prerequisite:**
 - you are required to run the [setup basic components](setup-basic-components-in-aws-account.md#2-setup-basic-components) once if you and other developers did not setup these components before.

--- a/docs/run-testing-framework.md
+++ b/docs/run-testing-framework.md
@@ -72,8 +72,10 @@ cd terraform/imagebuild && terraform init && terraform apply -auto-approve
 ````
 this task will build and push the sample apps and mocked server images to the ecr repos,
  so that the following test could use them.
- 
+
 Remember, if you have changes on sample apps or the mocked server, you need to rerun this imagebuild task.
+
+Note: Before building the sample apps and mocked server images, you may need to update variable `platform_os` at `/terraform/imagebuild/common.auto.tf` in accordance with the infrastructure's operating system/architecture where the test-suite is deployed. This is required to allow multi-arch image build.
 
 #### 2.1.4 Share Setup resources (Optional)
 **Prerequisite:**

--- a/terraform/common.tf
+++ b/terraform/common.tf
@@ -83,7 +83,3 @@ variable "aoc_vpc_name" {
 variable "aoc_vpc_security_group" {
   default = "aoc-vpc-security-group"
 }
-
-variable "platform_arch" {
-  default = "linux/amd64"
-}

--- a/terraform/common.tf
+++ b/terraform/common.tf
@@ -83,3 +83,7 @@ variable "aoc_vpc_name" {
 variable "aoc_vpc_security_group" {
   default = "aoc-vpc-security-group"
 }
+
+variable "platform_arch" {
+  default = "linux/amd64"
+}

--- a/terraform/imagebuild/main.tf
+++ b/terraform/imagebuild/main.tf
@@ -56,7 +56,7 @@ resource "null_resource" "build_and_push_sample_apps" {
   count = length(local.sample_apps_dockerfile_list)
 
   provisioner "local-exec" {
-    command = "docker build -t ${data.aws_ecr_repository.sample_app.repository_url}:${dirname(element(local.sample_apps_dockerfile_list, count.index))}-latest ../../sample-apps/${dirname(element(local.sample_apps_dockerfile_list, count.index))}/"
+    command = "docker buildx build --platform ${var.platform_arch} -t ${data.aws_ecr_repository.sample_app.repository_url}:${dirname(element(local.sample_apps_dockerfile_list, count.index))}-latest ../../sample-apps/${dirname(element(local.sample_apps_dockerfile_list, count.index))}/"
   }
 
   provisioner "local-exec" {
@@ -71,7 +71,7 @@ resource "null_resource" "build_and_push_mocked_server" {
   count = length(local.mocked_servers_dockerfile_list)
 
   provisioner "local-exec" {
-    command = "docker build -t ${data.aws_ecr_repository.mocked_server.repository_url}:${dirname(element(local.mocked_servers_dockerfile_list, count.index))}-latest ../../mocked_servers/${dirname(element(local.mocked_servers_dockerfile_list, count.index))}/"
+    command = "docker buildx build --platform ${var.platform_arch} -t ${data.aws_ecr_repository.mocked_server.repository_url}:${dirname(element(local.mocked_servers_dockerfile_list, count.index))}-latest ../../mocked_servers/${dirname(element(local.mocked_servers_dockerfile_list, count.index))}/"
   }
 
   provisioner "local-exec" {


### PR DESCRIPTION
**Description:** <Describe what has changed.>
This PR allows multi-arch docker image build for sample apps and mocked servers. This is required to run this testsuite from new darwin/ARM64 systems.



<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

