### PR TITLE
Update ngnix version

### DIFF
--- a/terraform/eks/nginx/nginx.tf
+++ b/terraform/eks/nginx/nginx.tf
@@ -44,7 +44,7 @@ resource "helm_release" "nginx_ingress" {
 
   repository = "https://kubernetes.github.io/ingress-nginx"
   chart      = "ingress-nginx"
-  version    = "3.25.0"
+  version    = "4.4.0"
 
   set {
     name  = "controller.metrics.enabled"


### PR DESCRIPTION
**Description:** Updates nginx version used in helm chart. This allows `nginx` to be deployed on cluster greater than `v1.21`.

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

