### PR TITLE
Remove ekvs v1.24 cluster targets

### DIFF
--- a/tools/batchTestGenerator/testcases.json
+++ b/tools/batchTestGenerator/testcases.json
@@ -14,10 +14,6 @@
 				{
 					"name": "collector-ci-amd64-1-23",
 					"region": "us-west-2"
-				},
-				{
-					"name": "collector-ci-amd64-1-24",
-					"region": "us-west-2"
 				}
 			]
 		},
@@ -34,10 +30,6 @@
 				},
 				{
 					"name": "collector-ci-arm64-1-23",
-					"region": "us-west-2"
-				},
-				{
-					"name": "collector-ci-arm64-1-24",
 					"region": "us-west-2"
 				}
 			]


### PR DESCRIPTION
**Description:** Remove `v1.24` eks cluster targets
<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

