### PR TITLE
Update AMI ID for windows 2019 for EC2 tests

### DIFF
--- a/terraform/ec2/amis.tf
+++ b/terraform/ec2/amis.tf
@@ -177,7 +177,7 @@ EOF
       os_family          = "windows"
       ami_search_pattern = "Windows_Server-2019-English-Full-Base-*"
       ami_owner          = "amazon"
-      ami_id             = "ami-0297fbf7e83dd1209"
+      ami_id             = "ami-026bb75827bd3d68d"
       ami_product_code   = []
       family             = "windows"
       arch               = "amd64"

--- a/terraform/ec2_setup/amis.tf
+++ b/terraform/ec2_setup/amis.tf
@@ -66,7 +66,7 @@ variable "amis" {
       os_family          = "windows"
       ami_search_pattern = "Windows_Server-2019-English-Full-Base-*"
       ami_owner          = "amazon"
-      ami_id             = "ami-0297fbf7e83dd1209"
+      ami_id             = "ami-026bb75827bd3d68d"
       ami_product_code   = []
       family             = "windows"
       arch               = "amd64"


### PR DESCRIPTION
**Description:** 

This PR is created to use the AMI ID for windows 2019 from the community


![Screen Shot 2022-11-02 at 11 27 39 AM](https://user-images.githubusercontent.com/41936996/199572075-9062d10b-affb-4817-9068-3e6ce2368707.png)

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

