### PR TITLE
Enable and start ssm agent service for SLES15 in ARM

### DIFF
--- a/terraform/ec2/amis.tf
+++ b/terraform/ec2/amis.tf
@@ -328,7 +328,9 @@ EOF
 #! /bin/bash
 cd /tmp
 sudo wget https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_arm64/amazon-ssm-agent.rpm
-sudo rpm -ivh amazon-ssm-agent.rpm
+sudo rpm -Uvh amazon-ssm-agent.rpm
+sudo systemctl enable amazon-ssm-agent
+sudo systemctl start amazon-ssm-agent
 EOF
     }
     suse12 = {


### PR DESCRIPTION
Signed-off-by: Raphael Silva <rapphil@gmail.com>

**Description:** Enable and start ssm service as recommended by the manual.
https://docs.aws.amazon.com/systems-manager/latest/userguide/agent-install-sles.html


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

