### PR TITLE
Update GHA workflow concurrency settings

### DIFF
--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -10,7 +10,10 @@ permissions:
   id-token: write
   contents: read
 
-concurrency: cdk_infra_deploy
+concurrency: 
+  group: cdk_infra_deploy
+  cancel-in-progress: false
+
 jobs:
   run-cdk-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-test-images.yml
+++ b/.github/workflows/update-test-images.yml
@@ -1,7 +1,9 @@
 name: Update Test Images
 
 # We should execute only one workflow run at a time
-concurrency: test_images_concurrency
+concurrency: 
+  group: test_images_concurrency
+  cancel-in-progress: false
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
**Description:** Update concurrency settings for cdk deploy and image push actions. It was previously thought that the default behavior was not to cancel but that seems not to be true. This PR explicitly defines the desired concurrency behavior. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

