### PR TITLE
Add operator ci cluster deployments

### DIFF
--- a/cdk_infra/lib/config/cluster-config/clusters.yml
+++ b/cdk_infra/lib/config/cluster-config/clusters.yml
@@ -16,6 +16,11 @@ clusters:
     launch_type: ec2
     instance_type: m5.large
     cert_manager: true
+  - name: operator-ci-arm64-1-21
+    version: "1.21"
+    launch_type: ec2
+    instance_type: m6g.medium
+    cert_manager: true
   - name: collector-ci-amd64-1-22
     version: "1.22"
     launch_type: ec2
@@ -32,6 +37,11 @@ clusters:
     launch_type: ec2
     instance_type: m5.large
     cert_manager: true
+  - name: operator-ci-arm64-1-22
+    version: "1.22"
+    launch_type: ec2
+    instance_type: m6g.medium
+    cert_manager: true
   - name: collector-ci-arm64-1-23
     version: "1.23"
     launch_type: ec2
@@ -47,6 +57,11 @@ clusters:
     version: "1.23"
     launch_type: ec2
     instance_type: m5.large
+    cert_manager: true
+  - name: operator-ci-arm64-1-23
+    version: "1.23"
+    launch_type: ec2
+    instance_type: m6g.medium
     cert_manager: true
   - name: collector-ci-arm64-1-24
     version: "1.24"

--- a/cdk_infra/lib/config/cluster-config/clusters.yml
+++ b/cdk_infra/lib/config/cluster-config/clusters.yml
@@ -11,6 +11,11 @@ clusters:
   - name: collector-ci-fargate-1-21
     version: "1.21"
     launch_type: fargate
+  - name: operator-ci-amd64-1-21
+    version: "1.21"
+    launch_type: ec2
+    instance_type: m5.large
+    cert_manager: true
   - name: collector-ci-amd64-1-22
     version: "1.22"
     launch_type: ec2
@@ -22,6 +27,11 @@ clusters:
   - name: collector-ci-fargate-1-22
     version: "1.22"
     launch_type: fargate
+  - name: operator-ci-amd64-1-22
+    version: "1.22"
+    launch_type: ec2
+    instance_type: m5.large
+    cert_manager: true
   - name: collector-ci-arm64-1-23
     version: "1.23"
     launch_type: ec2
@@ -33,6 +43,11 @@ clusters:
   - name: collector-ci-fargate-1-23
     version: "1.23"
     launch_type: fargate
+  - name: operator-ci-amd64-1-23
+    version: "1.23"
+    launch_type: ec2
+    instance_type: m5.large
+    cert_manager: true
   - name: collector-ci-arm64-1-24
     version: "1.24"
     launch_type: ec2


### PR DESCRIPTION
**Description:** Deploy clusters for use in ADOT Operator CI tests. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

