### PR TITLE
Add launch template for ec2s to require IMDSv2 for eks nodegroups

### DIFF
--- a/cdk_infra/lib/stacks/eks/ec2-cluster-stack.ts
+++ b/cdk_infra/lib/stacks/eks/ec2-cluster-stack.ts
@@ -1,7 +1,7 @@
 import { Stack, StackProps, aws_eks as eks, aws_ec2 as ec2 } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { Vpc } from 'aws-cdk-lib/aws-ec2';
-import { KubernetesVersion, Nodegroup, LaunchTemplateSpec } from 'aws-cdk-lib/aws-eks';
+import { KubernetesVersion, Nodegroup } from 'aws-cdk-lib/aws-eks';
 import { ManagedPolicy } from 'aws-cdk-lib/aws-iam';
 import { GetLayer } from '../../utils/eks/kubectlLayer';
 


### PR DESCRIPTION
**Description:** Add an ec2 launch template to require IMDSv2 in our eks nodegroups

**Testing:**

Before the change:
![image](https://user-images.githubusercontent.com/15241987/211921582-28d79681-76eb-40c2-bc67-1f4bc9790fb4.png)
HttpTokens are optional and a curl request completed without a token

After the change:
![image](https://user-images.githubusercontent.com/15241987/211921818-7b076d9c-c915-467d-b3c4-c6563ac2146f.png)
HttpTokens are now required and a curl request could not complete without a token

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

