### PR TITLE
[release/v0.24.x] Update operator CI cluster targets

### DIFF
--- a/tools/batchTestGenerator/testcases.json
+++ b/tools/batchTestGenerator/testcases.json
@@ -38,7 +38,15 @@
 			"type": "EKS_ADOT_OPERATOR",
 			"targets": [
 				{
-					"name": "adot-op-cluster",
+					"name": "operator-ci-amd64-1-21",
+					"region": "us-west-2"
+				},
+				{
+					"name": "operator-ci-amd64-1-22",
+					"region": "us-west-2"
+				},
+				{
+					"name": "operator-ci-amd64-1-23",
 					"region": "us-west-2"
 				}
 			]
@@ -47,7 +55,15 @@
 			"type": "EKS_ADOT_OPERATOR_ARM64",
 			"targets": [
 				{
-					"name": "arm64-adot-op-cluster",
+					"name": "operator-ci-arm64-1-21",
+					"region": "us-west-2"
+				},
+				{
+					"name": "operator-ci-arm64-1-22",
+					"region": "us-west-2"
+				},
+				{
+					"name": "operator-ci-arm64-1-23",
 					"region": "us-west-2"
 				}
 			]


### PR DESCRIPTION
**Description:** Update cluster targets used for ADOT Operator CI tests. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

