### PR TITLE
Add v1.22 and v1.23 k8s clusters

### DIFF
--- a/cdk_infra/lib/config/cluster-config/clusters.yml
+++ b/cdk_infra/lib/config/cluster-config/clusters.yml
@@ -4,6 +4,22 @@ clusters:
     version: "1.21"
     launch_type: ec2
     instance_type: m6g.medium
+  - name: collector-ci-amd64-1-22
+    version: "1.22"
+    launch_type: ec2
+    instance_type: "m5.large"
+  - name: collector-ci-arm64-1-22
+    version: "1.22"
+    launch_type: ec2
+    instance_type: m6g.medium
+  - name: collector-ci-arm64-1-23
+    version: "1.23"
+    launch_type: ec2
+    instance_type: m6g.medium
+  - name: collector-ci-amd64-1-23
+    version: "1.23"
+    launch_type: ec2
+    instance_type: "m5.large"
   - name: collector-ci-arm64-1-24
     version: "1.24"
     launch_type: ec2


### PR DESCRIPTION
**Description:** Add new clusters running `k8s` `v1.22` and `v1.23`. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

