### PR TITLE
[batchTestGenerator] Remove EKS_ARM64 from non parallel test set

### DIFF
--- a/tools/batchTestGenerator/internal/githubGenerator.go
+++ b/tools/batchTestGenerator/internal/githubGenerator.go
@@ -63,7 +63,6 @@ func createBatchMap(maxBatches int, testCases []TestCaseInfo) (map[string][]stri
 		"EKS_ADOT_OPERATOR":       {},
 		"EKS_ADOT_OPERATOR_ARM64": {},
 		"EKS_FARGATE":             {},
-		"EKS_ARM64":               {},
 	}
 
 	if numBatches == 1 {


### PR DESCRIPTION
**Description:** Remove `eks_arm64` from nonparallel test set list. `EKS_ARM64` test cases are the same as `EKS` test cases which can be executed in parallel.

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

