### PR TITLE
[dev/cdk] Refactor VPC deployment outside of cluster deployment

### DIFF
--- a/cdk_infra/README.md
+++ b/cdk_infra/README.md
@@ -28,7 +28,6 @@ In order to update clusters, just change the config file and then call `make -j 
 There are a number of environment variables that should be defined before deploying the clusters:
 
 * `CDK_CONFIG_PATH` - This is the path for which the cluster configuration file is located - default is `clusters.yml` in `lib/config/cluster-config` folder.
-* `REGION` - This is the region for which the clusters should be deployed - default is `us-west-2`.
 
 ### Cluster Configuration
 
@@ -78,6 +77,10 @@ In order to run these tests, use command `npm run test`.
 ### Linter
 
 ESLint is used to make sure formatting is done well. To run the linter, call `npm run lint`. 
+
+### cdk.context.json
+
+The app relies on `CDK_DEFAULT_ACCOUNT` and `CDK_DEFAULT_REGION` to set their [environment](https://docs.aws.amazon.com/cdk/v2/guide/environments.html). The CDK documentation suggestions that [runtime context](https://docs.aws.amazon.com/cdk/v2/guide/context.html#context_construct) files should be checked into source control. A readonly IAM role is required to run `cdk synth` on all accounts that this app will be subsequently deployed to. 
 
 ## Useful commands
 

--- a/cdk_infra/cdk.context.json
+++ b/cdk_infra/cdk.context.json
@@ -1,0 +1,14 @@
+{
+  "availability-zones:account=616567865305:region=us-west-2": [
+    "us-west-2a",
+    "us-west-2b",
+    "us-west-2c",
+    "us-west-2d"
+  ],
+  "availability-zones:account=611364707713:region=us-west-2": [
+    "us-west-2a",
+    "us-west-2b",
+    "us-west-2c",
+    "us-west-2d"
+  ]
+}

--- a/cdk_infra/lib/app.ts
+++ b/cdk_infra/lib/app.ts
@@ -2,7 +2,14 @@
 import 'source-map-support/register';
 import * as cdk from 'aws-cdk-lib';
 import { deployClusters } from './cluster-deployment';
+import { VPCStack } from './stacks/vpc/vpc-stack';
+import { StackProps } from 'aws-cdk-lib';
 
+
+const envDefault  = { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION };
 const app = new cdk.App();
 
-const clusterMap = deployClusters(app);
+const vpcStack = new VPCStack(app, 'EKSVpc', {
+    env: envDefault
+});
+deployClusters(app, vpcStack.vpc, envDefault );

--- a/cdk_infra/lib/app.ts
+++ b/cdk_infra/lib/app.ts
@@ -5,11 +5,13 @@ import { deployClusters } from './cluster-deployment';
 import { VPCStack } from './stacks/vpc/vpc-stack';
 import { StackProps } from 'aws-cdk-lib';
 
-
-const envDefault  = { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION };
+const envDefault = {
+  account: process.env.CDK_DEFAULT_ACCOUNT,
+  region: process.env.CDK_DEFAULT_REGION
+};
 const app = new cdk.App();
 
 const vpcStack = new VPCStack(app, 'EKSVpc', {
-    env: envDefault
+  env: envDefault
 });
-deployClusters(app, vpcStack.vpc, envDefault );
+deployClusters(app, vpcStack.vpc, envDefault);

--- a/cdk_infra/lib/app.ts
+++ b/cdk_infra/lib/app.ts
@@ -3,7 +3,6 @@ import 'source-map-support/register';
 import * as cdk from 'aws-cdk-lib';
 import { deployClusters } from './cluster-deployment';
 import { VPCStack } from './stacks/vpc/vpc-stack';
-import { StackProps } from 'aws-cdk-lib';
 
 const envDefault = {
   account: process.env.CDK_DEFAULT_ACCOUNT,

--- a/cdk_infra/lib/cluster-deployment.ts
+++ b/cdk_infra/lib/cluster-deployment.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 import 'source-map-support/register';
 import * as cdk from 'aws-cdk-lib';
-import { VPCStack } from './stacks/vpc/vpc-stack';
 import { aws_eks as eks, StackProps } from 'aws-cdk-lib';
 import { readFileSync } from 'fs';
 import { EC2Stack } from './stacks/eks/ec2-cluster-stack';

--- a/cdk_infra/lib/cluster-deployment.ts
+++ b/cdk_infra/lib/cluster-deployment.ts
@@ -17,7 +17,11 @@ import { Vpc } from 'aws-cdk-lib/aws-ec2';
 
 const yaml = require('js-yaml');
 
-export function deployClusters(app: cdk.App, vpc: Vpc, envInput?: StackProps["env"]): Map<string, FargateStack | EC2Stack> {
+export function deployClusters(
+  app: cdk.App,
+  vpc: Vpc,
+  envInput?: StackProps['env']
+): Map<string, FargateStack | EC2Stack> {
   const route =
     process.env.CDK_CONFIG_PATH ||
     __dirname + '/config/cluster-config/clusters.yml';

--- a/cdk_infra/lib/cluster-deployment.ts
+++ b/cdk_infra/lib/cluster-deployment.ts
@@ -2,7 +2,7 @@
 import 'source-map-support/register';
 import * as cdk from 'aws-cdk-lib';
 import { VPCStack } from './stacks/vpc/vpc-stack';
-import { aws_eks as eks } from 'aws-cdk-lib';
+import { aws_eks as eks, StackProps } from 'aws-cdk-lib';
 import { readFileSync } from 'fs';
 import { EC2Stack } from './stacks/eks/ec2-cluster-stack';
 import { FargateStack } from './stacks/eks/fargate-cluster-stack';
@@ -13,14 +13,11 @@ import { validateInterface } from './utils/eks/validate-interface-schema';
 import { ClusterAuth } from './constructs/eks/clusterAuthConstruct';
 import { HelmChart } from 'aws-cdk-lib/aws-eks';
 import { OpenIdConnectProvider } from 'aws-cdk-lib/aws-eks';
+import { Vpc } from 'aws-cdk-lib/aws-ec2';
 
 const yaml = require('js-yaml');
 
-export function deployClusters(
-  app: cdk.App
-): Map<string, FargateStack | EC2Stack> {
-  const REGION = process.env.REGION || 'us-west-2';
-
+export function deployClusters(app: cdk.App, vpc: Vpc, envInput: StackProps["env"]) {
   const route =
     process.env.CDK_CONFIG_PATH ||
     __dirname + '/config/cluster-config/clusters.yml';
@@ -35,12 +32,6 @@ export function deployClusters(
   validateFileSchema(configData);
 
   const eksClusterMap = new Map<string, FargateStack | EC2Stack>();
-
-  const vpcStack = new VPCStack(app, 'EKSVpc', {
-    env: {
-      region: REGION
-    }
-  });
 
   const clusterNameSet = new Set();
   for (const cluster of configData['clusters']) {
@@ -61,12 +52,10 @@ export function deployClusters(
       validateInterface(ec2Cluster);
       clusterStack = new EC2Stack(app, `${ec2Cluster.name}EKSCluster`, {
         name: ec2Cluster.name,
-        vpc: vpcStack.vpc,
+        vpc: vpc,
         version: versionKubernetes,
         instance_type: ec2Cluster.instance_type,
-        env: {
-          region: REGION
-        }
+        env: envInput
       });
     } else {
       validateInterface(clusterInterface);
@@ -75,11 +64,9 @@ export function deployClusters(
         `${clusterInterface.name}EKSCluster`,
         {
           name: clusterInterface.name,
-          vpc: vpcStack.vpc,
+          vpc: vpc,
           version: versionKubernetes,
-          env: {
-            region: REGION
-          }
+          env: envInput
         }
       );
     }
@@ -122,6 +109,4 @@ export function deployClusters(
     );
     eksClusterMap.set(cluster['name'], clusterStack);
   }
-
-  return eksClusterMap;
 }

--- a/cdk_infra/lib/cluster-deployment.ts
+++ b/cdk_infra/lib/cluster-deployment.ts
@@ -17,7 +17,7 @@ import { Vpc } from 'aws-cdk-lib/aws-ec2';
 
 const yaml = require('js-yaml');
 
-export function deployClusters(app: cdk.App, vpc: Vpc, envInput: StackProps["env"]) {
+export function deployClusters(app: cdk.App, vpc: Vpc, envInput?: StackProps["env"]): Map<string, FargateStack | EC2Stack> {
   const route =
     process.env.CDK_CONFIG_PATH ||
     __dirname + '/config/cluster-config/clusters.yml';
@@ -109,4 +109,5 @@ export function deployClusters(app: cdk.App, vpc: Vpc, envInput: StackProps["env
     );
     eksClusterMap.set(cluster['name'], clusterStack);
   }
+  return eksClusterMap;
 }

--- a/cdk_infra/lib/stacks/eks/ec2-cluster-stack.ts
+++ b/cdk_infra/lib/stacks/eks/ec2-cluster-stack.ts
@@ -1,13 +1,8 @@
 import { Stack, StackProps, aws_eks as eks, aws_ec2 as ec2 } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { Vpc } from 'aws-cdk-lib/aws-ec2';
-import {
-  CapacityType,
-  KubectlProvider,
-  KubernetesVersion,
-  Nodegroup
-} from 'aws-cdk-lib/aws-eks';
-import { ManagedPolicy, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
+import { KubernetesVersion, Nodegroup } from 'aws-cdk-lib/aws-eks';
+import { ManagedPolicy } from 'aws-cdk-lib/aws-iam';
 import { GetLayer } from '../../utils/eks/kubectlLayer';
 
 export class EC2Stack extends Stack {

--- a/cdk_infra/lib/stacks/vpc/vpc-stack.ts
+++ b/cdk_infra/lib/stacks/vpc/vpc-stack.ts
@@ -7,13 +7,14 @@ export class VPCStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
-    const REGION = process.env.REGION || 'us-west-2';
+    const REGION = process.env.CDK_DEFAULT_REGION || 'us-west-2';
 
     this.vpc = new ec2.Vpc(this, 'EKSVpc', {
       cidr: '10.0.0.0/16',
       natGateways: 1,
       vpnGateway: true,
-      availabilityZones: [REGION + 'a', REGION + 'b', REGION + 'c'],
+      //https://github.com/aws/aws-cdk/issues/21690
+      availabilityZones: Stack.of(this).availabilityZones.sort().slice(0,1),
       subnetConfiguration: [
         {
           cidrMask: 24,

--- a/cdk_infra/lib/stacks/vpc/vpc-stack.ts
+++ b/cdk_infra/lib/stacks/vpc/vpc-stack.ts
@@ -6,9 +6,6 @@ export class VPCStack extends Stack {
 
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
-
-    const REGION = process.env.CDK_DEFAULT_REGION || 'us-west-2';
-
     this.vpc = new ec2.Vpc(this, 'EKSVpc', {
       cidr: '10.0.0.0/16',
       natGateways: 1,

--- a/cdk_infra/lib/stacks/vpc/vpc-stack.ts
+++ b/cdk_infra/lib/stacks/vpc/vpc-stack.ts
@@ -14,7 +14,7 @@ export class VPCStack extends Stack {
       natGateways: 1,
       vpnGateway: true,
       //https://github.com/aws/aws-cdk/issues/21690
-      availabilityZones: Stack.of(this).availabilityZones.sort().slice(0,1),
+      availabilityZones: Stack.of(this).availabilityZones.sort().slice(0, 1),
       subnetConfiguration: [
         {
           cidrMask: 24,

--- a/cdk_infra/test/cluster-deployment.test.ts
+++ b/cdk_infra/test/cluster-deployment.test.ts
@@ -5,6 +5,7 @@ import { deployClusters } from '../lib/cluster-deployment';
 import { ClusterInterface } from '../lib/interfaces/eks/cluster-interface';
 import { EC2Stack } from '../lib/stacks/eks/ec2-cluster-stack';
 import { FargateStack } from '../lib/stacks/eks/fargate-cluster-stack';
+import { VPCStack } from '../lib/stacks/vpc/vpc-stack';
 
 const yaml = require('js-yaml');
 
@@ -19,9 +20,8 @@ test('ClusterTest', () => {
 
   let clusterMap = new Map<string, FargateStack | EC2Stack>();
   const versionMap = new Map<string, string>();
-
-  clusterMap = deployClusters(app);
-
+  const vpc = new VPCStack(app,'testVPC')
+  clusterMap = deployClusters(app,vpc.vpc);
   for (const cluster of data['clusters']) {
     const clusterInterface = cluster as ClusterInterface;
     versionMap.set(clusterInterface.name, clusterInterface.version);

--- a/cdk_infra/test/cluster-deployment.test.ts
+++ b/cdk_infra/test/cluster-deployment.test.ts
@@ -20,8 +20,8 @@ test('ClusterTest', () => {
 
   let clusterMap = new Map<string, FargateStack | EC2Stack>();
   const versionMap = new Map<string, string>();
-  const vpc = new VPCStack(app,'testVPC')
-  clusterMap = deployClusters(app,vpc.vpc);
+  const vpc = new VPCStack(app, 'testVPC');
+  clusterMap = deployClusters(app, vpc.vpc);
   for (const cluster of data['clusters']) {
     const clusterInterface = cluster as ClusterInterface;
     versionMap.set(clusterInterface.name, clusterInterface.version);


### PR DESCRIPTION
**Description:** This PR accomplishes the following: 
- Move VPC deployment outside of `deployclusters`. This will allow it to be leveraged by other stacks in the future other than EKS Clusters. 
- Check in `cdk.context.json` for target account. 
- Leverage `CDK_DEFAULT_ACCOUNT` and `CDK_DEFAULT_REGION` to infer environment

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

