### PR TITLE
Fix Operator image repo/tag variable usage

### DIFF
--- a/terraform/eks/adot-operator/adot_operator.tf
+++ b/terraform/eks/adot-operator/adot_operator.tf
@@ -24,11 +24,9 @@ variable "kubeconfig" {
 }
 
 variable "operator_repository" {
-  default = "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator"
 }
 
 variable "operator_tag" {
-  default = "latest"
 }
 
 resource "helm_release" "adot-operator" {

--- a/terraform/eks/main.tf
+++ b/terraform/eks/main.tf
@@ -223,10 +223,10 @@ module "adot_operator" {
   count  = replace(var.testcase, "_adot_operator", "") == var.testcase ? 0 : 1
   source = "./adot-operator"
 
-  testing_id = module.common.testing_id
-  kubeconfig = local_file.kubeconfig.filename
+  testing_id          = module.common.testing_id
+  kubeconfig          = local_file.kubeconfig.filename
   operator_repository = var.operator_repository
-  operator_tag = var.operator_tag
+  operator_tag        = var.operator_tag
 }
 
 

--- a/terraform/eks/main.tf
+++ b/terraform/eks/main.tf
@@ -225,6 +225,8 @@ module "adot_operator" {
 
   testing_id = module.common.testing_id
   kubeconfig = local_file.kubeconfig.filename
+  operator_repository = var.operator_repository
+  operator_tag = var.operator_tag
 }
 
 

--- a/terraform/eks/variables.tf
+++ b/terraform/eks/variables.tf
@@ -57,9 +57,11 @@ variable "fargate_sample_app_lb_port" {
 }
 
 variable "operator_repository" {
+  type    = string
   default = "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator"
 }
 
 variable "operator_tag" {
+  type    = string
   default = "latest"
 }

--- a/terraform/eks/variables.tf
+++ b/terraform/eks/variables.tf
@@ -55,3 +55,11 @@ variable "rollup" {
 variable "fargate_sample_app_lb_port" {
   default = "80"
 }
+
+variable "operator_repository" {
+  default = "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator"
+}
+
+variable "operator_tag" {
+  default = "latest"
+}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
This PR fixes how Operator image repo/tag variables are set so that they can be properly overridden with a `TF_VAR_` env variable export in the Operator CI, see [here](https://github.com/aws-observability/aws-otel-collector/blob/main/.github/workflows/CI-Operator.yml#L173). 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

