### PR TITLE
Change suse12 search pattern

### DIFF
--- a/terraform/ec2/amis.tf
+++ b/terraform/ec2/amis.tf
@@ -333,7 +333,7 @@ EOF
     }
     suse12 = {
       os_family          = "suse"
-      ami_search_pattern = "suse-sles-12*"
+      ami_search_pattern = "suse-sles-12-sp5-v????????-hvm-ssd-x86_64"
       ami_owner          = "amazon"
       ami_product_code   = []
       family             = "linux"


### PR DESCRIPTION
**Description:** 

The search pattern `suse-sles-12*` for `suse12` picks up an AMI which is an optimized version for ECS. This is causing permission errors while running `remote-exec` command of downloading the ADOT collector. This PR changes the search pattern to be more specific in picking the enterprise version of suse12.


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

