### PR TITLE
Require IMDSv2 for instances in ecs tests

### DIFF
--- a/terraform/ecs/efs.tf
+++ b/terraform/ecs/efs.tf
@@ -84,6 +84,11 @@ resource "aws_instance" "collector_efs_ec2" {
     Name = "Integ-test-aoc"
   }
 
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens   = "required"
+  }
+
   depends_on = [aws_efs_mount_target.collector_efs_mount, aws_key_pair.aws_ssh_key]
 }
 


### PR DESCRIPTION
**Description:** Updated the test framework to require IMDSv2 on hosts.  Tested on dev branch and the CI passed for ecs tests: https://github.com/aws-observability/aws-otel-collector/actions/runs/3841882267

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

