### PR TITLE
Update haproxy version

### DIFF
--- a/terraform/eks/haproxy/haproxy.tf
+++ b/terraform/eks/haproxy/haproxy.tf
@@ -33,7 +33,7 @@ resource "helm_release" "haproxy" {
 
   repository = "https://haproxy-ingress.github.io/charts"
   chart      = "haproxy-ingress"
-  version    = "0.11.4"
+  version    = "0.13.9"
 
   set {
     name  = "defaultBackend.enabled"

--- a/validator/src/main/resources/expected-data-template/container-insight/eks/prometheus/haproxy_metrics.mustache
+++ b/validator/src/main/resources/expected-data-template/container-insight/eks/prometheus/haproxy_metrics.mustache
@@ -116,7 +116,7 @@
     - name: Service
       value: {{cloudWatchContext.haproxy.namespace}}-haproxy-ingress-metrics
     - name: backend
-      value: _default_backend
+      value: {{cloudWatchContext.haproxy.namespace}}_{{cloudWatchContext.haproxy.namespace}}-haproxy-ingress-default-backend_http
     - name: code
       value: 2xx
 - metricName: haproxy_frontend_http_responses_total


### PR DESCRIPTION
**Description:** Upgdrade haprox version for compatability with eks cluster >1.19. This change brought a change to the `backend` label value. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

