### PR TITLE
Add IAM role to eks testservice account

### DIFF
--- a/terraform/eks/main.tf
+++ b/terraform/eks/main.tf
@@ -155,8 +155,12 @@ resource "kubernetes_service_account" "aoc-role" {
   metadata {
     name      = "aoc-role-${module.common.testing_id}"
     namespace = kubernetes_namespace.aoc_ns.metadata[0].name
+    annotations = {
+      "eks.amazonaws.com/role-arn" : module.iam_assumable_role_admin.iam_role_arn
+    }
   }
 
+  depends_on                      = [module.iam_assumable_role_admin]
   automount_service_account_token = true
 }
 
@@ -185,6 +189,8 @@ module "iam_assumable_role_admin" {
     "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy",
     "arn:aws:iam::aws:policy/AWSXrayFullAccess",
     "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess",
+    "arn:aws:iam::aws:policy/AmazonPrometheusRemoteWriteAccess",
+    "arn:aws:iam::aws:policy/AWSAppMeshEnvoyAccess",
   ]
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
   version = "4.7.0"


### PR DESCRIPTION
**Description:** Adds IAM policies to allow the test workers to exporter data off of cluster and into storage back end by utilizing IRSA. Removes need to attach policies during cluster creation time.

**Testing:** 
Tested on local dev cluster with default ec2 worker node IAM Policies. Enabled OIDC on cluster by using eksctl. Tested with `otlp_metric_adot_operator` test case. 
I also [verified](https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html) that existing test cluster (arm64-adot-operator) has OIDC provider. 


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

