### PR TITLE
Make collector log level a template variable in config

### DIFF
--- a/terraform/basic_components/main.tf
+++ b/terraform/basic_components/main.tf
@@ -80,6 +80,7 @@ data "template_file" "otconfig" {
     cortex_instance_endpoint       = var.cortex_instance_endpoint
     sample_app_listen_address_host = var.sample_app_listen_address_host
     sample_app_listen_address_port = var.sample_app_listen_address_port
+    log_level                      = var.debug ? "debug" : "info"
 
     mock_endpoint = var.mocked_endpoint
   }

--- a/terraform/basic_components/variables.tf
+++ b/terraform/basic_components/variables.tf
@@ -51,3 +51,8 @@ variable "sample_app_listen_address_host" {
 variable "sample_app_listen_address_port" {
   default = ""
 }
+
+variable "debug" {
+  type = bool
+  default = false
+}

--- a/terraform/basic_components/variables.tf
+++ b/terraform/basic_components/variables.tf
@@ -53,6 +53,6 @@ variable "sample_app_listen_address_port" {
 }
 
 variable "debug" {
-  type = bool
+  type    = bool
   default = false
 }

--- a/terraform/canary/main.tf
+++ b/terraform/canary/main.tf
@@ -29,6 +29,7 @@ module "basic_components" {
   mocked_endpoint = var.mock_endpoint
   sample_app      = var.sample_app
   mocked_server   = var.mocked_server
+  debug           = var.debug
 }
 
 # launch ec2

--- a/terraform/ec2/main.tf
+++ b/terraform/ec2/main.tf
@@ -44,6 +44,8 @@ module "basic_components" {
   sample_app_listen_address_host = aws_instance.sidecar.public_ip
 
   sample_app_listen_address_port = module.common.sample_app_lb_port
+
+  debug = var.debug
 }
 
 provider "aws" {

--- a/terraform/ecs/main.tf
+++ b/terraform/ecs/main.tf
@@ -40,6 +40,8 @@ module "basic_components" {
   sample_app_listen_address_port = module.common.sample_app_listen_address_port
 
   cortex_instance_endpoint = var.cortex_instance_endpoint
+
+  debug = var.debug
 }
 
 locals {

--- a/terraform/eks/otlp.tf
+++ b/terraform/eks/otlp.tf
@@ -26,6 +26,7 @@ module "basic_components" {
   cortex_instance_endpoint       = var.cortex_instance_endpoint
   sample_app_listen_address_host = var.sample_app_mode == "pull" ? kubernetes_service.sample_app_service.0.load_balancer_ingress.0.hostname : ""
   sample_app_listen_address_port = module.common.sample_app_lb_port
+  debug                          = var.debug
 }
 
 # create an IAM role here so that we can reference the clusters OIDC Provider.

--- a/terraform/testcases/containerinsight_ecs_prometheus/otconfig.tpl
+++ b/terraform/testcases/containerinsight_ecs_prometheus/otconfig.tpl
@@ -160,7 +160,7 @@ exporters:
 service:
   telemetry:
     logs:
-      level: debug
+      level: ${log_level}
   extensions: [ ecs_observer ]
   pipelines:
     metrics:

--- a/terraform/testcases/datadog_exporter_metric_mock/otconfig.tpl
+++ b/terraform/testcases/datadog_exporter_metric_mock/otconfig.tpl
@@ -28,4 +28,4 @@ service:
   extensions: [pprof]
   telemetry:
     logs:
-      level: debug
+      level: ${log_level}

--- a/terraform/testcases/datadog_exporter_trace_mock/otconfig.tpl
+++ b/terraform/testcases/datadog_exporter_trace_mock/otconfig.tpl
@@ -30,4 +30,4 @@ service:
   extensions: [pprof]
   telemetry:
     logs:
-      level: debug
+      level: ${log_level}

--- a/terraform/testcases/dynatrace_exporter_metric_mock/otconfig.tpl
+++ b/terraform/testcases/dynatrace_exporter_metric_mock/otconfig.tpl
@@ -26,5 +26,5 @@ service:
   extensions: [pprof]
   telemetry:
     logs:
-      level: debug
+      level: ${log_level}
 

--- a/terraform/testcases/ecs_instance_metrics/otconfig.tpl
+++ b/terraform/testcases/ecs_instance_metrics/otconfig.tpl
@@ -49,4 +49,4 @@ service:
       exporters: [awsemf,logging]
   telemetry:
     logs:
-      level: debug
+      level: ${log_level}

--- a/terraform/testcases/ecsmetrics/otconfig.tpl
+++ b/terraform/testcases/ecsmetrics/otconfig.tpl
@@ -101,4 +101,4 @@ service:
   extensions: [pprof]
   telemetry:
     logs:
-      level: debug
+      level: ${log_level}

--- a/terraform/testcases/jaeger_mock/otconfig.tpl
+++ b/terraform/testcases/jaeger_mock/otconfig.tpl
@@ -28,4 +28,4 @@ service:
   extensions: [pprof]
   telemetry:
     logs:
-      level: debug
+      level: ${log_level}

--- a/terraform/testcases/logzio_exporter_trace_mock/otconfig.tpl
+++ b/terraform/testcases/logzio_exporter_trace_mock/otconfig.tpl
@@ -26,4 +26,4 @@ service:
   extensions: [pprof]
   telemetry:
     logs:
-      level: debug
+      level: ${log_level}

--- a/terraform/testcases/newrelic_exporter_metric_mock/otconfig.tpl
+++ b/terraform/testcases/newrelic_exporter_metric_mock/otconfig.tpl
@@ -29,4 +29,4 @@ service:
   extensions: [pprof]
   telemetry:
     logs:
-      level: debug
+      level: ${log_level}

--- a/terraform/testcases/newrelic_exporter_trace_mock/otconfig.tpl
+++ b/terraform/testcases/newrelic_exporter_trace_mock/otconfig.tpl
@@ -29,4 +29,4 @@ service:
   extensions: [pprof]
   telemetry:
     logs:
-      level: debug
+      level: ${log_level}

--- a/terraform/testcases/otlp_grpc_exporter_cw_amp_xray_ecs/otconfig.tpl
+++ b/terraform/testcases/otlp_grpc_exporter_cw_amp_xray_ecs/otconfig.tpl
@@ -149,4 +149,4 @@ service:
   extensions: [pprof, sigv4auth]
   telemetry:
     logs:
-      level: debug
+      level: ${log_level}

--- a/terraform/testcases/otlp_grpc_exporter_metric_mock/otconfig.tpl
+++ b/terraform/testcases/otlp_grpc_exporter_metric_mock/otconfig.tpl
@@ -28,4 +28,4 @@ service:
   extensions: [pprof]
   telemetry:
     logs:
-      level: debug
+      level: ${log_level}

--- a/terraform/testcases/otlp_grpc_exporter_trace_mock/otconfig.tpl
+++ b/terraform/testcases/otlp_grpc_exporter_trace_mock/otconfig.tpl
@@ -28,4 +28,4 @@ service:
   extensions: [pprof]
   telemetry:
     logs:
-      level: debug
+      level: ${log_level}

--- a/terraform/testcases/otlp_http_exporter_metric_mock/otconfig.tpl
+++ b/terraform/testcases/otlp_http_exporter_metric_mock/otconfig.tpl
@@ -27,4 +27,4 @@ service:
   extensions: [pprof]
   telemetry:
     logs:
-      level: debug
+      level: ${log_level}

--- a/terraform/testcases/otlp_http_exporter_trace_mock/otconfig.tpl
+++ b/terraform/testcases/otlp_http_exporter_trace_mock/otconfig.tpl
@@ -27,4 +27,4 @@ service:
   extensions: [pprof]
   telemetry:
     logs:
-      level: debug
+      level: ${log_level}

--- a/terraform/testcases/otlp_metric/otconfig.tpl
+++ b/terraform/testcases/otlp_metric/otconfig.tpl
@@ -25,4 +25,4 @@ service:
   extensions: [pprof]
   telemetry:
     logs:
-      level: debug
+      level: ${log_level}

--- a/terraform/testcases/otlp_metric_adot_operator/otconfig.tpl
+++ b/terraform/testcases/otlp_metric_adot_operator/otconfig.tpl
@@ -25,4 +25,4 @@ extensions:
       extensions: [pprof]
       telemetry:
         logs:
-          level: debug
+          level: ${log_level}

--- a/terraform/testcases/otlp_metric_amp/otconfig.tpl
+++ b/terraform/testcases/otlp_metric_amp/otconfig.tpl
@@ -31,4 +31,4 @@ service:
   extensions: [pprof, sigv4auth]
   telemetry:
     logs:
-      level: debug
+      level: ${log_level}

--- a/terraform/testcases/otlp_metric_mock/otconfig.tpl
+++ b/terraform/testcases/otlp_metric_mock/otconfig.tpl
@@ -26,4 +26,4 @@ service:
   extensions: [pprof]
   telemetry:
     logs:
-      level: debug
+      level: ${log_level}

--- a/terraform/testcases/otlp_mock/otconfig.tpl
+++ b/terraform/testcases/otlp_mock/otconfig.tpl
@@ -28,4 +28,4 @@ service:
   extensions: [pprof]
   telemetry:
     logs:
-      level: debug
+      level: ${log_level}

--- a/terraform/testcases/otlp_trace/otconfig.tpl
+++ b/terraform/testcases/otlp_trace/otconfig.tpl
@@ -26,4 +26,4 @@ service:
   extensions: [pprof]
   telemetry:
     logs:
-      level: debug
+      level: ${log_level}

--- a/terraform/testcases/otlp_trace_adot_operator/otconfig.tpl
+++ b/terraform/testcases/otlp_trace_adot_operator/otconfig.tpl
@@ -26,4 +26,4 @@ extensions:
       extensions: [pprof]
       telemetry:
         logs:
-          level: debug
+          level: ${log_level}

--- a/terraform/testcases/otlp_trace_resourcedetection_ec2/otconfig.tpl
+++ b/terraform/testcases/otlp_trace_resourcedetection_ec2/otconfig.tpl
@@ -34,4 +34,4 @@ service:
   extensions: [pprof]
   telemetry:
     logs:
-      level: debug
+      level: ${log_level}

--- a/terraform/testcases/otlp_trace_resourcedetection_ecs/otconfig.tpl
+++ b/terraform/testcases/otlp_trace_resourcedetection_ecs/otconfig.tpl
@@ -30,4 +30,4 @@ service:
   extensions: [pprof]
   telemetry:
     logs:
-      level: debug
+      level: ${log_level}

--- a/terraform/testcases/otlp_trace_resourcedetection_eks/otconfig.tpl
+++ b/terraform/testcases/otlp_trace_resourcedetection_eks/otconfig.tpl
@@ -30,4 +30,4 @@ service:
   extensions: [pprof]
   telemetry:
     logs:
-      level: debug
+      level: ${log_level}

--- a/terraform/testcases/prometheus_mock/otconfig.tpl
+++ b/terraform/testcases/prometheus_mock/otconfig.tpl
@@ -23,4 +23,4 @@ service:
   extensions: [sigv4auth]
   telemetry:
     logs:
-      level: debug
+      level: ${log_level}

--- a/terraform/testcases/prometheus_sd/otconfig.tpl
+++ b/terraform/testcases/prometheus_sd/otconfig.tpl
@@ -32,4 +32,4 @@ service:
   extensions: [sigv4auth]
   telemetry:
     logs:
-      level: debug
+      level: ${log_level}

--- a/terraform/testcases/prometheus_sd_adot_operator/otconfig.tpl
+++ b/terraform/testcases/prometheus_sd_adot_operator/otconfig.tpl
@@ -32,4 +32,4 @@ extensions:
       extensions: [sigv4auth]
       telemetry:
         logs:
-          level: debug
+          level: ${log_level}

--- a/terraform/testcases/prometheus_static/otconfig.tpl
+++ b/terraform/testcases/prometheus_static/otconfig.tpl
@@ -25,4 +25,4 @@ service:
   extensions: [sigv4auth]
   telemetry:
     logs:
-      level: debug
+      level: ${log_level}

--- a/terraform/testcases/prometheus_static_adot_operator/otconfig.tpl
+++ b/terraform/testcases/prometheus_static_adot_operator/otconfig.tpl
@@ -25,4 +25,4 @@ extensions:
       extensions: [sigv4auth]
       telemetry:
         logs:
-          level: debug
+          level: ${log_level}

--- a/terraform/testcases/sapm_exporter_trace_mock/otconfig.tpl
+++ b/terraform/testcases/sapm_exporter_trace_mock/otconfig.tpl
@@ -25,4 +25,4 @@ service:
   extensions: [pprof]
   telemetry:
     logs:
-      level: debug
+      level: ${log_level}

--- a/terraform/testcases/signalfx_exporter_metric_mock/otconfig.tpl
+++ b/terraform/testcases/signalfx_exporter_metric_mock/otconfig.tpl
@@ -27,4 +27,4 @@ service:
   extensions: [pprof]
   telemetry:
     logs:
-      level: debug
+      level: ${log_level}

--- a/terraform/testcases/signalfxcorrelation_exporter_trace_mock/otconfig.tpl
+++ b/terraform/testcases/signalfxcorrelation_exporter_trace_mock/otconfig.tpl
@@ -25,4 +25,4 @@ service:
   extensions: [pprof]
   telemetry:
     logs:
-      level: debug
+      level: ${log_level}

--- a/terraform/testcases/splunkhec_exporter_trace_mock/otconfig.tpl
+++ b/terraform/testcases/splunkhec_exporter_trace_mock/otconfig.tpl
@@ -26,4 +26,4 @@ service:
   extensions: [pprof]
   telemetry:
     logs:
-      level: debug
+      level: ${log_level}

--- a/terraform/testcases/statsd/otconfig.tpl
+++ b/terraform/testcases/statsd/otconfig.tpl
@@ -15,4 +15,4 @@ service:
       exporters: [awsemf, logging]
   telemetry:
     logs:
-      level: debug
+      level: ${log_level}

--- a/terraform/testcases/statsd_mock/otconfig.tpl
+++ b/terraform/testcases/statsd_mock/otconfig.tpl
@@ -16,4 +16,4 @@ service:
       exporters: [otlphttp]
   telemetry:
     logs:
-      level: debug
+      level: ${log_level}

--- a/terraform/testcases/xrayreceiver/otconfig.tpl
+++ b/terraform/testcases/xrayreceiver/otconfig.tpl
@@ -25,4 +25,4 @@ service:
   extensions: [pprof]
   telemetry:
     logs:
-      level: debug
+      level: ${log_level}

--- a/terraform/testcases/xrayreceiver_mock/otconfig.tpl
+++ b/terraform/testcases/xrayreceiver_mock/otconfig.tpl
@@ -19,7 +19,6 @@ exporters:
     endpoint: "${mock_endpoint}"
 
 service:
-  extensions:
   pipelines:
     traces:
       receivers: [awsxray]
@@ -28,4 +27,4 @@ service:
   extensions: [pprof]
   telemetry:
     logs:
-      level: debug
+      level: ${log_level}

--- a/terraform/testcases/zipkin_mock/otconfig.tpl
+++ b/terraform/testcases/zipkin_mock/otconfig.tpl
@@ -26,4 +26,4 @@ service:
   extensions: [pprof]
   telemetry:
     logs:
-      level: debug
+      level: ${log_level}


### PR DESCRIPTION
Signed-off-by: Anthony J Mirabella <a9@aneurysm9.com>

**Description:** Makes debug logging a flag that can be toggled in the `basic_components` Terraform module. Defaults to `false`.  Previously debug logging was always on, this appears to be a cause of issues in performance testing but disabling it may impact other tests.  Keep an eye out after merging this change.

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

