### PR TITLE
Use suse12 ami-id to the latest available

### DIFF
--- a/terraform/ec2/amis.tf
+++ b/terraform/ec2/amis.tf
@@ -204,9 +204,9 @@ EOF
     suse12 = {
       os_family          = "suse"
       ami_search_pattern = "suse-sles-12*"
-      ami_owner          = "amazon"
+      ami_owner          = "013907871322"
       ami_product_code   = []
-      ami_id             = "ami-088a78f435ef7f78a"
+      ami_id             = "ami-045fab2f0a419b67b"
       family             = "linux"
       login_user         = "ec2-user"
       arch               = "amd64"


### PR DESCRIPTION
**Description:** 

This PR uses suse12 ami-id to the latest available, targeted to address the [failure](https://github.com/aws-observability/aws-otel-collector/actions/runs/3397061559/jobs/5670341069#step:9:736) -> [reference](https://github.com/aws-observability/aws-otel-collector/actions/runs/3397061559/jobs/5670341069#step:9:243)

<img width="539" alt="image" src="https://user-images.githubusercontent.com/41936996/200280351-a5c2d396-7e13-42a9-8a45-4dc92117e414.png">

Reference from successful tests : https://github.com/aws-observability/aws-otel-collector/actions/runs/3372537380/jobs/5596536744#step:9:2805

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

