### PR TITLE
Update k8s provider version to ~> 2.0

### DIFF
--- a/terraform/eks/jmx/jmx.tf
+++ b/terraform/eks/jmx/jmx.tf
@@ -67,7 +67,7 @@ resource "kubernetes_deployment" "jmx_metric_deployment" {
           image             = local.jmx_sample_app_image
           image_pull_policy = "Always"
           resources {
-            requests {
+            requests = {
               cpu    = "100m"
               memory = "180Mi"
             }

--- a/terraform/eks/jmx/jmx.tf
+++ b/terraform/eks/jmx/jmx.tf
@@ -71,7 +71,7 @@ resource "kubernetes_deployment" "jmx_metric_deployment" {
               cpu    = "100m"
               memory = "180Mi"
             }
-            limits {
+            limits = {
               cpu    = "300m"
               memory = "300Mi"
             }

--- a/terraform/eks/main.tf
+++ b/terraform/eks/main.tf
@@ -61,7 +61,6 @@ provider "kubernetes" {
   host                   = data.aws_eks_cluster.testing_cluster.endpoint
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.testing_cluster.certificate_authority[0].data)
   token                  = data.aws_eks_cluster_auth.testing_cluster.token
-  load_config_file       = false
 }
 
 provider "kubectl" {

--- a/terraform/eks/main.tf
+++ b/terraform/eks/main.tf
@@ -24,7 +24,7 @@ locals {
 terraform {
   required_providers {
     kubernetes = {
-      version = "~> 1.13"
+      version = ">= 2.0"
     }
     kubectl = {
       source  = "gavinbunney/kubectl"

--- a/terraform/eks/main.tf
+++ b/terraform/eks/main.tf
@@ -209,11 +209,11 @@ module "validator" {
   region            = var.region
   testing_id        = module.common.testing_id
   metric_namespace  = "${module.common.otel_service_namespace}/${module.common.otel_service_name}"
-  sample_app_endpoint = (length(kubernetes_ingress.app) > 0 && var.deployment_type == "fargate" ? "http://${kubernetes_ingress.app.0.load_balancer_ingress.0.hostname}:${var.fargate_sample_app_lb_port}" : (
-    length(kubernetes_service.sample_app_service) > 0 ? "http://${kubernetes_service.sample_app_service.0.load_balancer_ingress.0.hostname}:${module.common.sample_app_lb_port}" : ""
+  sample_app_endpoint = (length(kubernetes_ingress.app) > 0 && var.deployment_type == "fargate" ? "http://${kubernetes_ingress.app.status[0].load_balancer[0].ingress[0].hostname}:${var.fargate_sample_app_lb_port}" : (
+    length(kubernetes_service.sample_app_service) > 0 ? "http://${kubernetes_service.sample_app_service.status[0].load_balancer[0].ingress[0].hostname}:${module.common.sample_app_lb_port}" : ""
     )
   )
-  mocked_server_validating_url = length(kubernetes_service.mocked_server_service) > 0 ? "http://${kubernetes_service.mocked_server_service.0.load_balancer_ingress.0.hostname}/check-data" : ""
+  mocked_server_validating_url = length(kubernetes_service.mocked_server_service) > 0 ? "http://${kubernetes_service.mocked_server_service.status[0].load_balancer[0].ingress[0].hostname}/check-data" : ""
   cloudwatch_context_json = var.aoc_base_scenario == "prometheus" ? jsonencode({
     clusterName : var.eks_cluster_name
     #    appMesh : {

--- a/terraform/eks/main.tf
+++ b/terraform/eks/main.tf
@@ -209,11 +209,11 @@ module "validator" {
   region            = var.region
   testing_id        = module.common.testing_id
   metric_namespace  = "${module.common.otel_service_namespace}/${module.common.otel_service_name}"
-  sample_app_endpoint = (length(kubernetes_ingress.app) > 0 && var.deployment_type == "fargate" ? "http://${kubernetes_ingress.app.status[0].load_balancer[0].ingress[0].hostname}:${var.fargate_sample_app_lb_port}" : (
-    length(kubernetes_service.sample_app_service) > 0 ? "http://${kubernetes_service.sample_app_service.status[0].load_balancer[0].ingress[0].hostname}:${module.common.sample_app_lb_port}" : ""
+  sample_app_endpoint = (length(kubernetes_ingress.app) > 0 && var.deployment_type == "fargate" ? "http://${kubernetes_ingress.app[0].status[0].load_balancer[0].ingress[0].hostname}:${var.fargate_sample_app_lb_port}" : (
+    length(kubernetes_service.sample_app_service) > 0 ? "http://${kubernetes_service.sample_app_service[0].status[0].load_balancer[0].ingress[0].hostname}:${module.common.sample_app_lb_port}" : ""
     )
   )
-  mocked_server_validating_url = length(kubernetes_service.mocked_server_service) > 0 ? "http://${kubernetes_service.mocked_server_service.status[0].load_balancer[0].ingress[0].hostname}/check-data" : ""
+  mocked_server_validating_url = length(kubernetes_service.mocked_server_service) > 0 ? "http://${kubernetes_service.mocked_server_service[0].status[0].load_balancer[0].ingress[0].hostname}/check-data" : ""
   cloudwatch_context_json = var.aoc_base_scenario == "prometheus" ? jsonencode({
     clusterName : var.eks_cluster_name
     #    appMesh : {

--- a/terraform/eks/main.tf
+++ b/terraform/eks/main.tf
@@ -24,7 +24,7 @@ locals {
 terraform {
   required_providers {
     kubernetes = {
-      version = ">= 2.0"
+      version = "~> 2.0"
     }
     kubectl = {
       source  = "gavinbunney/kubectl"

--- a/terraform/eks/nginx/nginx.tf
+++ b/terraform/eks/nginx/nginx.tf
@@ -83,7 +83,7 @@ data "template_file" "traffic_deployment_file" {
   template = file("./nginx/nginx_traffic_sample.tpl")
   vars = {
     NAMESPACE   = kubernetes_namespace.traffic_ns.metadata[0].name
-    EXTERNAL_IP = data.kubernetes_service.nginx_ingress_sample.load_balancer_ingress.0.hostname
+    EXTERNAL_IP = data.kubernetes_service.nginx_ingress_sample.status[0].load_balancer[0].ingress[0].hostname
   }
 }
 

--- a/terraform/eks/otlp.tf
+++ b/terraform/eks/otlp.tf
@@ -24,7 +24,7 @@ module "basic_components" {
   sample_app                     = var.sample_app
   mocked_server                  = var.mocked_server
   cortex_instance_endpoint       = var.cortex_instance_endpoint
-  sample_app_listen_address_host = var.sample_app_mode == "pull" ? kubernetes_service.sample_app_service.status[0].load_balancer[0].ingress[0].hostname : ""
+  sample_app_listen_address_host = var.sample_app_mode == "pull" ? kubernetes_service.sample_app_service[0].status[0].load_balancer[0].ingress[0].hostname : ""
   sample_app_listen_address_port = module.common.sample_app_lb_port
   debug                          = var.debug
 }

--- a/terraform/eks/otlp.tf
+++ b/terraform/eks/otlp.tf
@@ -191,7 +191,7 @@ resource "kubernetes_deployment" "aoc_deployment" {
           "--config=/aoc/aoc-config.yml"]
 
           resources {
-            limits {
+            limits = {
               cpu    = "0.2"
               memory = "256Mi"
             }

--- a/terraform/eks/otlp.tf
+++ b/terraform/eks/otlp.tf
@@ -24,7 +24,7 @@ module "basic_components" {
   sample_app                     = var.sample_app
   mocked_server                  = var.mocked_server
   cortex_instance_endpoint       = var.cortex_instance_endpoint
-  sample_app_listen_address_host = var.sample_app_mode == "pull" ? kubernetes_service.sample_app_service.0.load_balancer_ingress.0.hostname : ""
+  sample_app_listen_address_host = var.sample_app_mode == "pull" ? kubernetes_service.sample_app_service.status[0].load_balancer[0].ingress[0].hostname : ""
   sample_app_listen_address_port = module.common.sample_app_lb_port
   debug                          = var.debug
 }

--- a/terraform/eks/otlp/otlp.tf
+++ b/terraform/eks/otlp/otlp.tf
@@ -16,7 +16,7 @@
 terraform {
   required_providers {
     kubernetes = {
-      version = "~> 1.13"
+      version = ">= 2.0"
     }
   }
 }

--- a/terraform/eks/otlp/otlp.tf
+++ b/terraform/eks/otlp/otlp.tf
@@ -16,7 +16,7 @@
 terraform {
   required_providers {
     kubernetes = {
-      version = ">= 2.0"
+      version = "~> 2.0"
     }
   }
 }

--- a/terraform/eks/otlp/pull_mode_samples.tf
+++ b/terraform/eks/otlp/pull_mode_samples.tf
@@ -70,7 +70,7 @@ resource "kubernetes_deployment" "pull_mode_sample_app_deployment" {
           }
 
           resources {
-            limits {
+            limits = {
               cpu    = "0.2"
               memory = "256Mi"
             }

--- a/terraform/eks/otlp/push_mode_samples.tf
+++ b/terraform/eks/otlp/push_mode_samples.tf
@@ -116,7 +116,7 @@ resource "kubernetes_deployment" "push_mode_sample_app_deployment" {
           }
 
           resources {
-            limits {
+            limits = {
               cpu    = "0.2"
               memory = "256Mi"
             }

--- a/terraform/eks/prometheus.tf
+++ b/terraform/eks/prometheus.tf
@@ -44,7 +44,7 @@ resource "kubernetes_deployment" "standalone_aoc_deployment" {
             value = "ClusterName=${var.eks_cluster_name}"
           }
           resources {
-            limits {
+            limits = {
               cpu    = "0.2"
               memory = "256Mi"
             }


### PR DESCRIPTION
**Description:** Update kubernetes provider version to `v2.0`. This is to fix incompatibilities with k8s `v1.24`. Followed migration guide [here](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/guides/v2-upgrade-guide). 


**Testing:** Tested with `otlp_metric` test case on `v1.24` eks cluster. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

