### PR TITLE
Add opts for `terraform destroy` for arm64 tests

### DIFF
--- a/terraform/executeTerraformCleanup.sh
+++ b/terraform/executeTerraformCleanup.sh
@@ -41,8 +41,12 @@ case "$service" in
     ;;
     "EKS_ARM64") TEST_FOLDER="./eks/"
         arm_64_region=$(echo $3 | cut -d \| -f 1);
+        arm_64_clustername=$(echo $3 | cut -d \| -f 2);
+        arm_64_amp=$(echo $3 | cut -d \| -f 3);
         export AWS_REGION=${arm_64_region};
         opts+=" -var=region=${arm_64_region}";
+        opts+=" -var=cortex_instance_endpoint=${arm_64_amp}";
+        opts+=" -var=eks_cluster_name=${arm_64_clustername}";
     ;;
     "EKS_FARGATE") TEST_FOLDER="./eks/";
     ;;
@@ -63,7 +67,7 @@ esac
 
 
 case "$service" in
-    "EKS_FARGATE" | "EKS_ADOT_OPERATOR" | "EKS_ADOT_OPERATOR_ARM64") terraform destroy --auto-approve $opts;
+    "EKS_FARGATE" | "EKS_ARM64" | "EKS_ADOT_OPERATOR" | "EKS_ADOT_OPERATOR_ARM64") terraform destroy --auto-approve $opts;
     ;;
 *)
     terraform destroy --auto-approve;

--- a/terraform/executeTerraformTest.sh
+++ b/terraform/executeTerraformTest.sh
@@ -91,7 +91,7 @@ while [ $ATTEMPTS_LEFT -gt 0 ] && [ -z "${CACHE_HIT}" ]; do
     fi
 
     case "$service" in
-        "EKS_FARGATE" | "EKS_ADOT_OPERATOR" | "EKS_ADOT_OPERATOR_ARM64") terraform destroy --auto-approve $opts;
+        "EKS_FARGATE" | "EKS_ARM64" | "EKS_ADOT_OPERATOR" | "EKS_ADOT_OPERATOR_ARM64") terraform destroy --auto-approve $opts;
         ;;
     *)
         terraform destroy --auto-approve;


### PR DESCRIPTION
**Description:** <Describe what has changed.>
This PR adds in the same opts for `EKS_ARM64` tests used in `executeTerraformTest.sh` to `executeTerraformCleanup.sh`, and adds `EKS_ARM64` to the list of services that run `terraform destroy` with options. This is to handle improper resource deletion that happens during Collector CI, causing some tests to hang, waiting for an available node to schedule.

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

