### PR TITLE
Remove update for eks_containerinsight_prometheus testcase

### DIFF
--- a/terraform/eks/appmesh/appmesh.tf
+++ b/terraform/eks/appmesh/appmesh.tf
@@ -154,8 +154,8 @@ data "template_file" "traffic_deployment_file" {
   vars = {
     APP_NAMESPACE   = kubernetes_namespace.traffic_ns.metadata[0].name
     MESH_NAME       = local.mesh_name
-    FRONT_APP_IMAGE = "${var.sample_app_image_repo}:feapp-latest"
-    COLOR_APP_IMAGE = "${var.sample_app_image_repo}:colorapp-latest"
+    FRONT_APP_IMAGE = "${var.sample_app_image_repo}:feapp"
+    COLOR_APP_IMAGE = "${var.sample_app_image_repo}:colorapp"
   }
 
   depends_on = [

--- a/terraform/eks/jmx/jmx.tf
+++ b/terraform/eks/jmx/jmx.tf
@@ -34,7 +34,7 @@ output "metric_dimension_namespace" {
 
 locals {
   traffic_generator_image = "${var.sample_app_image_repo}:traffic-generator"
-  jmx_sample_app_image    = "${var.sample_app_image_repo}:tomcatapp-latest"
+  jmx_sample_app_image    = "${var.sample_app_image_repo}:tomcatapp"
 }
 
 resource "kubernetes_namespace" "jmx_ns" {

--- a/tools/batchTestGenerator/testcases.json
+++ b/tools/batchTestGenerator/testcases.json
@@ -356,8 +356,7 @@
 		{
 			"case_name": "containerinsight_eks_prometheus",
 			"platforms": [
-				"EKS",
-				"EKS_ARM64"
+				"EKS"
 			]
 		},
 		{


### PR DESCRIPTION
**Description:** Revert changes in #521 and remove `EKS_ARM64` target from `eks_containerinsight_prometheus` test case. 

These changes broke the Collector CI. The manifest of these images was also inspected and they are not multi arch. They only target amd64 platform. There is no CI/CD around these images and we should investigate them further before updating the image tag. An issue will be created for these follow on items. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

