### PR TITLE
Update appmesh helm chart version and crds

### DIFF
--- a/terraform/eks/appmesh/appmesh.tf
+++ b/terraform/eks/appmesh/appmesh.tf
@@ -109,7 +109,7 @@ resource "helm_release" "eks" {
   }
 
   provisioner "local-exec" {
-    command = "kubectl --kubeconfig=${var.kubeconfig} apply -k \"github.com/aws/eks-charts/stable/appmesh-controller//crds?ref=master\""
+    command = "kubectl --kubeconfig=${var.kubeconfig} apply -k \"github.com/aws/eks-charts/stable/appmesh-controller/crds?ref=v0.0.116\""
   }
 
   wait = true

--- a/terraform/eks/appmesh/appmesh.tf
+++ b/terraform/eks/appmesh/appmesh.tf
@@ -91,7 +91,7 @@ resource "helm_release" "eks" {
 
   repository = "https://aws.github.io/eks-charts"
   chart      = "appmesh-controller"
-  version    = "1.3.0"
+  version    = "1.9.0"
 
   set {
     name  = "serviceAccount.create"
@@ -109,7 +109,7 @@ resource "helm_release" "eks" {
   }
 
   provisioner "local-exec" {
-    command = "kubectl --kubeconfig=${var.kubeconfig} apply -k \"github.com/aws/eks-charts/stable/appmesh-controller/crds?ref=v0.0.47\""
+    command = "kubectl --kubeconfig=${var.kubeconfig} apply -k \"github.com/aws/eks-charts/stable/appmesh-controller//crds?ref=master\""
   }
 
   wait = true


### PR DESCRIPTION
**Description:** Updates app mesh version used. currently [validations are not done](https://github.com/aws-observability/aws-otel-test-framework/blob/b63945c3a5446595f29db9ebe39718b0c403bd29/terraform/eks/main.tf#L222) for app mesh but this upgrade is required to run `containerinsight_eks_prometheus` tests on EKS `v1.24` due to deprecated CRD apis used in old version. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

