### PR TITLE
Use local Arch variable 

### DIFF
--- a/terraform/ec2/amis.tf
+++ b/terraform/ec2/amis.tf
@@ -398,7 +398,7 @@ data "aws_ami" "selected" {
 
   filter {
     name   = "architecture"
-    values = [var.amis[var.testing_ami]["arch"]]
+    values = [local.arch]
   }
 
   filter {


### PR DESCRIPTION
**Description:** 

This is an extension to #863 to let `aws_ami` data module to use `local arch` variable instead of the `default`

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

