### PR TITLE
Use latest ami id for arm_suse15 in suse OS family

### DIFF
--- a/terraform/ec2/amis.tf
+++ b/terraform/ec2/amis.tf
@@ -300,13 +300,13 @@ EOF
 
     arm_suse15 = {
       os_family          = "suse"
-      ami_search_pattern = "suse-sles-15*"
-      ami_owner          = "amazon"
+      ami_search_pattern = "suse-sles-15-sp2-v20210212-hvm-ssd-arm64*"
+      ami_owner          = "013907871322"
+      ami_id             = "ami-0b704e615e7364682"
       ami_product_code   = []
       family             = "linux"
-      login_user         = "ec2-user"
       arch               = "arm64"
-      instance_type      = "t4g.micro"
+      instance_type      = "t4g.nano"
       user_data          = <<EOF
 #! /bin/bash
 cd /tmp

--- a/terraform/ec2/amis.tf
+++ b/terraform/ec2/amis.tf
@@ -300,13 +300,13 @@ EOF
 
     arm_suse15 = {
       os_family          = "suse"
-      ami_search_pattern = "suse-sles-15-sp2-v20200721-hvm-ssd-arm64*"
+      ami_search_pattern = "suse-sles-15*"
       ami_owner          = "amazon"
-      ami_id             = "ami-0bfc92b18fd79372c"
       ami_product_code   = []
       family             = "linux"
+      login_user         = "ec2-user"
       arch               = "arm64"
-      instance_type      = "t4g.nano"
+      instance_type      = "t4g.micro"
       user_data          = <<EOF
 #! /bin/bash
 cd /tmp


### PR DESCRIPTION
**Description:** 

This PR is to use latest arm_suse15 available for the tests, using latest ami availble in community closest to the pattern since `suse-sles-15-sp2-v20200721-hvm-ssd-arm64*` doesn't any updated matching ami's available.


<img width="742" alt="image" src="https://user-images.githubusercontent.com/41936996/200207611-e50963e7-0d7c-4650-9c93-842e0bdaed76.png">

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

