### PR TITLE
execute terraform cleanup synchronously

### DIFF
--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -26,7 +26,7 @@ checkCacheHits:
 
 .PHONY: terraformCleanup
 terraformCleanup: test-case-batch
-	cat test-case-batch | xargs -L1 ./executeTerraformCleanup.sh 
+	cat test-case-batch | xargs -L1 -P1 ./executeTerraformCleanup.sh 
 
  
 


### PR DESCRIPTION
**Description:** Execute terraform cleanup synchronously in an attempt to prevent any statelock issues. This will prevent two instances of `terraform destroy` being called at the same time in the same folder. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

