### PR TITLE
Update AMI Id for arm_redhat8 EC2 Instances

### DIFF
--- a/terraform/ec2/amis.tf
+++ b/terraform/ec2/amis.tf
@@ -317,9 +317,9 @@ EOF
 
     arm_redhat8 = {
       os_family          = "redhat"
-      ami_search_pattern = "RHEL-8.0.0_HVM-20190426-arm64*"
+      ami_search_pattern = "RHEL-8.6.0_HVM-20220503-arm64*"
       ami_owner          = "309956199498"
-      ami_id             = "ami-0f7a968a2c17fb48b"
+      ami_id             = "ami-0bb199dd39edd7d71"
       ami_product_code   = []
       family             = "linux"
       arch               = "arm64"


### PR DESCRIPTION
**Description:** 

The PR is created to update the AMI id to the stable version.

AMI ID reference : https://access.redhat.com/solutions/15356
[AMI ID](https://github.com/aws-observability/aws-otel-collector/actions/runs/3372537380/jobs/5596542155#step:9:2803) from Last successful CI run 


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

