### PR TITLE
Install aws cdk toolkit in GHA workflow

### DIFF
--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -35,6 +35,9 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
+      - name: install cdk
+        run: |
+          npm install -g aws-cdk
       - name: npm install
         working-directory: cdk_infra
         run: |

--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -10,6 +10,7 @@ permissions:
   id-token: write
   contents: read
 
+concurrency: cdk_infra_deploy
 jobs:
   run-cdk-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**Description:** Installs the CDK toolkit in the GHA workflow prior to using the `cdk` command. This is following the CDK setup instructions [here](https://docs.aws.amazon.com/cdk/v2/guide/getting_started.html#getting_started_install). 

Also adds concurrency to GHA workflow

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

