### PR TITLE
Chain imagebuild commands

### DIFF
--- a/terraform/imagebuild/main.tf
+++ b/terraform/imagebuild/main.tf
@@ -58,8 +58,10 @@ resource "null_resource" "build_and_push_sample_apps" {
   provisioner "local-exec" {
     command = <<-EOT
       docker buildx create --use --name sapbuilder.${count.index} --platform=linux/arm64,linux/amd64 --driver  docker-container --bootstrap && \
-      docker buildx build --builder=sapbuilder.${count.index} --push --platform=linux/amd64,linux/arm64 -t ${data.aws_ecr_repository.sample_app.repository_url}:${dirname(element(local.sample_apps_dockerfile_list, count.index))}-latest ../../sample-apps/${dirname(element(local.sample_apps_dockerfile_list, count.index))}/ && \
+      docker buildx build --builder=sapbuilder.${count.index} --push --platform=linux/amd64,linux/arm64 -t ${data.aws_ecr_repository.sample_app.repository_url}:${dirname(element(local.sample_apps_dockerfile_list, count.index))}-latest ../../sample-apps/${dirname(element(local.sample_apps_dockerfile_list, count.index))}/
+      RESULT=$?
       docker buildx rm sapbuilder.${count.index}
+      exit $RESULT
     EOT
   }
 
@@ -73,8 +75,10 @@ resource "null_resource" "build_and_push_mocked_server" {
   provisioner "local-exec" {
     command = <<-EOT
       docker buildx create --use --name msgbuilder.${count.index} --platform=linux/arm64,linux/amd64 --driver docker-container --bootstrap && \
-      docker buildx build --builder=msgbuilder.${count.index} --push --platform=linux/amd64,linux/arm64 -t ${data.aws_ecr_repository.mocked_server.repository_url}:${dirname(element(local.mocked_servers_dockerfile_list, count.index))}-latest ../../mocked_servers/${dirname(element(local.mocked_servers_dockerfile_list, count.index))}/ && \
+      docker buildx build --builder=msgbuilder.${count.index} --push --platform=linux/amd64,linux/arm64 -t ${data.aws_ecr_repository.mocked_server.repository_url}:${dirname(element(local.mocked_servers_dockerfile_list, count.index))}-latest ../../mocked_servers/${dirname(element(local.mocked_servers_dockerfile_list, count.index))}/
+      RESULT=$?
       docker buildx rm msgbuilder.${count.index}
+      exit $RESULT
     EOT
   }
 

--- a/terraform/imagebuild/main.tf
+++ b/terraform/imagebuild/main.tf
@@ -57,8 +57,8 @@ resource "null_resource" "build_and_push_sample_apps" {
 
   provisioner "local-exec" {
     command = <<-EOT
-      docker buildx create --use --name sapbuilder.${count.index} --platform=linux/arm64,linux/amd64 --driver  docker-container --bootstrap
-      docker buildx build --builder=sapbuilder.${count.index} --push --platform=linux/amd64,linux/arm64 -t ${data.aws_ecr_repository.sample_app.repository_url}:${dirname(element(local.sample_apps_dockerfile_list, count.index))}-latest ../../sample-apps/${dirname(element(local.sample_apps_dockerfile_list, count.index))}/
+      docker buildx create --use --name sapbuilder.${count.index} --platform=linux/arm64,linux/amd64 --driver  docker-container --bootstrap && \
+      docker buildx build --builder=sapbuilder.${count.index} --push --platform=linux/amd64,linux/arm64 -t ${data.aws_ecr_repository.sample_app.repository_url}:${dirname(element(local.sample_apps_dockerfile_list, count.index))}-latest ../../sample-apps/${dirname(element(local.sample_apps_dockerfile_list, count.index))}/ && \
       docker buildx rm sapbuilder.${count.index}
     EOT
   }
@@ -72,8 +72,8 @@ resource "null_resource" "build_and_push_mocked_server" {
 
   provisioner "local-exec" {
     command = <<-EOT
-      docker buildx create --use --name msgbuilder.${count.index} --platform=linux/arm64,linux/amd64 --driver docker-container --bootstrap
-      docker buildx build --builder=msgbuilder.${count.index} --push --platform=linux/amd64,linux/arm64 -t ${data.aws_ecr_repository.mocked_server.repository_url}:${dirname(element(local.mocked_servers_dockerfile_list, count.index))}-latest ../../mocked_servers/${dirname(element(local.mocked_servers_dockerfile_list, count.index))}/
+      docker buildx create --use --name msgbuilder.${count.index} --platform=linux/arm64,linux/amd64 --driver docker-container --bootstrap && \
+      docker buildx build --builder=msgbuilder.${count.index} --push --platform=linux/amd64,linux/arm64 -t ${data.aws_ecr_repository.mocked_server.repository_url}:${dirname(element(local.mocked_servers_dockerfile_list, count.index))}-latest ../../mocked_servers/${dirname(element(local.mocked_servers_dockerfile_list, count.index))}/ && \
       docker buildx rm msgbuilder.${count.index}
     EOT
   }


### PR DESCRIPTION
Chain imagebuild commands so that terraform can properly stop on failure.

**Description:** As of now, if there is a failure in one of the image build commands, we might get a healthy workflow status even though it failed. This PR tries to address this issue by chaining the imagebuild commands.


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

