### PR TITLE
Remove integ-test-arm64-cluster

### DIFF
--- a/tools/batchTestGenerator/testcases.json
+++ b/tools/batchTestGenerator/testcases.json
@@ -17,10 +17,6 @@
 			"type": "EKS_ARM64",
 			"targets": [
 				{
-					"name": "integ-test-arm64-cluster",
-					"region": "us-east-2"
-				},
-				{
 					"name": "collector-ci-arm64-1-21",
 					"region": "us-west-2"
 				},


### PR DESCRIPTION
**Description:** Remove `integ-test-arm64-cluster` from cluster targets. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

