### PR TITLE
Update adot-operator values file for kube rbac ver

### DIFF
--- a/terraform/eks/adot-operator/adot-operator-values.yaml
+++ b/terraform/eks/adot-operator/adot-operator-values.yaml
@@ -1,4 +1,4 @@
 kubeRBACProxy:
   image:
     repository: public.ecr.aws/aws-observability/mirror-kube-rbac-proxy
-    tag: "v0.8.0"
+    tag: "v0.13.0"


### PR DESCRIPTION
**Description:** Updates the kube-rbac version used for adot-operator installs. `v0.8.0` caused the operator to fail installation on `arm-64` based node groups. 

**testing:** tested on arm-64 based dev cluster. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

