### PR TITLE
[dev/cdk] Apply rbac changes to cluster by default

### DIFF
--- a/cdk_framework/EKS/lib/cluster-deployment.ts
+++ b/cdk_framework/EKS/lib/cluster-deployment.ts
@@ -10,6 +10,7 @@ import { validateFileSchema } from './utils/validate-config-schema';
 import { ClusterInterface } from './interfaces/cluster-interface';
 import { ec2ClusterInterface } from './interfaces/ec2cluster-interface';
 import { validateInterface } from './utils/validate-interface-schema';
+import { ClusterAuth } from './constructs/clusterAuthConstruct';
 
 const yaml = require('js-yaml');
 
@@ -41,7 +42,7 @@ export function deployClusters(
 
   const clusterNameSet = new Set();
   for (const cluster of configData['clusters']) {
-    let stack;
+    let clusterStack;
     const clusterInterface = cluster as ClusterInterface;
     if (clusterNameSet.has(clusterInterface.name)) {
       throw new Error(
@@ -56,7 +57,7 @@ export function deployClusters(
     if (clusterInterface.launch_type === 'ec2') {
       const ec2Cluster = cluster as ec2ClusterInterface;
       validateInterface(ec2Cluster);
-      stack = new EC2Stack(app, `${ec2Cluster.name}EKSCluster`, {
+      clusterStack = new EC2Stack(app, `${ec2Cluster.name}EKSCluster`, {
         name: ec2Cluster.name,
         vpc: vpcStack.vpc,
         version: versionKubernetes,
@@ -67,7 +68,7 @@ export function deployClusters(
       });
     } else {
       validateInterface(clusterInterface);
-      stack = new FargateStack(app, `${clusterInterface.name}EKSCluster`, {
+      clusterStack = new FargateStack(app, `${clusterInterface.name}EKSCluster`, {
         name: clusterInterface.name,
         vpc: vpcStack.vpc,
         version: versionKubernetes,
@@ -76,7 +77,10 @@ export function deployClusters(
         }
       });
     }
-    eksClusterMap.set(cluster['name'], stack);
+    new ClusterAuth(clusterStack, `${clusterInterface.name}ClusterAuth`, {
+      cluster: clusterStack.cluster
+    });
+    eksClusterMap.set(cluster['name'], clusterStack);
   }
 
   return eksClusterMap;

--- a/cdk_framework/EKS/lib/cluster-deployment.ts
+++ b/cdk_framework/EKS/lib/cluster-deployment.ts
@@ -68,14 +68,18 @@ export function deployClusters(
       });
     } else {
       validateInterface(clusterInterface);
-      clusterStack = new FargateStack(app, `${clusterInterface.name}EKSCluster`, {
-        name: clusterInterface.name,
-        vpc: vpcStack.vpc,
-        version: versionKubernetes,
-        env: {
-          region: REGION
+      clusterStack = new FargateStack(
+        app,
+        `${clusterInterface.name}EKSCluster`,
+        {
+          name: clusterInterface.name,
+          vpc: vpcStack.vpc,
+          version: versionKubernetes,
+          env: {
+            region: REGION
+          }
         }
-      });
+      );
     }
     new ClusterAuth(clusterStack, `${clusterInterface.name}ClusterAuth`, {
       cluster: clusterStack.cluster

--- a/cdk_framework/EKS/lib/constructs/clusterAuthConstruct.ts
+++ b/cdk_framework/EKS/lib/constructs/clusterAuthConstruct.ts
@@ -13,8 +13,8 @@ export class ClusterAuth extends Construct {
   constructor(scope: Construct, id: string, props: ClusterAuthConstructProps) {
     super(scope, id);
     this.cluster = props.cluster;
-    this.applyClusterAuthMap()
-    this.applyClusterRbac()
+    this.applyClusterAuthMap();
+    this.applyClusterRbac();
   }
   applyClusterAuthMap() {
     const clusterReadOnlyRole = Role.fromRoleName(

--- a/cdk_framework/EKS/lib/constructs/clusterAuthConstruct.ts
+++ b/cdk_framework/EKS/lib/constructs/clusterAuthConstruct.ts
@@ -1,0 +1,135 @@
+import { Construct } from 'constructs';
+import { Cluster, FargateCluster } from 'aws-cdk-lib/aws-eks';
+import { Role } from 'aws-cdk-lib/aws-iam';
+
+/**
+ * Apply a set of opinionated ClusterRoles, ClusterRoleBindings
+ * and AWSAuth map modifications. This construct does not create
+ * new IAM roles but assumes that these roles already exist.
+ */
+export class ClusterAuth extends Construct {
+  cluster: Cluster | FargateCluster;
+
+  constructor(scope: Construct, id: string, props: ClusterAuthConstructProps) {
+    super(scope, id);
+    this.cluster = props.cluster;
+    this.applyClusterAuthMap()
+    this.applyClusterRbac()
+  }
+  applyClusterAuthMap() {
+    const clusterReadOnlyRole = Role.fromRoleName(
+      this,
+      'clusterReadOnlyRole',
+      'ClusterReadOnly'
+    );
+    this.cluster.awsAuth.addRoleMapping(clusterReadOnlyRole, {
+      groups: ['adot-dev-readonly'],
+      username: 'adot-readonly'
+    });
+
+    const clusterAdminRole = Role.fromRoleName(
+      this,
+      'clusterAdminRole',
+      'ClusterAdmin'
+    );
+    this.cluster.awsAuth.addRoleMapping(clusterAdminRole, {
+      groups: ['adot-dev-admin'],
+      username: 'adot-admin'
+    });
+
+    const repoWorkflowRole = Role.fromRoleName(
+      this,
+      'repoWorkflowRole',
+      'aws-obs-collector-gha'
+    );
+    this.cluster.awsAuth.addRoleMapping(repoWorkflowRole, {
+      groups: ['adot-workflow'],
+      username: 'adot-workflow'
+    });
+  }
+  applyClusterRbac() {
+    const roClusterRole = {
+      apiVersion: 'rbac.authorization.k8s.io/v1',
+      kind: 'ClusterRole',
+      metadata: {
+        name: 'otel-operator-readonly',
+        labels: {
+          'rbac.authorization.k8s.io/aggregate-to-view': 'true'
+        }
+      },
+      rules: [
+        {
+          apiGroups: ['opentelemetry.io'],
+          resources: ['instrumentations', 'opentelemetrycollectors'],
+          verbs: ['get', 'list', 'watch']
+        }
+      ]
+    };
+
+    const roClusterRoleBinding = {
+      kind: 'ClusterRoleBinding',
+      apiVersion: 'rbac.authorization.k8s.io/v1',
+      metadata: { name: 'adot-dev-readonly-crb' },
+      subjects: [
+        {
+          kind: 'Group',
+          name: 'adot-dev-readonly',
+          apiGroup: 'rbac.authorization.k8s.io'
+        }
+      ],
+      roleRef: {
+        kind: 'ClusterRole',
+        name: 'view',
+        apiGroup: 'rbac.authorization.k8s.io'
+      }
+    };
+
+    const adminClusterRoleBinding = {
+      kind: 'ClusterRoleBinding',
+      apiVersion: 'rbac.authorization.k8s.io/v1',
+      metadata: { name: 'adot-dev-admin-crb' },
+      subjects: [
+        {
+          kind: 'Group',
+          name: 'adot-dev-admin',
+          apiGroup: 'rbac.authorization.k8s.io'
+        }
+      ],
+      roleRef: {
+        kind: 'ClusterRole',
+        name: 'cluster-admin',
+        apiGroup: 'rbac.authorization.k8s.io'
+      }
+    };
+
+    const workflowClusterRoleBinding = {
+      kind: 'ClusterRoleBinding',
+      apiVersion: 'rbac.authorization.k8s.io/v1',
+      metadata: { name: 'adot-workflow-admin-crb' },
+
+      subjects: [
+        {
+          kind: 'Group',
+          name: 'adot-workflow-admin',
+          apiGroup: 'rbac.authorization.k8s.io'
+        }
+      ],
+      roleRef: {
+        kind: 'ClusterRole',
+        name: 'cluster-admin',
+        apiGroup: 'rbac.authorization.k8s.io'
+      }
+    };
+    this.cluster.addManifest(
+      'ClusterRoleBindings',
+      roClusterRole,
+      roClusterRoleBinding,
+      adminClusterRoleBinding,
+      workflowClusterRoleBinding
+    );
+  }
+}
+
+export interface ClusterAuthConstructProps {
+  cluster: Cluster | FargateCluster;
+}

--- a/cdk_framework/EKS/test/cluster-deployment.test.ts
+++ b/cdk_framework/EKS/test/cluster-deployment.test.ts
@@ -51,5 +51,6 @@ test('ClusterTest', () => {
         }
       }
     });
+    template.resourceCountIs('Custom::AWSCDK-EKS-KubernetesResource',2)
   }
 });

--- a/cdk_framework/EKS/test/cluster-deployment.test.ts
+++ b/cdk_framework/EKS/test/cluster-deployment.test.ts
@@ -51,6 +51,6 @@ test('ClusterTest', () => {
         }
       }
     });
-    template.resourceCountIs('Custom::AWSCDK-EKS-KubernetesResource',2)
+    template.resourceCountIs('Custom::AWSCDK-EKS-KubernetesResource', 2);
   }
 });


### PR DESCRIPTION
**Description:** This PR adds a new construct `clusterAuthConstruct`. This is used to apply the necessary RBAC changes necessary for the integration test suite to every cluster. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

