### PR TITLE
ECS_HealthCheck_Config_Correction

### DIFF
--- a/terraform/testcases/ecshealthcheck/otconfig.tpl
+++ b/terraform/testcases/ecshealthcheck/otconfig.tpl
@@ -1,7 +1,5 @@
 extensions:
   health_check:
-    endpoint: "localhost:13133"
-    path: "/health/status"
 receivers:
   prometheus:
     config:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Made correction to aws-otel-test-framework/terraform/testcases/ecshealthcheck/otconfig.tpl to remove the non-default healthcheck endpoints. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

