### PR TITLE
Update debian ARM search pattern

### DIFF
--- a/terraform/ec2/amis.tf
+++ b/terraform/ec2/amis.tf
@@ -193,7 +193,7 @@ EOF
     }
     arm_debian11 = {
       os_family          = "debian"
-      ami_search_pattern = "debian-11-*"
+      ami_search_pattern = "debian-11-arm64*"
       ami_owner          = "amazon"
       ami_product_code   = []
       family             = "debian"
@@ -232,7 +232,7 @@ EOF
     }
     arm_debian10 = {
       os_family          = "debian"
-      ami_search_pattern = "debian-10-*"
+      ami_search_pattern = "debian-10-arm64*"
       ami_owner          = "amazon"
       ami_product_code   = []
       family             = "debian"


### PR DESCRIPTION
**Description:** 

The current CI runs fail for the following two test cases. `EC2 ssm_package arm_debian11` and `EC2 ssm_package arm_debian10`. This is because of the failure in installation of the collector through SSM. This PR pulls a different AMI of the ARM versions of debian 10 and 11 which seems to mitigate this failure.


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

