### PR TITLE
Choose subnet based on random id. 

### DIFF
--- a/terraform/basic_components/main.tf
+++ b/terraform/basic_components/main.tf
@@ -20,6 +20,16 @@ module "common" {
   security_group_name = var.aoc_vpc_security_group
 }
 
+locals {
+  otconfig_path = fileexists("${var.testcase}/otconfig.tpl") ? "${var.testcase}/otconfig.tpl" : module.common.default_otconfig_path
+
+  subnet_ids_list = tolist(data.aws_subnet_ids.aoc_public_subnet_ids.ids)
+
+  subnet_ids_random_index = random_id.subnetSelector.dec % length(data.aws_subnet_ids.aoc_public_subnet_ids.ids)
+
+  random_instance_subnet_id = local.subnet_ids_list[local.subnet_ids_random_index]
+}
+
 data "aws_security_group" "aoc_security_group" {
   name = module.common.aoc_vpc_security_group
 }
@@ -61,8 +71,8 @@ data "aws_subnet_ids" "aoc_public_subnet_ids" {
   }
 }
 
-locals {
-  otconfig_path = fileexists("${var.testcase}/otconfig.tpl") ? "${var.testcase}/otconfig.tpl" : module.common.default_otconfig_path
+resource "random_id" "subnetSelector" {
+  byte_length = 2
 }
 
 # generate otconfig

--- a/terraform/basic_components/main.tf
+++ b/terraform/basic_components/main.tf
@@ -25,7 +25,7 @@ locals {
 
   subnet_ids_list = tolist(data.aws_subnet_ids.aoc_public_subnet_ids.ids)
 
-  subnet_ids_random_index = random_id.subnetSelector.dec % length(data.aws_subnet_ids.aoc_public_subnet_ids.ids)
+  subnet_ids_random_index = random_id.subnetSelector.dec % length(subnet_ids_list)
 
   random_instance_subnet_id = local.subnet_ids_list[local.subnet_ids_random_index]
 }

--- a/terraform/basic_components/outputs.tf
+++ b/terraform/basic_components/outputs.tf
@@ -52,3 +52,7 @@ output "sample_app_image" {
 output "mocked_server_image" {
   value = "${data.aws_ecr_repository.mocked_servers.repository_url}:${var.mocked_server}-latest"
 }
+
+output "random_subnet_instance_id" {
+  value = local.random_instance_subnet_id
+}

--- a/terraform/ec2/main.tf
+++ b/terraform/ec2/main.tf
@@ -78,9 +78,6 @@ locals {
   # get ecr login domain
   ecr_login_domain = split("/", data.aws_ecr_repository.sample_app.repository_url)[0]
 
-  # get instance subnet, use separate subnet for soaking and performance test as it takes more instances and some times eat up all the available ip address in the subnet
-  instance_subnet = var.testing_type == "e2e" ? tolist(module.basic_components.aoc_public_subnet_ids)[1] : tolist(module.basic_components.aoc_public_subnet_ids)[0]
-
   # get SSM package version, latest is the default version
   ssm_package_version = var.aoc_version == "latest" ? "\"\"" : var.aoc_version
   testcase_name       = split("/", var.testcase)[2]
@@ -90,7 +87,7 @@ locals {
 resource "aws_instance" "sidecar" {
   ami                         = data.aws_ami.amazonlinux2.id
   instance_type               = var.sidecar_instance_type
-  subnet_id                   = local.instance_subnet
+  subnet_id                   = module.basic_components.random_subnet_instance_id
   vpc_security_group_ids      = [module.basic_components.aoc_security_group_id]
   associate_public_ip_address = true
   iam_instance_profile        = module.common.aoc_iam_role_name
@@ -108,7 +105,7 @@ resource "aws_instance" "sidecar" {
 resource "aws_instance" "aoc" {
   ami                         = local.ami_id
   instance_type               = local.instance_type
-  subnet_id                   = local.instance_subnet
+  subnet_id                   = module.basic_components.random_subnet_instance_id
   vpc_security_group_ids      = [module.basic_components.aoc_security_group_id]
   associate_public_ip_address = true
   iam_instance_profile        = module.common.aoc_iam_role_name

--- a/terraform/ecs/efs.tf
+++ b/terraform/ecs/efs.tf
@@ -70,7 +70,7 @@ resource "aws_key_pair" "aws_ssh_key" {
 resource "aws_instance" "collector_efs_ec2" {
   ami                         = data.aws_ami.amazonlinux2.id
   instance_type               = "c5a.large"
-  subnet_id                   = tolist(module.basic_components.aoc_public_subnet_ids)[0]
+  subnet_id                   = module.basic_components.random_subnet_instance_id
   vpc_security_group_ids      = [module.basic_components.aoc_security_group_id]
   associate_public_ip_address = true
   iam_instance_profile        = module.common.aoc_iam_role_name


### PR DESCRIPTION
**Description:** Previously all ec2 instances created were going into a single subnet. This would cause the subnet to run out of IPs. This change tries to balance this selection across the three subnets to avoid IP resource limitations. 

Testing: Tested this locally by running multiple ec2 tests to ensure different subnets would be selected. 
<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

