### PR TITLE
Update distribution support for Testing Framework

### DIFF
--- a/terraform/canary/amis.tf
+++ b/terraform/canary/amis.tf
@@ -60,7 +60,7 @@ variable "amis" {
     }
     canary_linux = {
       os_family          = "amazon_linux"
-      ami_search_pattern = "amzn2-ami-kernel*"
+      ami_search_pattern = "amzn2-ami-kernel.5*"
       ami_owner          = "amazon"
       ami_product_code   = []
       family             = "amazon_linux"

--- a/terraform/canary/amis.tf
+++ b/terraform/canary/amis.tf
@@ -52,21 +52,19 @@ variable "amis" {
   default = {
     canary_windows = {
       os_family          = "windows"
-      ami_search_pattern = "Windows_Server-2019-English-Full-Base-*"
+      ami_search_pattern = "Windows_Server-2022-English-Full-Base*"
       ami_owner          = "amazon"
-      ami_id             = "ami-01f14dc60171d8d7b"
       ami_product_code   = []
       family             = "windows"
-      arch               = "amd64"
+      arch               = "x86_64"
     }
     canary_linux = {
       os_family          = "amazon_linux"
-      ami_search_pattern = "amzn2-ami-hvm-2.0.????????.?-x86_64-gp2"
+      ami_search_pattern = "amzn2-ami-kernel*"
       ami_owner          = "amazon"
-      ami_id             = "ami-0c2ab3b8efb09f272"
       ami_product_code   = []
       family             = "amazon_linux"
-      arch               = "amd64"
+      arch               = "x86_64"
     }
   }
 }

--- a/terraform/ec2/amis.tf
+++ b/terraform/ec2/amis.tf
@@ -92,13 +92,26 @@ variable "amis" {
     # Ubuntu Distribution
     ubuntu18 = {
       os_family          = "ubuntu"
-      ami_search_pattern = "ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-*"
-      ami_owner          = "099720109477"
-      ami_id             = "ami-0688ba7eeeeefe3cd"
+      ami_search_pattern = "ubuntu/images/hvm-ssd/ubuntu-bionic-*"
+      owners             = "aws-marketplace"
       ami_product_code   = []
       family             = "debian"
-      arch               = "amd64"
+      arch               = "x86_64"
       login_user         = "ubuntu"
+      user_data          = <<EOF
+#! /bin/bash
+sudo snap refresh amazon-ssm-agent
+EOF
+    }
+    arm_ubuntu18 = {
+      os_family          = "ubuntu"
+      ami_search_pattern = "ubuntu/images/hvm-ssd/ubuntu-bionic-*"
+      owners             = "aws-marketplace"
+      ami_product_code   = []
+      family             = "debian"
+      arch               = "arm64"
+      login_user         = "ubuntu"
+      instance_type      = "t4g.nano"
       user_data          = <<EOF
 #! /bin/bash
 sudo snap refresh amazon-ssm-agent
@@ -106,11 +119,11 @@ EOF
     }
     ubuntu20 = {
       os_family          = "ubuntu"
-      ami_search_pattern = "ubuntu/images/hvm-ssd/ubuntu-jammy*"
-      owners             = "aws-marketplace"
+      ami_search_pattern = "ubuntu/images/hvm-ssd/ubuntu-focal*"
+      ami_owner          = "aws-marketplace"
       ami_product_code   = []
       family             = "debian"
-      arch               = "amd64"
+      arch               = "x86_64"
       login_user         = "ubuntu"
       user_data          = <<EOF
 #! /bin/bash
@@ -119,12 +132,12 @@ EOF
     }
     arm_ubuntu20 = {
       os_family          = "ubuntu"
-      ami_search_pattern = "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-arm64*"
-      ami_owner          = "099720109477"
-      ami_id             = "ami-0f1337c0023ea5b49"
+      ami_search_pattern = "ubuntu/images/hvm-ssd/ubuntu-focal*"
+      ami_owner          = "aws-marketplace"
       ami_product_code   = []
       family             = "debian"
       arch               = "arm64"
+      login_user         = "ubuntu"
       instance_type      = "t4g.nano"
       user_data          = <<EOF
 #! /bin/bash
@@ -134,10 +147,10 @@ EOF
     ubuntu22 = {
       os_family          = "ubuntu"
       ami_search_pattern = "ubuntu/images/hvm-ssd/ubuntu-jammy*"
-      owners             = "amazon"
+      ami_owner          = "aws-marketplace"
       ami_product_code   = []
       family             = "debian"
-      arch               = "amd64"
+      arch               = "x86_64"
       login_user         = "ubuntu"
       user_data          = <<EOF
 #! /bin/bash
@@ -147,7 +160,7 @@ EOF
     arm_ubuntu22 = {
       os_family          = "ubuntu"
       ami_search_pattern = "ubuntu/images/hvm-ssd/ubuntu-jammy*"
-      owners             = "aws-marketplace"
+      ami_owner          = "aws-marketplace"
       ami_product_code   = []
       family             = "debian"
       arch               = "arm64"
@@ -161,16 +174,33 @@ EOF
     # Debian Distribution
     debian11 = {
       os_family          = "debian"
-      ami_search_pattern = "debian-10-amd64*"
-      ami_owner          = "679593333241"
-      ami_id             = "ami-0900b247bf638c13f"
-      # NOTE: we need product code to pick the right debian 10.
-      ami_product_code = [
-      "auhljmclkudu651zy27rih2x2"]
-      family     = "debian"
-      arch       = "amd64"
-      login_user = "admin"
-      user_data  = <<EOF
+      ami_search_pattern = "debian-11-*"
+      ami_owner          = "aws-marketplace"
+      ami_product_code   = []
+      family             = "debian"
+      arch               = "x86_64"
+      login_user         = "admin"
+      user_data          = <<EOF
+#! /bin/bash
+cd /tmp
+sudo wget https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/debian_amd64/amazon-ssm-agent.deb
+while sudo fuser {/var/{lib/{dpkg,apt/lists},cache/apt/archives}/lock,/var/lib/dpkg/lock-frontend}; do
+   echo 'Waiting for dpkg lock...' && sleep 1
+done
+sudo dpkg -i amazon-ssm-agent.deb
+sudo systemctl enable amazon-ssm-agent
+EOF
+    }
+    arm_debian11 = {
+      os_family          = "debian"
+      ami_search_pattern = "debian-11-*"
+      ami_owner          = "aws-marketplace"
+      ami_product_code   = []
+      family             = "debian"
+      arch               = "arm64"
+      login_user         = "admin"
+      instance_type      = "t4g.nano"
+      user_data          = <<EOF
 #! /bin/bash
 cd /tmp
 sudo wget https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/debian_amd64/amazon-ssm-agent.deb
@@ -183,16 +213,13 @@ EOF
     }
     debian10 = {
       os_family          = "debian"
-      ami_search_pattern = "debian-10-amd64*"
-      ami_owner          = "679593333241"
-      ami_id             = "ami-0900b247bf638c13f"
-      # NOTE: we need product code to pick the right debian 10.
-      ami_product_code = [
-      "auhljmclkudu651zy27rih2x2"]
-      family     = "debian"
-      arch       = "amd64"
-      login_user = "admin"
-      user_data  = <<EOF
+      ami_search_pattern = "debian-10-*"
+      ami_owner          = "aws-marketplace"
+      ami_product_code   = []
+      family             = "debian"
+      arch               = "x86_64"
+      login_user         = "admin"
+      user_data          = <<EOF
 #! /bin/bash
 cd /tmp
 sudo wget https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/debian_amd64/amazon-ssm-agent.deb
@@ -203,15 +230,34 @@ sudo dpkg -i amazon-ssm-agent.deb
 sudo systemctl enable amazon-ssm-agent
 EOF
     }
-  #AL2
+    arm_debian11 = {
+      os_family          = "debian"
+      ami_search_pattern = "debian-10-*"
+      ami_owner          = "aws-marketplace"
+      ami_product_code   = []
+      family             = "debian"
+      arch               = "arm64"
+      login_user         = "admin"
+      instance_type      = "t4g.nano"
+      user_data          = <<EOF
+#! /bin/bash
+cd /tmp
+sudo wget https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/debian_amd64/amazon-ssm-agent.deb
+while sudo fuser {/var/{lib/{dpkg,apt/lists},cache/apt/archives}/lock,/var/lib/dpkg/lock-frontend}; do
+   echo 'Waiting for dpkg lock...' && sleep 1
+done
+sudo dpkg -i amazon-ssm-agent.deb
+sudo systemctl enable amazon-ssm-agent
+EOF
+    }
+    #AL2
     amazonlinux2 = {
       os_family          = "amazon_linux"
-      ami_search_pattern = "amzn2-ami-hvm-2.0.????????.?-x86_64-gp2"
+      ami_search_pattern = "amzn2-ami-kernel*"
       ami_owner          = "amazon"
-      ami_id             = "ami-0c2ab3b8efb09f272"
       ami_product_code   = []
       family             = "linux"
-      arch               = "amd64"
+      arch               = "x86_64"
       login_user         = "ec2-user"
       user_data          = <<EOF
 #! /bin/bash
@@ -220,12 +266,12 @@ EOF
     }
     arm_amazonlinux2 = {
       os_family          = "amazon_linux"
-      ami_search_pattern = "amzn2-ami-hvm-2.0.????????.?-arm64-gp2"
+      ami_search_pattern = "amzn2-ami-kernel*"
       ami_owner          = "amazon"
-      ami_id             = "ami-07c02c38124bd75bd"
       ami_product_code   = []
       family             = "linux"
       arch               = "arm64"
+      login_user         = "ec2-user"
       instance_type      = "t4g.nano"
       user_data          = <<EOF
 #! /bin/bash
@@ -235,12 +281,11 @@ EOF
     # Windows Distribution
     windows2022 = {
       os_family          = "windows"
-      ami_search_pattern = "Windows_Server-2019-English-Full-Base-*"
+      ami_search_pattern = "Windows_Server-2022-English-Full-Base*"
       ami_owner          = "amazon"
-      ami_id             = "ami-0297fbf7e83dd1209"
       ami_product_code   = []
       family             = "windows"
-      arch               = "amd64"
+      arch               = "x86_64"
       login_user         = "Administrator"
     }
     windows2019 = {
@@ -250,37 +295,18 @@ EOF
       ami_id             = "ami-0297fbf7e83dd1209"
       ami_product_code   = []
       family             = "windows"
-      arch               = "amd64"
+      arch               = "x86_64"
       login_user         = "Administrator"
     }
     # Suse Distribution
     suse15 = {
       os_family          = "suse"
       ami_search_pattern = "suse-sles-15*"
-      ami_owner          = "amazon"
-      ami_id             = "ami-0164f097bf264d944"
+      ami_owner          = "aws-marketplace"
       ami_product_code   = []
       family             = "linux"
       login_user         = "ec2-user"
-      arch               = "amd64"
-      user_data          = <<EOF
-#! /bin/bash
-cd /tmp
-sudo wget https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
-sudo rpm -Uvh amazon-ssm-agent.rpm
-sudo systemctl enable amazon-ssm-agent
-sudo systemctl start amazon-ssm-agent
-EOF
-    }
-    suse12 = {
-      os_family          = "suse"
-      ami_search_pattern = "suse-sles-12*"
-      ami_owner          = "amazon"
-      ami_product_code   = []
-      ami_id             = "ami-088a78f435ef7f78a"
-      family             = "linux"
-      login_user         = "ec2-user"
-      arch               = "amd64"
+      arch               = "x86_64"
       user_data          = <<EOF
 #! /bin/bash
 cd /tmp
@@ -292,11 +318,11 @@ EOF
     }
     arm_suse15 = {
       os_family          = "suse"
-      ami_search_pattern = "suse-sles-15-sp2-v20200721-hvm-ssd-arm64*"
-      ami_owner          = "amazon"
-      ami_id             = "ami-0bfc92b18fd79372c"
+      ami_search_pattern = "suse-sles-15*"
+      ami_owner          = "aws-marketplace"
       ami_product_code   = []
       family             = "linux"
+      login_user         = "ec2-user"
       arch               = "arm64"
       instance_type      = "t4g.nano"
       user_data          = <<EOF
@@ -306,55 +332,41 @@ sudo wget https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_a
 sudo rpm -ivh amazon-ssm-agent.rpm
 EOF
     }
-  # Redhat Distribution
-  redhat9 = {
-      os_family          = "redhat"
-      ami_search_pattern = "RHEL-8.0.0_HVM*"
-      ami_owner          = "309956199498"
-      ami_id             = "ami-087c2c50437d0b80d"
+    suse12 = {
+      os_family          = "suse"
+      ami_search_pattern = "suse-sles-12*"
+      ami_owner          = "amazon"
       ami_product_code   = []
       family             = "linux"
-      arch               = "amd64"
+      login_user         = "ec2-user"
+      arch               = "x86_64"
       user_data          = <<EOF
 #! /bin/bash
-sudo dnf install -y python3
-sudo dnf install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
+cd /tmp
+sudo wget https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
+sudo rpm -Uvh amazon-ssm-agent.rpm
+sudo systemctl enable amazon-ssm-agent
+sudo systemctl start amazon-ssm-agent
 EOF
     }
+    # Redhat Distribution
     redhat8 = {
       os_family          = "redhat"
-      ami_search_pattern = "RHEL-8.0.0_HVM*"
-      ami_owner          = "309956199498"
-      ami_id             = "ami-087c2c50437d0b80d"
+      ami_search_pattern = "RHEL-8.6.0_HVM*"
+      ami_owner          = "amazon"
       ami_product_code   = []
       family             = "linux"
-      arch               = "amd64"
+      arch               = "x86_64"
       user_data          = <<EOF
 #! /bin/bash
 sudo dnf install -y python3
 sudo dnf install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
-EOF
-    }
-    arm_redhat9 = {
-      os_family          = "redhat"
-      ami_search_pattern = "RHEL-8.0.0_HVM-20190426-arm64*"
-      ami_owner          = "309956199498"
-      ami_id             = "ami-0f7a968a2c17fb48b"
-      ami_product_code   = []
-      family             = "linux"
-      arch               = "arm64"
-      instance_type      = "t4g.micro"
-      user_data          = <<EOF
-#! /bin/bash
-sudo dnf install -y python3
-sudo dnf install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_arm64/amazon-ssm-agent.rpm
 EOF
     }
     arm_redhat8 = {
       os_family          = "redhat"
-      ami_search_pattern = "RHEL-7.6_HVM_GA-20181122-arm64*"
-      ami_owner          = "309956199498"
-      ami_id             = "ami-0e00026dd0f3688e2"
+      ami_search_pattern = "RHEL-8.6.0_HVM*"
+      ami_owner          = "amazon"
       ami_product_code   = []
       family             = "linux"
       arch               = "arm64"
@@ -368,9 +380,30 @@ EOF
   }
 }
 
-# Local variables only apply to aws_ami for the customized filter input
-locals {
-  arch = var.amis[var.testing_ami]["arch"] == "amd64" ? "x86_64" : var.amis[var.testing_ami]["arch"]
+
+data "aws_ami" "selected" {
+  most_recent = true
+
+  owners = [
+  var.amis[var.testing_ami]["ami_owner"]]
+
+  filter {
+    name = "name"
+    values = [
+    var.amis[var.testing_ami]["ami_search_pattern"]]
+  }
+
+  filter {
+    name   = "architecture"
+    values = [var.amis[var.testing_ami]["arch"]]
+  }
+
+  filter {
+    name = "state"
+    values = [
+    "available"]
+  }
+
 }
 
 # this ami is used to launch the emitter instance
@@ -381,7 +414,7 @@ data "aws_ami" "amazonlinux2" {
   filter {
     name = "name"
     values = [
-    "amzn2-ami-hvm-2.0.????????.?-x86_64-gp2"]
+    "amzn2-ami-kernel*"]
   }
 
   filter {

--- a/terraform/ec2/amis.tf
+++ b/terraform/ec2/amis.tf
@@ -230,7 +230,7 @@ sudo dpkg -i amazon-ssm-agent.deb
 sudo systemctl enable amazon-ssm-agent
 EOF
     }
-    arm_debian11 = {
+    arm_debian10 = {
       os_family          = "debian"
       ami_search_pattern = "debian-10-*"
       ami_owner          = "aws-marketplace"

--- a/terraform/ec2/amis.tf
+++ b/terraform/ec2/amis.tf
@@ -111,7 +111,7 @@ EOF
       family             = "debian"
       arch               = "arm64"
       login_user         = "ubuntu"
-      instance_type      = "t4g.nano"
+      instance_type      = "t4g.micro"
       user_data          = <<EOF
 #! /bin/bash
 sudo snap refresh amazon-ssm-agent
@@ -138,7 +138,7 @@ EOF
       family             = "debian"
       arch               = "arm64"
       login_user         = "ubuntu"
-      instance_type      = "t4g.nano"
+      instance_type      = "t4g.micro"
       user_data          = <<EOF
 #! /bin/bash
 sudo snap refresh amazon-ssm-agent
@@ -165,7 +165,7 @@ EOF
       family             = "debian"
       arch               = "arm64"
       login_user         = "ubuntu"
-      instance_type      = "t4g.nano"
+      instance_type      = "t4g.micro"
       user_data          = <<EOF
 #! /bin/bash
 sudo snap refresh amazon-ssm-agent
@@ -199,7 +199,7 @@ EOF
       family             = "debian"
       arch               = "arm64"
       login_user         = "admin"
-      instance_type      = "t4g.nano"
+      instance_type      = "t4g.micro"
       user_data          = <<EOF
 #! /bin/bash
 cd /tmp
@@ -238,7 +238,7 @@ EOF
       family             = "debian"
       arch               = "arm64"
       login_user         = "admin"
-      instance_type      = "t4g.nano"
+      instance_type      = "t4g.micro"
       user_data          = <<EOF
 #! /bin/bash
 cd /tmp
@@ -272,7 +272,7 @@ EOF
       family             = "linux"
       arch               = "arm64"
       login_user         = "ec2-user"
-      instance_type      = "t4g.nano"
+      instance_type      = "t4g.micro"
       user_data          = <<EOF
 #! /bin/bash
 sudo yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_arm64/amazon-ssm-agent.rpm
@@ -324,7 +324,7 @@ EOF
       family             = "linux"
       login_user         = "ec2-user"
       arch               = "arm64"
-      instance_type      = "t4g.nano"
+      instance_type      = "t4g.micro"
       user_data          = <<EOF
 #! /bin/bash
 cd /tmp

--- a/terraform/ec2/amis.tf
+++ b/terraform/ec2/amis.tf
@@ -89,7 +89,8 @@ EOF
 ########################################
 variable "amis" {
   default = {
-    ubuntu16 = {
+    # Ubuntu Distribution
+    ubuntu18 = {
       os_family          = "ubuntu"
       ami_search_pattern = "ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-*"
       ami_owner          = "099720109477"
@@ -103,11 +104,10 @@ variable "amis" {
 sudo snap refresh amazon-ssm-agent
 EOF
     }
-    ubuntu18 = {
+    ubuntu20 = {
       os_family          = "ubuntu"
-      ami_search_pattern = "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server*"
-      ami_owner          = "099720109477"
-      ami_id             = "ami-02da34c96f69d525c"
+      ami_search_pattern = "ubuntu/images/hvm-ssd/ubuntu-jammy*"
+      owners             = "aws-marketplace"
       ami_product_code   = []
       family             = "debian"
       arch               = "amd64"
@@ -115,6 +115,70 @@ EOF
       user_data          = <<EOF
 #! /bin/bash
 sudo snap refresh amazon-ssm-agent
+EOF
+    }
+    arm_ubuntu20 = {
+      os_family          = "ubuntu"
+      ami_search_pattern = "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-arm64*"
+      ami_owner          = "099720109477"
+      ami_id             = "ami-0f1337c0023ea5b49"
+      ami_product_code   = []
+      family             = "debian"
+      arch               = "arm64"
+      instance_type      = "t4g.nano"
+      user_data          = <<EOF
+#! /bin/bash
+sudo snap refresh amazon-ssm-agent
+EOF
+    }
+    ubuntu22 = {
+      os_family          = "ubuntu"
+      ami_search_pattern = "ubuntu/images/hvm-ssd/ubuntu-jammy*"
+      owners             = "amazon"
+      ami_product_code   = []
+      family             = "debian"
+      arch               = "amd64"
+      login_user         = "ubuntu"
+      user_data          = <<EOF
+#! /bin/bash
+sudo snap refresh amazon-ssm-agent
+EOF
+    }
+    arm_ubuntu22 = {
+      os_family          = "ubuntu"
+      ami_search_pattern = "ubuntu/images/hvm-ssd/ubuntu-jammy*"
+      owners             = "aws-marketplace"
+      ami_product_code   = []
+      family             = "debian"
+      arch               = "arm64"
+      login_user         = "ubuntu"
+      instance_type      = "t4g.nano"
+      user_data          = <<EOF
+#! /bin/bash
+sudo snap refresh amazon-ssm-agent
+EOF
+    }
+    # Debian Distribution
+    debian11 = {
+      os_family          = "debian"
+      ami_search_pattern = "debian-10-amd64*"
+      ami_owner          = "679593333241"
+      ami_id             = "ami-0900b247bf638c13f"
+      # NOTE: we need product code to pick the right debian 10.
+      ami_product_code = [
+      "auhljmclkudu651zy27rih2x2"]
+      family     = "debian"
+      arch       = "amd64"
+      login_user = "admin"
+      user_data  = <<EOF
+#! /bin/bash
+cd /tmp
+sudo wget https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/debian_amd64/amazon-ssm-agent.deb
+while sudo fuser {/var/{lib/{dpkg,apt/lists},cache/apt/archives}/lock,/var/lib/dpkg/lock-frontend}; do
+   echo 'Waiting for dpkg lock...' && sleep 1
+done
+sudo dpkg -i amazon-ssm-agent.deb
+sudo systemctl enable amazon-ssm-agent
 EOF
     }
     debian10 = {
@@ -139,26 +203,7 @@ sudo dpkg -i amazon-ssm-agent.deb
 sudo systemctl enable amazon-ssm-agent
 EOF
     }
-    debian9 = {
-      os_family          = "debian"
-      ami_search_pattern = "debian-stretch-hvm-x86_64-gp2*"
-      ami_owner          = "679593333241"
-      ami_id             = "ami-028ee8676d656d1d6"
-      ami_product_code   = []
-      family             = "debian"
-      arch               = "amd64"
-      login_user         = "admin"
-      user_data          = <<EOF
-#! /bin/bash
-cd /tmp
-sudo wget https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/debian_amd64/amazon-ssm-agent.deb
-while sudo fuser {/var/{lib/{dpkg,apt/lists},cache/apt/archives}/lock,/var/lib/dpkg/lock-frontend}; do
-   echo 'Waiting for dpkg lock...' && sleep 1
-done
-sudo dpkg -i amazon-ssm-agent.deb
-sudo systemctl enable amazon-ssm-agent
-EOF
-    }
+  #AL2
     amazonlinux2 = {
       os_family          = "amazon_linux"
       ami_search_pattern = "amzn2-ami-hvm-2.0.????????.?-x86_64-gp2"
@@ -173,6 +218,31 @@ EOF
 sudo yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
 EOF
     }
+    arm_amazonlinux2 = {
+      os_family          = "amazon_linux"
+      ami_search_pattern = "amzn2-ami-hvm-2.0.????????.?-arm64-gp2"
+      ami_owner          = "amazon"
+      ami_id             = "ami-07c02c38124bd75bd"
+      ami_product_code   = []
+      family             = "linux"
+      arch               = "arm64"
+      instance_type      = "t4g.nano"
+      user_data          = <<EOF
+#! /bin/bash
+sudo yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_arm64/amazon-ssm-agent.rpm
+EOF
+    }
+    # Windows Distribution
+    windows2022 = {
+      os_family          = "windows"
+      ami_search_pattern = "Windows_Server-2019-English-Full-Base-*"
+      ami_owner          = "amazon"
+      ami_id             = "ami-0297fbf7e83dd1209"
+      ami_product_code   = []
+      family             = "windows"
+      arch               = "amd64"
+      login_user         = "Administrator"
+    }
     windows2019 = {
       os_family          = "windows"
       ami_search_pattern = "Windows_Server-2019-English-Full-Base-*"
@@ -183,6 +253,7 @@ EOF
       arch               = "amd64"
       login_user         = "Administrator"
     }
+    # Suse Distribution
     suse15 = {
       os_family          = "suse"
       ami_search_pattern = "suse-sles-15*"
@@ -219,85 +290,6 @@ sudo systemctl enable amazon-ssm-agent
 sudo systemctl start amazon-ssm-agent
 EOF
     }
-    redhat8 = {
-      os_family          = "redhat"
-      ami_search_pattern = "RHEL-8.0.0_HVM*"
-      ami_owner          = "309956199498"
-      ami_id             = "ami-087c2c50437d0b80d"
-      ami_product_code   = []
-      family             = "linux"
-      arch               = "amd64"
-      user_data          = <<EOF
-#! /bin/bash
-sudo dnf install -y python3
-sudo dnf install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
-EOF
-    }
-    redhat7 = {
-      os_family          = "redhat"
-      ami_search_pattern = "RHEL-7.7_HVM*"
-      ami_owner          = "309956199498"
-      ami_id             = "ami-0c2dfd42fa1fbb52c"
-      ami_product_code   = []
-      family             = "linux"
-      arch               = "amd64"
-      user_data          = <<EOF
-#! /bin/bash
-sudo yum install -y python3
-sudo yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
-EOF
-    }
-    centos7 = {
-      login_user         = "centos"
-      os_family          = "centos"
-      ami_search_pattern = "CentOS Linux 7 x86_64*"
-      ami_owner          = "679593333241"
-      ami_id             = "ami-0bc06212a56393ee1"
-      ami_product_code   = []
-      family             = "linux"
-      arch               = "amd64"
-      user_data          = <<EOF
-#! /bin/bash
-sudo yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
-EOF
-    }
-    #centos6 is not used in testing anymore
-    centos6 = {
-      login_user         = "centos"
-      os_family          = "centos"
-      ami_search_pattern = "CentOS Linux 6 x86_64 HVM EBS 2002*"
-      ami_owner          = "679593333241"
-      ami_product_code   = []
-      family             = "linux"
-      arch               = "amd64"
-      user_data          = <<EOF
-#! /bin/bash
-sudo iptables -I INPUT -p tcp -m tcp --dport 4317 -j ACCEPT
-sudo iptables -I INPUT -p udp -m udp --dport 55690 -j ACCEPT
-sudo service iptables save
-cd /tmp
-sudo curl https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm -o amazon-ssm-agent.rpm
-sudo rpm -ivh amazon-ssm-agent.rpm
-EOF
-    }
-
-
-    # arm amis
-    arm_amazonlinux2 = {
-      os_family          = "amazon_linux"
-      ami_search_pattern = "amzn2-ami-hvm-2.0.????????.?-arm64-gp2"
-      ami_owner          = "amazon"
-      ami_id             = "ami-07c02c38124bd75bd"
-      ami_product_code   = []
-      family             = "linux"
-      arch               = "arm64"
-      instance_type      = "t4g.nano"
-      user_data          = <<EOF
-#! /bin/bash
-sudo yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_arm64/amazon-ssm-agent.rpm
-EOF
-    }
-
     arm_suse15 = {
       os_family          = "suse"
       ami_search_pattern = "suse-sles-15-sp2-v20200721-hvm-ssd-arm64*"
@@ -314,8 +306,36 @@ sudo wget https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_a
 sudo rpm -ivh amazon-ssm-agent.rpm
 EOF
     }
-
-    arm_redhat8 = {
+  # Redhat Distribution
+  redhat9 = {
+      os_family          = "redhat"
+      ami_search_pattern = "RHEL-8.0.0_HVM*"
+      ami_owner          = "309956199498"
+      ami_id             = "ami-087c2c50437d0b80d"
+      ami_product_code   = []
+      family             = "linux"
+      arch               = "amd64"
+      user_data          = <<EOF
+#! /bin/bash
+sudo dnf install -y python3
+sudo dnf install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
+EOF
+    }
+    redhat8 = {
+      os_family          = "redhat"
+      ami_search_pattern = "RHEL-8.0.0_HVM*"
+      ami_owner          = "309956199498"
+      ami_id             = "ami-087c2c50437d0b80d"
+      ami_product_code   = []
+      family             = "linux"
+      arch               = "amd64"
+      user_data          = <<EOF
+#! /bin/bash
+sudo dnf install -y python3
+sudo dnf install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
+EOF
+    }
+    arm_redhat9 = {
       os_family          = "redhat"
       ami_search_pattern = "RHEL-8.0.0_HVM-20190426-arm64*"
       ami_owner          = "309956199498"
@@ -330,8 +350,7 @@ sudo dnf install -y python3
 sudo dnf install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_arm64/amazon-ssm-agent.rpm
 EOF
     }
-
-    arm_redhat7 = {
+    arm_redhat8 = {
       os_family          = "redhat"
       ami_search_pattern = "RHEL-7.6_HVM_GA-20181122-arm64*"
       ami_owner          = "309956199498"
@@ -345,72 +364,6 @@ EOF
 sudo yum install -y python3
 sudo yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_arm64/amazon-ssm-agent.rpm
 EOF
-    }
-
-    arm_ubuntu18 = {
-      os_family          = "ubuntu"
-      ami_search_pattern = "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-arm64*"
-      ami_owner          = "099720109477"
-      ami_id             = "ami-0f1337c0023ea5b49"
-      ami_product_code   = []
-      family             = "debian"
-      arch               = "arm64"
-      instance_type      = "t4g.nano"
-      user_data          = <<EOF
-#! /bin/bash
-sudo snap refresh amazon-ssm-agent
-EOF
-    }
-
-    arm_ubuntu16 = {
-      os_family          = "ubuntu"
-      ami_search_pattern = "ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-arm64*"
-      ami_owner          = "099720109477"
-      ami_id             = "ami-08305dd8ab642ad8c"
-      ami_product_code   = []
-      family             = "debian"
-      arch               = "arm64"
-      instance_type      = "t4g.nano"
-      user_data          = <<EOF
-#! /bin/bash
-sudo snap refresh amazon-ssm-agent
-EOF
-    }
-    canary_windows = {
-      os_family          = "windows"
-      ami_search_pattern = "Windows_Server-2019-English-Full-Base-*"
-      ami_owner          = "amazon"
-      ami_id             = "ami-01f14dc60171d8d7b"
-      ami_product_code   = []
-      family             = "windows"
-      arch               = "amd64"
-    }
-    canary_linux = {
-      os_family          = "amazon_linux"
-      ami_search_pattern = "amzn2-ami-hvm-2.0.????????.?-x86_64-gp2"
-      ami_owner          = "amazon"
-      ami_id             = "ami-0c2ab3b8efb09f272"
-      ami_product_code   = []
-      family             = "amazon_linux"
-      arch               = "amd64"
-    }
-    soaking_windows = {
-      os_family          = "windows"
-      ami_search_pattern = "Windows_Server-2019-English-Full-Base-*"
-      ami_owner          = "amazon"
-      ami_id             = "ami-01f14dc60171d8d7b"
-      ami_product_code   = []
-      family             = "windows"
-      arch               = "amd64"
-    }
-    soaking_linux = {
-      os_family          = "amazon_linux"
-      ami_search_pattern = "amzn2-ami-hvm-2.0.????????.?-x86_64-gp2"
-      ami_owner          = "amazon"
-      ami_id             = "ami-0c2ab3b8efb09f272"
-      ami_product_code   = []
-      family             = "amazon_linux"
-      arch               = "amd64"
     }
   }
 }

--- a/terraform/ec2/amis.tf
+++ b/terraform/ec2/amis.tf
@@ -253,7 +253,7 @@ EOF
     #AL2
     amazonlinux2 = {
       os_family          = "amazon_linux"
-      ami_search_pattern = "amzn2-ami-kernel*"
+      ami_search_pattern = "amzn2-ami-kernel.5*"
       ami_owner          = "amazon"
       ami_product_code   = []
       family             = "linux"
@@ -266,7 +266,7 @@ EOF
     }
     arm_amazonlinux2 = {
       os_family          = "amazon_linux"
-      ami_search_pattern = "amzn2-ami-kernel*"
+      ami_search_pattern = "amzn2-ami-kernel.5*"
       ami_owner          = "amazon"
       ami_product_code   = []
       family             = "linux"

--- a/terraform/ec2/main.tf
+++ b/terraform/ec2/main.tf
@@ -64,7 +64,7 @@ locals {
   docker_compose_path  = var.soaking_compose_file != "" ? var.soaking_compose_file : fileexists("${var.testcase}/docker_compose.tpl") ? "${var.testcase}/docker_compose.tpl" : module.common.default_docker_compose_path
   selected_ami         = var.amis[var.testing_ami]
   ami_family           = var.ami_family[local.selected_ami["family"]]
-  ami_id               = var.amis[var.testing_ami]["ami_id"]
+  ami_id               = data.aws_ami.selected.id
   instance_type        = lookup(local.selected_ami, "instance_type", local.ami_family["instance_type"])
   otconfig_destination = local.ami_family["otconfig_destination"]
   login_user           = lookup(local.selected_ami, "login_user", local.ami_family["login_user"])

--- a/terraform/ec2_setup/amis.tf
+++ b/terraform/ec2_setup/amis.tf
@@ -64,21 +64,19 @@ variable "amis" {
   default = {
     soaking_windows = {
       os_family          = "windows"
-      ami_search_pattern = "Windows_Server-2019-English-Full-Base-*"
+      ami_search_pattern = "Windows_Server-2022-English-Full-Base*"
       ami_owner          = "amazon"
-      ami_id             = "ami-0297fbf7e83dd1209"
       ami_product_code   = []
       family             = "windows"
-      arch               = "amd64"
+      arch               = "x86_64"
     }
     soaking_linux = {
       os_family          = "amazon_linux"
-      ami_search_pattern = "amzn2-ami-hvm-2.0.????????.?-x86_64-gp2"
+      ami_search_pattern = "amzn2-ami-kernel*"
       ami_owner          = "amazon"
-      ami_id             = "ami-0c2ab3b8efb09f272"
       ami_product_code   = []
       family             = "amazon_linux"
-      arch               = "amd64"
+      arch               = "x86_64"
     }
   }
 }

--- a/terraform/ec2_setup/amis.tf
+++ b/terraform/ec2_setup/amis.tf
@@ -72,7 +72,7 @@ variable "amis" {
     }
     soaking_linux = {
       os_family          = "amazon_linux"
-      ami_search_pattern = "amzn2-ami-kernel*"
+      ami_search_pattern = "amzn2-ami-kernel.5*"
       ami_owner          = "amazon"
       ami_product_code   = []
       family             = "amazon_linux"

--- a/tools/batchTestGenerator/internal/testCaseBuilder.go
+++ b/tools/batchTestGenerator/internal/testCaseBuilder.go
@@ -22,23 +22,24 @@ type TestCaseInfo struct {
 }
 
 var ec2AMIs = []string{
-	"amazonlinux2",
 	"ubuntu18",
-	"ubuntu16",
-	"debian10",
-	"debian9",
+	"arm_ubuntu18",
+	"ubuntu20",
+	"arm_ubuntu20"
+	"ubuntu22",
+	"arm_ubuntu22",
+	"debain11",
+	"arm_debian11",
+	"debain10",
+	"arm_debian10",
+	"amazonlinux2",
+	"arm_amazonlinux2",
+	"windows2022",
+	"windows2019",
 	"suse15",
 	"suse12",
 	"redhat8",
-	"redhat7",
-	"centos7",
-	"windows2019",
-	"arm_amazonlinux2",
-	"arm_suse15",
-	"arm_redhat8",
-	"arm_redhat7",
-	"arm_ubuntu18",
-	"arm_ubuntu16",
+	"arm_redhat8"
 }
 
 var ecsLaunchTypes = []string{"EC2", "FARGATE"}


### PR DESCRIPTION
**Description:** 

This PR introduces various updates for the `EC2 instance distributions` that the ADOT Testing Framework supports.The changes include:

- A simplified regex pattern to search for new AMIs.
- Remove AMI Id hardcoding.
- Include new versions of the Image distributions and deprecate older ones ( Ex Ubuntu 22 ).
- Add ARM images for some distributions.
- `Canary` and `Performance tests` now use `Windows 2022 `and `Amazon Linux 2`.
- Deprecate CentOS.

**Testing:** 

Tested locally by cross checking the terraform output AMI Id with AWS-EC2-AMI Console results.

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

