### PR TITLE
[cdk_infra] Update VPC AZs and managed node group name

### DIFF
--- a/cdk_infra/lib/stacks/eks/ec2-cluster-stack.ts
+++ b/cdk_infra/lib/stacks/eks/ec2-cluster-stack.ts
@@ -28,7 +28,7 @@ export class EC2Stack extends Stack {
       clusterLogging: logging,
       kubectlLayer: GetLayer(this, props.version)
     });
-    const clusterNodeGroup = new Nodegroup(this, '{props.name}-managed-ng', {
+    const clusterNodeGroup = new Nodegroup(this, `${props.name}-managed-ng`, {
       instanceTypes: [new ec2.InstanceType(instance_type)],
       cluster: this.cluster,
       minSize: 2

--- a/cdk_infra/lib/stacks/vpc/vpc-stack.ts
+++ b/cdk_infra/lib/stacks/vpc/vpc-stack.ts
@@ -9,9 +9,8 @@ export class VPCStack extends Stack {
     this.vpc = new ec2.Vpc(this, 'EKSVpc', {
       cidr: '10.0.0.0/16',
       natGateways: 0,
+      maxAzs: 3,
       vpnGateway: false,
-      //https://github.com/aws/aws-cdk/issues/21690
-      availabilityZones: Stack.of(this).availabilityZones.sort().slice(0, 1),
       subnetConfiguration: [
         {
           cidrMask: 24,


### PR DESCRIPTION
**Description:** Update VPC AZ to default to max 3 and managed nodegroup name interpolation. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

