### PR TITLE
Fix terraform execute script

### DIFF
--- a/terraform/executeTerraformCleanup.sh
+++ b/terraform/executeTerraformCleanup.sh
@@ -14,7 +14,7 @@
 # $1: aws_service
 # $2: testcase 
 # $3: ECS/EC2 only - ami/ecs launch type 
-# $3: For EKS-arm64 we expect region|clustername|amp_endoint
+# $3: For all EKS tests we expect region|clustername
 
 ##########################################
 
@@ -34,29 +34,17 @@ TEST_FOLDER=""
 service="$1"
 export AWS_REGION=us-west-2
 case "$service" in
-    "EC2") TEST_FOLDER="./ec2/";
+    EC2) TEST_FOLDER="./ec2/";
         opts+=" -var=testing_ami=$3";
     ;;
-    "EKS") TEST_FOLDER="./eks/";
+    EKS*) TEST_FOLDER="./eks/"
+        region=$(echo $3 | cut -d \| -f 1);
+        clustername=$(echo $3 | cut -d \| -f 2);
+        export AWS_REGION=${region};
+        opts+=" -var=region=${region}";
+        opts+=" -var=eks_cluster_name=${clustername}";
     ;;
-    "EKS_ARM64") TEST_FOLDER="./eks/"
-        arm_64_region=$(echo $3 | cut -d \| -f 1);
-        arm_64_clustername=$(echo $3 | cut -d \| -f 2);
-        arm_64_amp=$(echo $3 | cut -d \| -f 3);
-        export AWS_REGION=${arm_64_region};
-        opts+=" -var=region=${arm_64_region}";
-        opts+=" -var=cortex_instance_endpoint=${arm_64_amp}";
-        opts+=" -var=eks_cluster_name=${arm_64_clustername}";
-    ;;
-    "EKS_FARGATE") TEST_FOLDER="./eks/";
-    ;;
-    "EKS_ADOT_OPERATOR") TEST_FOLDER="./eks/";
-        opts+=" -var=eks_cluster_name=adot-op-cluster";
-    ;;
-    "EKS_ADOT_OPERATOR_ARM64") TEST_FOLDER="./eks/";
-        opts+=" -var=eks_cluster_name=arm64-adot-op-cluster";
-    ;;
-    "ECS") TEST_FOLDER="./ecs/";
+    ECS) TEST_FOLDER="./ecs/";
         opts+=" -var=ecs_launch_type=$3";
     ;;
     *)
@@ -65,9 +53,16 @@ case "$service" in
     ;;
 esac
 
+case ${AWS_REGION} in
+    "us-east-2") export TF_VAR_cortex_instance_endpoint="https://aps-workspaces.us-east-2.amazonaws.com/workspaces/ws-1de68e95-0680-42bb-8e55-67e7fd5d0861";
+    ;;
+    "us-west-2") export TF_VAR_cortex_instance_endpoint="https://aps-workspaces.us-west-2.amazonaws.com/workspaces/ws-e0c3c74f-7fdf-4e90-87d2-a61f52df40cd";
+    ;;
+esac
+
 cd ${TEST_FOLDER};
 case "$service" in
-    "EKS_FARGATE" | "EKS_ARM64" | "EKS_ADOT_OPERATOR" | "EKS_ADOT_OPERATOR_ARM64") terraform destroy --auto-approve $opts;
+    EKS*) terraform destroy --auto-approve $opts;
     ;;
 *)
     terraform destroy --auto-approve;


### PR DESCRIPTION
**Description:** The batch test generator was updated so that each `EKS*` platform will specify their test targets. The setup script was not updated at the time to reflect those changes. All `EKS` tests now contain inputs for `region|clustername`. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

