### PR TITLE
Update service account to use IRSA

### DIFF
--- a/terraform/eks/main.tf
+++ b/terraform/eks/main.tf
@@ -183,7 +183,11 @@ resource "kubernetes_service_account" "aoc-agent-role" {
   metadata {
     name      = "aoc-agent-${module.common.testing_id}"
     namespace = var.deployment_type == "fargate" ? kubernetes_namespace.aoc_fargate_ns.metadata[0].name : kubernetes_namespace.aoc_ns.metadata[0].name
+    annotations = {
+      "eks.amazonaws.com/role-arn" : module.iam_assumable_role_admin.iam_role_arn
+    }
   }
+  depends_on = [module.iam_assumable_role_admin]
 
   automount_service_account_token = true
 }


### PR DESCRIPTION
**Description:** Updates `aoc-agent` role to use IRSA. Links previously created IAM role to service account used in some EKS tests. This resolved the `containerinsight_eks` failures on `v1.21` eks clusters. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

