### PR TITLE
Use cluster name to choose AMI type for EKS MNG launch template

### DIFF
--- a/cdk_infra/lib/cluster-deployment.ts
+++ b/cdk_infra/lib/cluster-deployment.ts
@@ -1,18 +1,17 @@
 #!/usr/bin/env node
 import 'source-map-support/register';
 import * as cdk from 'aws-cdk-lib';
-import { aws_eks as eks, StackProps } from 'aws-cdk-lib';
-import { readFileSync } from 'fs';
-import { EC2Stack } from './stacks/eks/ec2-cluster-stack';
-import { FargateStack } from './stacks/eks/fargate-cluster-stack';
-import { validateFileSchema } from './utils/eks/validate-config-schema';
-import { ClusterInterface } from './interfaces/eks/cluster-interface';
-import { ec2ClusterInterface } from './interfaces/eks/ec2cluster-interface';
-import { validateInterface } from './utils/eks/validate-interface-schema';
-import { ClusterAuth } from './constructs/eks/clusterAuthConstruct';
-import { HelmChart } from 'aws-cdk-lib/aws-eks';
-import { OpenIdConnectProvider } from 'aws-cdk-lib/aws-eks';
-import { Vpc } from 'aws-cdk-lib/aws-ec2';
+import {aws_eks as eks, StackProps} from 'aws-cdk-lib';
+import {readFileSync} from 'fs';
+import {EC2Stack} from './stacks/eks/ec2-cluster-stack';
+import {FargateStack} from './stacks/eks/fargate-cluster-stack';
+import {validateFileSchema} from './utils/eks/validate-config-schema';
+import {ClusterInterface} from './interfaces/eks/cluster-interface';
+import {ec2ClusterInterface} from './interfaces/eks/ec2cluster-interface';
+import {validateInterface} from './utils/eks/validate-interface-schema';
+import {ClusterAuth} from './constructs/eks/clusterAuthConstruct';
+import {HelmChart, NodegroupAmiType, OpenIdConnectProvider} from 'aws-cdk-lib/aws-eks';
+import {InstanceType, Vpc} from 'aws-cdk-lib/aws-ec2';
 
 const yaml = require('js-yaml');
 
@@ -57,7 +56,8 @@ export function deployClusters(
         name: ec2Cluster.name,
         vpc: vpc,
         version: versionKubernetes,
-        instance_type: ec2Cluster.instance_type,
+        instanceTypes: [new InstanceType(ec2Cluster.instance_type.toLowerCase())],
+        amiType: ec2Cluster.name.match('\-arm64\-') ? NodegroupAmiType.AL2_ARM_64 : NodegroupAmiType.AL2_X86_64,
         env: envInput
       });
     } else {

--- a/cdk_infra/lib/stacks/eks/ec2-cluster-stack.ts
+++ b/cdk_infra/lib/stacks/eks/ec2-cluster-stack.ts
@@ -1,7 +1,7 @@
 import { Stack, StackProps, aws_eks as eks, aws_ec2 as ec2 } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
-import { Vpc } from 'aws-cdk-lib/aws-ec2';
-import { KubernetesVersion, Nodegroup } from 'aws-cdk-lib/aws-eks';
+import { Vpc, InstanceType } from 'aws-cdk-lib/aws-ec2';
+import { KubernetesVersion, Nodegroup, NodegroupAmiType } from 'aws-cdk-lib/aws-eks';
 import { ManagedPolicy } from 'aws-cdk-lib/aws-iam';
 import { GetLayer } from '../../utils/eks/kubectlLayer';
 
@@ -18,7 +18,6 @@ export class EC2Stack extends Stack {
       eks.ClusterLoggingTypes.CONTROLLER_MANAGER,
       eks.ClusterLoggingTypes.SCHEDULER
     ];
-    const instance_type = props.instance_type.toLowerCase();
     this.cluster = new eks.Cluster(this, props.name, {
       clusterName: props.name,
       vpc: props.vpc,
@@ -33,10 +32,10 @@ export class EC2Stack extends Stack {
       httpEndpoint: true,
       httpPutResponseHopLimit: 2,
       httpTokens: ec2.LaunchTemplateHttpTokens.REQUIRED,
-      
     })
     const clusterNodeGroup = new Nodegroup(this, `${props.name}-managed-ng`, {
-      instanceTypes: [new ec2.InstanceType(instance_type)],
+      amiType: props.amiType,
+      instanceTypes: props.instanceTypes,
       cluster: this.cluster,
       minSize: 2,
       subnets: { subnetType: ec2.SubnetType.PUBLIC },
@@ -55,5 +54,6 @@ export interface EC2ClusterStackProps extends StackProps {
   name: string;
   vpc: Vpc;
   version: KubernetesVersion;
-  instance_type: string;
+  instanceTypes: InstanceType[];
+  amiType: NodegroupAmiType;
 }

--- a/cdk_infra/test/test_config/test_clusters.yml
+++ b/cdk_infra/test/test_config/test_clusters.yml
@@ -1,14 +1,14 @@
 ---
 clusters:
-  - name: amdCluster
+  - name: m5-amd64-Cluster
+    launch_type: ec2
+    instance_type: m5.large
+    version: "1.21"
+  - name: t4g-arm64-Cluster
     launch_type: ec2
     instance_type: t4g.large
     version: "1.21"
-  - name: t4gCluster
-    launch_type: ec2
-    instance_type: t4g.large
-    version: "1.21"
-  - name: armCluster
+  - name: m6g-arm64-Cluster
     launch_type: ec2
     instance_type: m6g.large
     version: "1.21"


### PR DESCRIPTION
Signed-off-by: Anthony J Mirabella <a9@aneurysm9.com>

**Description:** Because we're specifying a launch template for the EKS managed nodegroups we're creating we need to tell it which AMI to use and that AMI needs to match the architecture for the instance type selected.  Because all of our clusters include the architecture in the name I have chosen to extract that information from there rather than add a new field to the configuration.

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

