### PR TITLE
Add prometheus ready check null resource

### DIFF
--- a/terraform/eks/main.tf
+++ b/terraform/eks/main.tf
@@ -249,5 +249,7 @@ module "validator" {
   depends_on = [
     module.aoc_oltp,
     module.adot_operator,
-  kubectl_manifest.logs_sample_fargate_deploy]
+    kubectl_manifest.logs_sample_fargate_deploy,
+    null_resource.prom_base_ready_check
+  ]
 }

--- a/terraform/eks/prometheus.tf
+++ b/terraform/eks/prometheus.tf
@@ -97,3 +97,20 @@ module "demo_haproxy" {
 
   testing_id = module.common.testing_id
 }
+
+// Stops validator from starting until all assets are deployed. Validator has a dependency on this null resource.
+resource "null_resource" "prom_base_ready_check" {
+  count = var.aoc_base_scenario == "prometheus" ? 1 : 0
+  depends_on = [
+    module.demo_haproxy,
+    module.demo_memcached,
+    module.demo_jmx,
+    module.demo_appmesh,
+    module.demo_nginx,
+    kubernetes_deployment.standalone_aoc_deployment
+  ]
+
+  provisioner "local-exec" {
+    command = "echo prom assets deployed"
+  }
+}


### PR DESCRIPTION
**Description:** This PR adds a ready check for the base case `prometheus`. Without this the `containerinsight_eks_prometheus` test case would start the validator before all assets were deployed. This would mean that the validator would be halfway through it's retry cycles before the traffic deployment would be created. This ready check ensures that the validator does not start until all assets are deployed and thus gives the validator a full 10 retry attempts. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

