### PR TITLE
Use 2 hops to access IMDS in the test service instance

### DIFF
--- a/terraform/ec2/main.tf
+++ b/terraform/ec2/main.tf
@@ -103,6 +103,9 @@ resource "aws_instance" "sidecar" {
   metadata_options {
     http_endpoint = "enabled"
     http_tokens = "required"
+    # Use 2 hops because some of the test services run inside docker in the instance.
+    # That counts as an extra hop to access the IMDS. The default value is 1.
+    http_put_response_hop_limit = 2
   }
 }
 


### PR DESCRIPTION
Signed-off-by: Raphael Silva <rapphil@gmail.com>

**Description:** Use 2 hops for accessing IMDS in the instance that run the test services.
**Testing:** Tested locally

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

