### PR TITLE
Update otlp_trace_resourcedetecion test case

### DIFF
--- a/terraform/testcases/otlp_trace_resourcedetection_eks/otconfig.tpl
+++ b/terraform/testcases/otlp_trace_resourcedetection_eks/otconfig.tpl
@@ -12,7 +12,7 @@ processors:
   resourcedetection:
       detectors: [env, eks]
       timeout: 2s
-      override: false
+      override: true
 
 exporters:
   logging:

--- a/terraform/testcases/otlp_trace_resourcedetection_eks/parameters.tfvars
+++ b/terraform/testcases/otlp_trace_resourcedetection_eks/parameters.tfvars
@@ -4,3 +4,5 @@ validation_config = "spark-otel-trace-eks-validation.yml"
 soaking_data_mode = "trace"
 
 sample_app = "spark"
+
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"


### PR DESCRIPTION
**Description:** Update test case to use the latest spark sample app. After update the test case began to fail because `cloud.platform` output was `ec2. Updated config to override values and test passed. I suspect the change is due to updates to the sample app and default resource detectors that are enabled. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

