### PR TITLE
Use env vars for validator account credentials.

### DIFF
--- a/terraform/canary/main.tf
+++ b/terraform/canary/main.tf
@@ -52,9 +52,6 @@ module "ec2_setup" {
   # install cwagent
   install_cwagent = false
 
-  aws_access_key_id     = var.aws_access_key_id
-  aws_secret_access_key = var.aws_secret_access_key
-
   patch = true
 
   ssm_package_name       = "AWSDistroOTel-Collector"

--- a/terraform/common.tf
+++ b/terraform/common.tf
@@ -38,14 +38,6 @@ variable "aoc_version" {
   default = "latest"
 }
 
-variable "aws_access_key_id" {
-  default = ""
-}
-
-variable "aws_secret_access_key" {
-  default = ""
-}
-
 variable "soaking_metric_namespace" {
   default = "AWSOtelCollector/SoakingTest"
 }

--- a/terraform/ec2/main.tf
+++ b/terraform/ec2/main.tf
@@ -464,9 +464,6 @@ module "validator" {
     instanceType : aws_instance.aoc.instance_type
   })
 
-  aws_access_key_id     = var.aws_access_key_id
-  aws_secret_access_key = var.aws_secret_access_key
-
   depends_on = [null_resource.setup_sample_app_and_mock_server, null_resource.start_collector]
 }
 

--- a/terraform/ecs/main.tf
+++ b/terraform/ecs/main.tf
@@ -335,9 +335,6 @@ module "validator" {
     ecsLaunchType : aws_ecs_service.aoc[0].launch_type
   })
 
-  aws_access_key_id     = var.aws_access_key_id
-  aws_secret_access_key = var.aws_secret_access_key
-
   depends_on = [aws_ecs_service.aoc]
 }
 
@@ -360,9 +357,6 @@ module "validator_without_sample_app" {
 
   cloudwatch_context_json = data.template_file.cloudwatch_context.rendered
 
-  aws_access_key_id     = var.aws_access_key_id
-  aws_secret_access_key = var.aws_secret_access_key
-
   depends_on = [aws_ecs_service.aoc_without_sample_app, aws_ecs_service.extra_apps]
 }
 
@@ -384,8 +378,6 @@ module "validator_without_sample_app_for_bridge" {
     ecsTaskDefVersion : aws_ecs_task_definition.aoc_bridge[0].revision
   })
 
-  aws_access_key_id     = var.aws_access_key_id
-  aws_secret_access_key = var.aws_secret_access_key
   depends_on = [
   aws_ecs_service.aoc_without_sample_app_for_bridge]
 }

--- a/terraform/eks/main.tf
+++ b/terraform/eks/main.tf
@@ -243,9 +243,6 @@ module "validator" {
   cortex_instance_endpoint = var.cortex_instance_endpoint
   rollup                   = var.rollup
 
-  aws_access_key_id     = var.aws_access_key_id
-  aws_secret_access_key = var.aws_secret_access_key
-
   depends_on = [
     module.aoc_oltp,
     module.adot_operator,

--- a/terraform/performance/main.tf
+++ b/terraform/performance/main.tf
@@ -107,8 +107,5 @@ module "validator" {
   testing_id        = module.ec2_setup.testing_id
   metric_namespace  = var.performance_metric_namespace
 
-  aws_access_key_id     = var.aws_access_key_id
-  aws_secret_access_key = var.aws_secret_access_key
-
   depends_on = [time_sleep.wait_until_metrics_collected]
 }

--- a/terraform/soaking/main.tf
+++ b/terraform/soaking/main.tf
@@ -180,8 +180,6 @@ module "validator" {
   mem_alarm              = aws_cloudwatch_metric_alarm.mem_alarm.alarm_name
   incoming_packets_alarm = aws_cloudwatch_metric_alarm.incoming_bytes.alarm_name
 
-  aws_access_key_id     = var.aws_access_key_id
-  aws_secret_access_key = var.aws_secret_access_key
 
   depends_on = [time_sleep.wait_until_metric_is_sufficient]
 }

--- a/terraform/templates/defaults/credentials-env.tpl
+++ b/terraform/templates/defaults/credentials-env.tpl
@@ -1,3 +1,0 @@
-AWS_ACCESS_KEY_ID=${aws_access_key_id}
-AWS_SECRET_ACCESS_KEY=${aws_secret_access_key}
-AWS_DEFAULT_REGION=${region}

--- a/terraform/templates/defaults/validator_docker_compose.tpl
+++ b/terraform/templates/defaults/validator_docker_compose.tpl
@@ -7,8 +7,12 @@ services:
     volumes:
       - ~/.aws:/root/.aws
       - ./output:/var/output
-    env_file:
-      - creds.env
+    environment:
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - AWS_SESSION_TOKEN
+      - AWS_REGION
+      - AWS_DEFAULT_REGION
     command:
       - "-c=${validation_config}"
       - "-t=${testing_id}"

--- a/terraform/validation/main.tf
+++ b/terraform/validation/main.tf
@@ -18,7 +18,6 @@
 locals {
   docker_compose_path = "validator_docker_compose.yml"
 
-  provide_credentials_via_env_vars = var.aws_access_key_id != "" && var.aws_secret_access_key != ""
 }
 
 ## render docker compose file
@@ -61,24 +60,6 @@ resource "local_file" "docker_compose_file" {
 
   depends_on = [data.template_file.docker_compose]
 }
-
-# render credentials env file if the credentials env vars are provided,
-# this will be mainly used in github workflow where there's no ~/.aws folder
-data "template_file" "env_file_template" {
-  template = file("../templates/defaults/credentials-env.tpl")
-
-  vars = {
-    aws_access_key_id     = var.aws_access_key_id
-    aws_secret_access_key = var.aws_secret_access_key
-    region                = var.region
-  }
-}
-resource "local_file" "env_file" {
-  filename = "creds.env"
-
-  content = local.provide_credentials_via_env_vars ? data.template_file.env_file_template.rendered : ""
-}
-
 
 resource "null_resource" "validator" {
   provisioner "local-exec" {

--- a/terraform/validation/variables.tf
+++ b/terraform/validation/variables.tf
@@ -74,13 +74,6 @@ variable "ec2_context_json" {
   default = "{}"
 }
 
-variable "aws_access_key_id" {
-  default = ""
-}
-
-variable "aws_secret_access_key" {
-  default = ""
-}
 
 variable "cortex_instance_endpoint" {
   default = ""


### PR DESCRIPTION
**Description:**  This PR removes the `aws_access_key_id` and `aws_secret_access_key` as a variable in the Validator initialization. Instead of the using explicit variables these four environment variables are added to the validator docker compose file. 
```
      - AWS_ACCESS_KEY_ID
      - AWS_SECRET_ACCESS_KEY
      - AWS_SESSION_TOKEN
      - AWS_REGION
      - AWS_DEFAULT_REGION
```
This moves the burden of providing account credentials to either:
1. Having a `.aws` directory that will be copied into the container.
2. Having these env vars set in the shell where the docker compose file is built. This is backwards compatible in our existing workflows because the github marketplace actions  we use to authenticate to AWS accounts makes these env vars available. See [here](https://github.com/aws-observability/aws-otel-collector/runs/8139201101?check_suite_focus=true#step:8:31) for an example. 

This PR also adds the `AWS_SESSION_TOKEN` environment variable in the case that we begin to use temporary role based credentials instead of static user creds. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

