### PR TITLE
Add validator dependency for collector deployment

### DIFF
--- a/terraform/eks/main.tf
+++ b/terraform/eks/main.tf
@@ -250,6 +250,7 @@ module "validator" {
     module.aoc_oltp,
     module.adot_operator,
     kubectl_manifest.logs_sample_fargate_deploy,
-    null_resource.prom_base_ready_check
+    null_resource.prom_base_ready_check,
+    kubernetes_deployment.aoc_deployment
   ]
 }


### PR DESCRIPTION
**Description:** Do not start the validator unless the collector has been successfully deployed. 
Logs from the latest CI run shows the validator building and starting before the collector deployment has succeeded or failed.
```
odule.validator.null_resource.validator (local-exec): validator_1  | 03:42:53.568 [main] INFO  com.amazon.aoc.helpers.RetryHelper - retrying after 20 seconds
module.validator.null_resource.validator: Still creating... [1m20s elapsed]
kubernetes_deployment.aoc_deployment[0]: Still creating... [1m30s elapsed]
module.validator.null_resource.validator: Still creating... [1m30s elapsed]
kubernetes_deployment.aoc_deployment[0]: Still creating... [1m40s elapsed]
module.validator.null_resource.validator (local-exec): validator_1  | 03:43:13.569 [main] INFO  com.amazon.aoc.helpers.RetryHelper - retry attempt left : 28
module.validator.null_resource.validator (local-exec): validator_1  | 03:43:13.863 [main] INFO  com.amazon.aoc.validators.CWMetricValidator - dimensions to be skipped in validation: []
module.validator.null_resource.validator (local-exec): validator_1  | 03:43:13.864 [main] INFO  com.amazon.aoc.validators.CWMetricValidator - check if all the expected metrics are found
module.validator.null_resource.validator (local-exec): validator_1  | 03:43:13.864 [main] INFO  com.amazon.aoc.validators.CWMetricValidator - actual metricList is []
```

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

