### PR TITLE
Make `log_level` variable available to mock config template

### DIFF
--- a/terraform/mock/main.tf
+++ b/terraform/mock/main.tf
@@ -43,6 +43,7 @@ data "template_file" "otconfig" {
     mock_endpoint                  = local.mock_endpoint
     sample_app_listen_address_host = "172.17.0.1"
     sample_app_listen_address_port = module.common.sample_app_listen_address_port
+    log_level                      = var.debug ? "debug" : "info"
   }
 }
 


### PR DESCRIPTION
Signed-off-by: Anthony J Mirabella <a9@aneurysm9.com>

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

