### PR TITLE
Update AL2 to use newer AMIs

### DIFF
--- a/terraform/canary/amis.tf
+++ b/terraform/canary/amis.tf
@@ -63,7 +63,7 @@ variable "amis" {
       os_family          = "amazon_linux"
       ami_search_pattern = "amzn2-ami-hvm-2.0.????????.?-x86_64-gp2"
       ami_owner          = "amazon"
-      ami_id             = "ami-0d08ef957f0e4722b"
+      ami_id             = "ami-0c2ab3b8efb09f272"
       ami_product_code   = []
       family             = "amazon_linux"
       arch               = "amd64"

--- a/terraform/ec2/amis.tf
+++ b/terraform/ec2/amis.tf
@@ -163,7 +163,7 @@ EOF
       os_family          = "amazon_linux"
       ami_search_pattern = "amzn2-ami-hvm-2.0.????????.?-x86_64-gp2"
       ami_owner          = "amazon"
-      ami_id             = "ami-0d08ef957f0e4722b"
+      ami_id             = "ami-0c2ab3b8efb09f272"
       ami_product_code   = []
       family             = "linux"
       arch               = "amd64"
@@ -287,7 +287,7 @@ EOF
       os_family          = "amazon_linux"
       ami_search_pattern = "amzn2-ami-hvm-2.0.????????.?-arm64-gp2"
       ami_owner          = "amazon"
-      ami_id             = "ami-0d3c51ccaa76cbe2b"
+      ami_id             = "ami-07c02c38124bd75bd"
       ami_product_code   = []
       family             = "linux"
       arch               = "arm64"
@@ -389,7 +389,7 @@ EOF
       os_family          = "amazon_linux"
       ami_search_pattern = "amzn2-ami-hvm-2.0.????????.?-x86_64-gp2"
       ami_owner          = "amazon"
-      ami_id             = "ami-0d08ef957f0e4722b"
+      ami_id             = "ami-0c2ab3b8efb09f272"
       ami_product_code   = []
       family             = "amazon_linux"
       arch               = "amd64"
@@ -407,7 +407,7 @@ EOF
       os_family          = "amazon_linux"
       ami_search_pattern = "amzn2-ami-hvm-2.0.????????.?-x86_64-gp2"
       ami_owner          = "amazon"
-      ami_id             = "ami-0d08ef957f0e4722b"
+      ami_id             = "ami-0c2ab3b8efb09f272"
       ami_product_code   = []
       family             = "amazon_linux"
       arch               = "amd64"

--- a/terraform/ec2_setup/amis.tf
+++ b/terraform/ec2_setup/amis.tf
@@ -75,7 +75,7 @@ variable "amis" {
       os_family          = "amazon_linux"
       ami_search_pattern = "amzn2-ami-hvm-2.0.????????.?-x86_64-gp2"
       ami_owner          = "amazon"
-      ami_id             = "ami-0d08ef957f0e4722b"
+      ami_id             = "ami-0c2ab3b8efb09f272"
       ami_product_code   = []
       family             = "amazon_linux"
       arch               = "amd64"


### PR DESCRIPTION
**Description:** 

This PR updates the `amazon linux 2` AMIs to the latest version. This is mitigate the red instance violations of using a older AMI version

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

