### PR TITLE
Use Correct ami-id for the region us-west-2

### DIFF
--- a/terraform/ec2/amis.tf
+++ b/terraform/ec2/amis.tf
@@ -177,7 +177,7 @@ EOF
       os_family          = "windows"
       ami_search_pattern = "Windows_Server-2019-English-Full-Base-*"
       ami_owner          = "amazon"
-      ami_id             = "ami-026bb75827bd3d68d"
+      ami_id             = "ami-0101b5782d8fe3fbe"
       ami_product_code   = []
       family             = "windows"
       arch               = "amd64"

--- a/terraform/ec2_setup/amis.tf
+++ b/terraform/ec2_setup/amis.tf
@@ -66,7 +66,7 @@ variable "amis" {
       os_family          = "windows"
       ami_search_pattern = "Windows_Server-2019-English-Full-Base-*"
       ami_owner          = "amazon"
-      ami_id             = "ami-026bb75827bd3d68d"
+      ami_id             = "ami-0101b5782d8fe3fbe"
       ami_product_code   = []
       family             = "windows"
       arch               = "amd64"


### PR DESCRIPTION
**Description:** 

This PR fixes to use correct ami-id for the us-west-2 region. Initial PR #904 aimed to use us-east-1 region

link :
https://us-west-2.console.aws.amazon.com/ec2/home?region=us-west-2#AMICatalog:

![Screen Shot 2022-11-02 at 1 18 33 PM](https://user-images.githubusercontent.com/41936996/199594287-a8c3ecd4-5945-4b1a-9bfb-ecbd82f08ccb.png)


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

