### PR TITLE
[infra] Add new EKS clusters 

### DIFF
--- a/cdk_infra/lib/config/cluster-config/clusters.yml
+++ b/cdk_infra/lib/config/cluster-config/clusters.yml
@@ -4,6 +4,9 @@ clusters:
     version: "1.21"
     launch_type: ec2
     instance_type: m6g.medium
+  - name: collector-ci-fargate-1-21
+    version: "1.21"
+    launch_type: fargate
   - name: collector-ci-amd64-1-22
     version: "1.22"
     launch_type: ec2
@@ -12,6 +15,9 @@ clusters:
     version: "1.22"
     launch_type: ec2
     instance_type: m6g.medium
+  - name: collector-ci-fargate-1-22
+    version: "1.22"
+    launch_type: fargate
   - name: collector-ci-arm64-1-23
     version: "1.23"
     launch_type: ec2
@@ -20,6 +26,9 @@ clusters:
     version: "1.23"
     launch_type: ec2
     instance_type: "m5.large"
+  - name: collector-ci-fargate-1-23
+    version: "1.23"
+    launch_type: fargate
   - name: collector-ci-arm64-1-24
     version: "1.24"
     launch_type: ec2

--- a/cdk_infra/lib/config/cluster-config/clusters.yml
+++ b/cdk_infra/lib/config/cluster-config/clusters.yml
@@ -4,6 +4,10 @@ clusters:
     version: "1.21"
     launch_type: ec2
     instance_type: m6g.medium
+  - name: collector-ci-amd64-1-21
+    version: "1.21"
+    launch_type: ec2
+    instance_type: m5.large
   - name: collector-ci-fargate-1-21
     version: "1.21"
     launch_type: fargate

--- a/tools/batchTestGenerator/testcases.json
+++ b/tools/batchTestGenerator/testcases.json
@@ -4,7 +4,7 @@
 			"type": "EKS",
 			"targets": [
 				{
-					"name": "aws-otel-testing-framework-eks-2",
+					"name": "collector-ci-amd64-1-21",
 					"region": "us-west-2"
 				},
 				{
@@ -65,6 +65,18 @@
 			"targets": [
 				{
 					"name": "Fargate-Integ-Test-Cluster",
+					"region": "us-west-2"
+				},
+				{
+					"name": "collector-ci-fargate-1-21",
+					"region": "us-west-2"
+				},
+				{
+					"name": "collector-ci-fargate-1-22",
+					"region": "us-west-2"
+				},
+				{
+					"name": "collector-ci-fargate-1-23",
 					"region": "us-west-2"
 				}
 			]

--- a/tools/batchTestGenerator/testcases.json
+++ b/tools/batchTestGenerator/testcases.json
@@ -64,10 +64,6 @@
 			"type": "EKS_FARGATE",
 			"targets": [
 				{
-					"name": "Fargate-Integ-Test-Cluster",
-					"region": "us-west-2"
-				},
-				{
 					"name": "collector-ci-fargate-1-21",
 					"region": "us-west-2"
 				},


### PR DESCRIPTION
**Description:** This PR adds 4 new EKS clusters. 
1. amd64 v1.21
2. fargate v1.21
3. fargate v1.22
4. fargate v1.23

This PR also removes cluster targets referencing EKS clusters not defined with the new infra deployment framework. This PR brings us to feature parity for ADOT Collector CI Infra. Updates still need to be made for ADOT Operator infra in a later PR. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

