### PR TITLE
[Hostmetrics Receiver]: e2e testing- CW validator, Linux expectation template, Testcase, and ECS script

### DIFF
--- a/terraform/ecs/main.tf
+++ b/terraform/ecs/main.tf
@@ -75,6 +75,23 @@ module "ecs_cluster" {
   // TODO(pingleig): pass patch tag for canary and soaking (if any)
 }
 
+data "aws_instances" "ecs_instances" {
+  filter {
+    name   = "tag:Name"
+    values = ["cluster-worker-aoc-testing-${module.common.testing_id}"]
+  }
+  filter {
+    name   = "tag:ClusterName"
+    values = [module.common.testing_id]
+  }
+  depends_on = [module.ecs_cluster]
+}
+
+data "aws_instance" "get_specific_instance" {
+  instance_id = data.aws_instances.ecs_instances.ids[0]
+  depends_on = [data.aws_instances.ecs_instances]
+}
+
 # This is a hack for known issue https://github.com/hashicorp/terraform-provider-aws/issues/4852
 # We always create ECS cluster with active EC2 instances, so when destroy we need to scale down
 # the asg so the cluster can be destroyed.
@@ -287,7 +304,7 @@ resource "aws_ecs_service" "aoc" {
 
 # remove lb since there's no callable sample app, some test cases will drop in here, for example, ecsmetadata receiver test
 resource "aws_ecs_service" "aoc_without_sample_app" {
-  count            = !var.sample_app_callable && var.ecs_taskdef_network_mode == "awsvpc" ? 1 : 0
+  count            = !var.sample_app_callable && var.ecs_taskdef_network_mode == "awsvpc" && var.scheduling_strategy != "DAEMON" ? 1 : 0
   name             = "aocservice-${module.common.testing_id}"
   cluster          = module.ecs_cluster.cluster_id
   task_definition  = "${aws_ecs_task_definition.aoc[0].family}:1"
@@ -312,6 +329,29 @@ resource "aws_ecs_service" "aoc_without_sample_app_for_bridge" {
   depends_on      = [null_resource.scale_down_asg, aws_ecs_task_definition.aoc_bridge]
 }
 
+resource "aws_ecs_service" "aoc_without_sample_app_daemon_scheduling" {
+  count                 = !var.sample_app_callable && var.ecs_taskdef_network_mode == "awsvpc" && var.scheduling_strategy == "DAEMON" && var.ecs_launch_type != "FARGATE" ? 1 : 0
+  name                  = "aocservice-${module.common.testing_id}"
+  cluster               = module.ecs_cluster.cluster_id
+  task_definition       = "${aws_ecs_task_definition.aoc[0].family}:1"
+  launch_type           = var.ecs_launch_type
+  scheduling_strategy   = "DAEMON"
+  wait_for_steady_state = true
+
+  network_configuration {
+      subnets           = module.basic_components.aoc_private_subnet_ids
+      security_groups   = [module.basic_components.aoc_security_group_id]
+  }
+  depends_on            = [aws_ecs_task_definition.aoc]
+}
+
+# wait for task to get deployed and metrics have been received by cloudwatch
+resource "time_sleep" "wait_60_seconds" {
+  count      = endswith(var.testcase, "hostmetrics_receiver") ? 1 : 0
+  depends_on = [aws_ecs_service.aoc_without_sample_app_daemon_scheduling]
+
+  create_duration = "60s"
+}
 ##########################################
 # Validation
 ##########################################
@@ -350,6 +390,8 @@ module "validator_without_sample_app" {
   testing_id                   = module.common.testing_id
   metric_namespace             = "${module.common.otel_service_namespace}/${module.common.otel_service_name}"
   mocked_server_validating_url = var.disable_mocked_server ? "" : "http://${aws_lb.mocked_server_lb[0].dns_name}:${module.common.mocked_server_lb_port}/check-data"
+  testcase                     = var.testcase
+  rollup                       = var.rollup
 
   ecs_context_json = jsonencode({
     ecsClusterName : module.ecs_cluster.cluster_name
@@ -360,7 +402,25 @@ module "validator_without_sample_app" {
 
   cloudwatch_context_json = data.template_file.cloudwatch_context.rendered
 
-  depends_on = [aws_ecs_service.aoc_without_sample_app, aws_ecs_service.extra_apps]
+  # hostmetrics_receiver related variables
+  hostmetrics_context_json = !endswith(var.testcase, "hostmetrics_receiver") ? null : jsonencode({
+    hostId               : data.aws_instances.ecs_instances.ids
+    cpuNames              : ["cpu0", "cpu1"] # t2.medium is hardcoded, so cpu_count is not fetched using data_sources
+    diskDevices           : ["vda", "vda1"]
+    filesystemDevices     : tolist([
+      (tolist(data.aws_instance.get_specific_instance.root_block_device)[0]).device_name
+    ])
+    mountpointModes       : ["rw"]
+    mountpoints           : ["/etc/resolv.conf", "/etc/hostname", "/etc/hosts"]
+    networkInterfaces     : ["lo", "eth0", "ecs-eth0"]
+    processCommand        : ["/awscollector"] # as given in container definition (ADOT collector dockerfile)
+    processCommandLine    : ["/awscollector --config=/etc/otel-config.yaml"] # as given in container definition (cmd)
+    processExecutableName : ["awscollector"] # as given in container definition (ADOT collector dockerfile)
+    processCommand        : ["/awscollector"] # as given in container definition
+    processExecutablePath : ["/awscollector"] # as given in container definition(ADOT collector dockerfile entrypoint)
+  })
+
+  depends_on = [aws_ecs_service.aoc_without_sample_app, aws_ecs_service.aoc_without_sample_app_daemon_scheduling, aws_ecs_service.extra_apps, time_sleep.wait_60_seconds]
 }
 
 module "validator_without_sample_app_for_bridge" {

--- a/terraform/ecs/variables.tf
+++ b/terraform/ecs/variables.tf
@@ -58,3 +58,11 @@ variable "ecs_extra_apps" {
   default = {}
 }
 
+variable "scheduling_strategy" {
+  default = "REPLICA"
+}
+
+variable "rollup" {
+  type    = bool
+  default = true
+}

--- a/terraform/templates/defaults/validator_docker_compose.tpl
+++ b/terraform/templates/defaults/validator_docker_compose.tpl
@@ -27,6 +27,7 @@ services:
       - "--cloudwatch-context=${cloudwatch_context_json}"
       - "--ecs-context=${ecs_context_json}"
       - "--ec2-context=${ec2_context_json}"
+      - "--hostmetrics-context=${hostmetrics_context_json}"
       - "--alarm-names=${cpu_alarm}"
       - "--alarm-names=${mem_alarm}"
       - "--alarm-names=${incoming_packets_alarm}"

--- a/terraform/testcases/hostmetrics_receiver/ecs_taskdef.tpl
+++ b/terraform/testcases/hostmetrics_receiver/ecs_taskdef.tpl
@@ -1,0 +1,35 @@
+[
+    {
+      "name": "aoc-collector",
+      "image": "${aoc_image}",
+      "cpu": 10,
+      "memory": 256,
+      "secrets": [
+        {
+          "name": "AOT_CONFIG_CONTENT",
+          "valueFrom": "${ssm_parameter_arn}"
+        }
+      ],
+      "mountPoints": [
+        {
+          "sourceVolume": "efs",
+          "containerPath": "/etc/pki/tls/certs"
+        }
+      ],
+      "essential": true,
+      "entryPoint": [],
+      "command": [],
+      "environment": [],
+      "environmentFiles": [],
+      "dependsOn": [],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/aoc-collector",
+          "awslogs-region": "${region}",
+          "awslogs-stream-prefix": "ecs",
+          "awslogs-create-group": "True"
+        }
+      }
+    }
+]

--- a/terraform/testcases/hostmetrics_receiver/otconfig.tpl
+++ b/terraform/testcases/hostmetrics_receiver/otconfig.tpl
@@ -1,0 +1,76 @@
+
+receivers:
+  hostmetrics:
+    collection_interval: 15s
+    scrapers:
+      cpu:
+        metrics:
+          system.cpu.utilization:
+            enabled: true
+      load:
+      memory:
+        metrics:
+          system.memory.utilization:
+            enabled: true
+      disk:
+      filesystem:
+        metrics:
+          system.filesystem.utilization:
+            enabled: true
+      network:
+        metrics:
+          system.network.conntrack.count:
+            enabled: true
+          system.network.conntrack.max:
+            enabled: true
+      paging:
+        metrics:
+          system.paging.utilization:
+            enabled: true
+      processes:
+      process:
+        metrics:
+          process.memory.physical_usage:
+            enabled: false
+          process.memory.virtual_usage:
+            enabled: false
+          process.memory.usage:
+            enabled: true
+          process.memory.virtual:
+            enabled: true
+          process.context_switches:
+            enabled: true
+          process.cpu.utilization:
+            enabled: true
+          process.memory.utilization:
+            enabled: true
+          process.open_file_descriptors:
+            enabled: true
+          process.paging.faults:
+            enabled: true
+          process.signals_pending:
+            enabled: true
+          process.threads:
+            enabled: true
+
+processors:
+  resourcedetection/ec2:
+    detectors: [ec2]
+    timeout: 2s
+    attributes: [host.id]
+    override: true
+
+exporters:
+  awsemf:
+    namespace: '${testing_id}'
+    region: '${region}'
+    dimension_rollup_option: NoDimensionRollup
+    resource_to_telemetry_conversion:
+      enabled: true
+
+service:
+  pipelines:
+    metrics:
+      receivers: [hostmetrics]
+      processors: [resourcedetection/ec2]
+      exporters: [awsemf]

--- a/terraform/testcases/hostmetrics_receiver/parameters.tfvars
+++ b/terraform/testcases/hostmetrics_receiver/parameters.tfvars
@@ -1,0 +1,7 @@
+# this file is defined in validator/src/main/resources/validations
+validation_config = "hostmetrics-metric-linux-validation.yml" #incase windows ami_family is used in ec2 then this property will be overridden in EC2
+sample_app_callable = false
+disable_mocked_server = true
+scheduling_strategy = "DAEMON"
+rollup = false #config has NoDimensionRollup policy
+ecs_launch_type = "EC2"

--- a/terraform/validation/main.tf
+++ b/terraform/validation/main.tf
@@ -38,9 +38,10 @@ data "template_file" "docker_compose" {
 
     # Escaping (") in the JSON when using as a terraform string variable.
     # For more information: https://www.terraform.io/docs/configuration-0-11/interpolation.html#built-in-functions
-    ec2_context_json        = replace(var.ec2_context_json, "\"", "\\\"")
-    ecs_context_json        = replace(var.ecs_context_json, "\"", "\\\"")
-    cloudwatch_context_json = replace(var.cloudwatch_context_json, "\"", "\\\"")
+    ec2_context_json          = replace(var.ec2_context_json, "\"", "\\\"")
+    ecs_context_json          = replace(var.ecs_context_json, "\"", "\\\"")
+    cloudwatch_context_json   = replace(var.cloudwatch_context_json, "\"", "\\\"")
+    hostmetrics_context_json  = replace(var.hostmetrics_context_json, "\"", "\\\"")
 
     # alarm related
     cpu_alarm              = var.cpu_alarm

--- a/terraform/validation/variables.tf
+++ b/terraform/validation/variables.tf
@@ -83,3 +83,7 @@ variable "rollup" {
   type    = bool
   default = true
 }
+
+variable "hostmetrics_context_json" {
+  default = "{}"
+}

--- a/validator/src/main/java/com/amazon/aoc/fileconfigs/PredefinedExpectedTemplate.java
+++ b/validator/src/main/java/com/amazon/aoc/fileconfigs/PredefinedExpectedTemplate.java
@@ -36,6 +36,8 @@ public enum PredefinedExpectedTemplate implements FileConfig {
   CONTAINER_INSIGHT_ECS_PROMETHEUS_METRIC(
       "/expected-data-template/container-insight/ecs/prometheus"),
   FARGATE_EXPECTED_METRIC("/expected-data-template/EKSFargateCWCIExpectedMetric.mustache"),
+  HOSTMETRICS_CW_EXPECTED_METRIC_LINUX(
+      "/expected-data-template/hostmetricsCWExpectedMetric_Linux.mustache"),
 
 
   /**

--- a/validator/src/main/java/com/amazon/aoc/models/Context.java
+++ b/validator/src/main/java/com/amazon/aoc/models/Context.java
@@ -67,4 +67,10 @@ public class Context {
   cortex parameters
    */
   private String cortexInstanceEndpoint;
+
+  /*
+  hostMetrics parameters
+   */
+  private HostmetricsContext hostmetricsContext;
+
 }

--- a/validator/src/main/java/com/amazon/aoc/models/HostmetricsContext.java
+++ b/validator/src/main/java/com/amazon/aoc/models/HostmetricsContext.java
@@ -1,0 +1,23 @@
+package com.amazon.aoc.models;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class HostmetricsContext {
+  // hostmetrics receiver testcase related context
+  private List<String> hostId;
+
+  private List<String> cpuNames;
+  private List<String> diskDevices;
+  private List<String> filesystemDevices;
+  private List<String> mountpointModes;
+  private List<String> mountpoints;
+  private List<String> networkInterfaces;
+
+  private List<String> processCommand;
+  private List<String> processCommandLine;
+  private List<String> processExecutableName;
+  private List<String> processExecutablePath;
+}

--- a/validator/src/main/java/com/amazon/aoc/models/cwmodel/Dimension.java
+++ b/validator/src/main/java/com/amazon/aoc/models/cwmodel/Dimension.java
@@ -1,0 +1,16 @@
+package com.amazon.aoc.models.cwmodel;
+
+import lombok.*;
+
+import java.util.List;
+
+@Data
+@Builder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Dimension {
+  private String name;
+  private List<String> value;
+}

--- a/validator/src/main/java/com/amazon/aoc/models/cwmodel/Metric.java
+++ b/validator/src/main/java/com/amazon/aoc/models/cwmodel/Metric.java
@@ -1,0 +1,18 @@
+package com.amazon.aoc.models.cwmodel;
+
+
+import lombok.*;
+
+import java.util.List;
+
+@Data
+@Builder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Metric {
+  private String metricName;
+  private String namespace;
+  private List<Dimension> dimensions;
+}

--- a/validator/src/main/resources/expected-data-template/hostmetricsCWExpectedMetric_Linux.mustache
+++ b/validator/src/main/resources/expected-data-template/hostmetricsCWExpectedMetric_Linux.mustache
@@ -1,0 +1,762 @@
+{{!hostmetricsreceiver/cpu}}
+-
+  metricName: system.cpu.time
+  namespace: {{testingId}}
+  dimensions:
+    -
+      name: cpu
+      value: {{hostmetricsContext.cpuNames}}
+    -
+      name: state
+      value: [idle, interrupt, nice, softirq, steal, system, user, wait]
+    -
+      name: host.id
+      value: {{hostmetricsContext.hostId}}
+    -
+      name: OTelLib
+      value: [otelcol/hostmetricsreceiver/cpu]
+
+-
+  metricName: system.cpu.utilization
+  namespace: {{testingId}}
+  dimensions:
+    -
+      name: cpu
+      value: {{hostmetricsContext.cpuNames}}
+    -
+      name: state
+      value: [idle, interrupt, nice, softirq, steal, system, user, wait]
+    -
+      name: host.id
+      value: {{hostmetricsContext.hostId}}
+    -
+      name: OTelLib
+      value: [otelcol/hostmetricsreceiver/cpu]
+
+
+{{!hostmetricsreceiver/disk}}
+-
+  metricName: system.disk.io
+  namespace: {{testingId}}
+  dimensions:
+    -
+      name: device
+      value: [SKIP]
+    -
+      name: direction
+      value: [read, write]
+    -
+      name: host.id
+      value: {{hostmetricsContext.hostId}}
+    -
+      name: OTelLib
+      value: [otelcol/hostmetricsreceiver/disk]
+
+-
+  metricName: system.disk.io_time
+  namespace: {{testingId}}
+  dimensions:
+    -
+      name: device
+      value: [SKIP]
+    -
+      name: host.id
+      value: {{hostmetricsContext.hostId}}
+    -
+      name: OTelLib
+      value: [otelcol/hostmetricsreceiver/disk]
+
+-
+  metricName: system.disk.merged
+  namespace: {{testingId}}
+  dimensions:
+    -
+      name: device
+      value: [SKIP]
+    -
+      name: direction
+      value: [read, write]
+    -
+      name: host.id
+      value: {{hostmetricsContext.hostId}}
+    -
+      name: OTelLib
+      value: [otelcol/hostmetricsreceiver/disk]
+
+-
+  metricName: system.disk.operation_time
+  namespace: {{testingId}}
+  dimensions:
+    -
+      name: device
+      value: [SKIP]
+    -
+      name: direction
+      value: [read, write]
+    -
+      name: host.id
+      value: {{hostmetricsContext.hostId}}
+    -
+      name: OTelLib
+      value: [otelcol/hostmetricsreceiver/disk]
+
+-
+  metricName: system.disk.operations
+  namespace: {{testingId}}
+  dimensions:
+    -
+      name: device
+      value: [SKIP]
+    -
+      name: direction
+      value: [read, write]
+    -
+      name: host.id
+      value: {{hostmetricsContext.hostId}}
+    -
+      name: OTelLib
+      value: [otelcol/hostmetricsreceiver/disk]
+
+-
+  metricName: system.disk.pending_operations
+  namespace: {{testingId}}
+  dimensions:
+    -
+      name: device
+      value: [SKIP]
+    -
+      name: host.id
+      value: {{hostmetricsContext.hostId}}
+    -
+      name: OTelLib
+      value: [otelcol/hostmetricsreceiver/disk]
+
+-
+  metricName: system.disk.weighted_io_time
+  namespace: {{testingId}}
+  dimensions:
+    -
+      name: device
+      value: [SKIP]
+    -
+      name: host.id
+      value: {{hostmetricsContext.hostId}}
+    -
+      name: OTelLib
+      value: [otelcol/hostmetricsreceiver/disk]
+
+
+{{!hostmetricsreceiver/load}}
+-
+  metricName: system.cpu.load_average.15m
+  namespace: {{testingId}}
+  dimensions:
+    -
+      name: host.id
+      value: {{hostmetricsContext.hostId}}
+    -
+      name: OTelLib
+      value: [otelcol/hostmetricsreceiver/load]
+
+-
+  metricName: system.cpu.load_average.1m
+  namespace: {{testingId}}
+  dimensions:
+    -
+      name: host.id
+      value: {{hostmetricsContext.hostId}}
+    -
+      name: OTelLib
+      value: [otelcol/hostmetricsreceiver/load]
+
+-
+  metricName: system.cpu.load_average.5m
+  namespace: {{testingId}}
+  dimensions:
+    -
+      name: host.id
+      value: {{hostmetricsContext.hostId}}
+    -
+      name: OTelLib
+      value: [otelcol/hostmetricsreceiver/load]
+
+
+{{!hostmetricsreceiver/filesystem}}
+-
+  metricName: system.filesystem.inodes.usage
+  namespace: {{testingId}}
+  dimensions:
+    -
+      name: device
+      value: {{hostmetricsContext.filesystemDevices}}
+    -
+      name: mode
+      value: {{hostmetricsContext.mountpointModes}}
+    -
+      name: mountpoint
+      value: {{hostmetricsContext.mountpoints}}
+    -
+      name: type
+      value: [SKIP]
+    -
+      name: state
+      value: [free, used]
+    -
+      name: host.id
+      value: {{hostmetricsContext.hostId}}
+    -
+      name: OTelLib
+      value: [otelcol/hostmetricsreceiver/filesystem]
+
+-
+  metricName: system.filesystem.usage
+  namespace: {{testingId}}
+  dimensions:
+    -
+      name: device
+      value: {{hostmetricsContext.filesystemDevices}}
+    -
+      name: mode
+      value: {{hostmetricsContext.mountpointModes}}
+    -
+      name: mountpoint
+      value: {{hostmetricsContext.mountpoints}}
+    -
+      name: type
+      value: [SKIP]
+    -
+      name: state
+      value: [free, reserved, used]
+    -
+      name: host.id
+      value: {{hostmetricsContext.hostId}}
+    -
+      name: OTelLib
+      value: [otelcol/hostmetricsreceiver/filesystem]
+
+-
+  metricName: system.filesystem.utilization
+  namespace: {{testingId}}
+  dimensions:
+    -
+      name: device
+      value: {{hostmetricsContext.filesystemDevices}}
+    -
+      name: mode
+      value: {{hostmetricsContext.mountpointModes}}
+    -
+      name: mountpoint
+      value: {{hostmetricsContext.mountpoints}}
+    -
+      name: type
+      value: [SKIP]
+    -
+      name: host.id
+      value: {{hostmetricsContext.hostId}}
+    -
+      name: OTelLib
+      value: [otelcol/hostmetricsreceiver/filesystem]
+
+
+{{!hostmetricsreceiver/memory}}
+-
+  metricName: system.memory.usage
+  namespace: {{testingId}}
+  dimensions:
+    -
+      name: state
+      value: [buffered, cached, used, slab_reclaimable, slab_unreclaimable, free]
+    -
+      name: host.id
+      value: {{hostmetricsContext.hostId}}
+    -
+      name: OTelLib
+      value: [otelcol/hostmetricsreceiver/memory]
+
+-
+  metricName: system.memory.utilization
+  namespace: {{testingId}}
+  dimensions:
+    -
+      name: state
+      value: [buffered, cached, used, slab_reclaimable, slab_unreclaimable, free]
+    -
+      name: host.id
+      value: {{hostmetricsContext.hostId}}
+    -
+      name: OTelLib
+      value: [otelcol/hostmetricsreceiver/memory]
+
+
+{{!hostmetricsreceiver/network}}
+-
+  metricName: system.network.connections
+  namespace: {{testingId}}
+  dimensions:
+    -
+      name: protocol
+      value: [tcp]
+    -
+      name: state
+      value: [SKIP]
+    -
+      name: host.id
+      value: {{hostmetricsContext.hostId}}
+    -
+      name: OTelLib
+      value: [otelcol/hostmetricsreceiver/network]
+
+-
+  metricName: system.network.dropped
+  namespace: {{testingId}}
+  dimensions:
+    -
+      name: device
+      value: {{hostmetricsContext.networkInterfaces}}
+    -
+      name: direction
+      value: [receive, transmit]
+    -
+      name: host.id
+      value: {{hostmetricsContext.hostId}}
+    -
+      name: OTelLib
+      value: [otelcol/hostmetricsreceiver/network]
+
+-
+  metricName: system.network.errors
+  namespace: {{testingId}}
+  dimensions:
+    -
+      name: device
+      value: {{hostmetricsContext.networkInterfaces}}
+    -
+      name: direction
+      value: [receive, transmit]
+    -
+      name: host.id
+      value: {{hostmetricsContext.hostId}}
+    -
+      name: OTelLib
+      value: [otelcol/hostmetricsreceiver/network]
+
+-
+  metricName: system.network.io
+  namespace: {{testingId}}
+  dimensions:
+    -
+      name: device
+      value: {{hostmetricsContext.networkInterfaces}}
+    -
+      name: direction
+      value: [receive, transmit]
+    -
+      name: host.id
+      value: {{hostmetricsContext.hostId}}
+    -
+      name: OTelLib
+      value: [otelcol/hostmetricsreceiver/network]
+
+-
+  metricName: system.network.packets
+  namespace: {{testingId}}
+  dimensions:
+    -
+      name: device
+      value: {{hostmetricsContext.networkInterfaces}}
+    -
+      name: direction
+      value: [receive, transmit]
+    -
+      name: host.id
+      value: {{hostmetricsContext.hostId}}
+    -
+      name: OTelLib
+      value: [otelcol/hostmetricsreceiver/network]
+
+-
+  metricName: system.network.conntrack.count
+  namespace: {{testingId}}
+  dimensions:
+    -
+      name: host.id
+      value: {{hostmetricsContext.hostId}}
+    -
+      name: OTelLib
+      value: [otelcol/hostmetricsreceiver/network]
+
+-
+  metricName: system.network.conntrack.max
+  namespace: {{testingId}}
+  dimensions:
+    -
+      name: host.id
+      value: {{hostmetricsContext.hostId}}
+    -
+      name: OTelLib
+      value: [otelcol/hostmetricsreceiver/network]
+
+
+{{!hostmetricsreceiver/paging}}
+-
+  metricName: system.paging.faults
+  namespace: {{testingId}}
+  dimensions:
+    -
+      name: type
+      value: [major, minor]
+    -
+      name: host.id
+      value: {{hostmetricsContext.hostId}}
+    -
+      name: OTelLib
+      value: [otelcol/hostmetricsreceiver/paging]
+
+-
+  metricName: system.paging.operations
+  namespace: {{testingId}}
+  dimensions:
+    -
+      name: direction
+      value: [page_in, page_out]
+    -
+      name: type
+      value: [major, minor]
+    -
+      name: host.id
+      value: {{hostmetricsContext.hostId}}
+    -
+      name: OTelLib
+      value: [otelcol/hostmetricsreceiver/paging]
+
+
+{{!hostmetricsreceiver/processes}}
+-
+  metricName: system.processes.count
+  namespace: {{testingId}}
+  dimensions:
+    -
+      name: status
+      value: [blocked, running, sleeping, unknown]
+    -
+      name: host.id
+      value: {{hostmetricsContext.hostId}}
+    -
+      name: OTelLib
+      value: [otelcol/hostmetricsreceiver/processes]
+
+-
+  metricName: system.processes.created
+  namespace: {{testingId}}
+  dimensions:
+    -
+      name: host.id
+      value: {{hostmetricsContext.hostId}}
+    -
+      name: OTelLib
+      value: [otelcol/hostmetricsreceiver/processes]
+
+
+{{!hostmetricsreceiver/process}}
+-
+  metricName: process.cpu.time
+  namespace: {{testingId}}
+  dimensions:
+    -
+      name: state
+      value: [system, user, wait]
+    -
+      name: host.id
+      value: {{hostmetricsContext.hostId}}
+    -
+      name: process.command
+      value: {{hostmetricsContext.processCommand}}
+    -
+      name: process.command_line
+      value: {{hostmetricsContext.processCommandLine}}
+    -
+      name: process.executable.name
+      value: {{hostmetricsContext.processExecutableName}}
+    -
+      name: process.executable.path
+      value: {{hostmetricsContext.processExecutablePath}}
+    -
+      name: process.owner
+      value: [SKIP]
+    -
+      name: process.parent_pid
+      value: [-1]
+    -
+      name: process.pid
+      value: [1]
+    -
+      name: OTelLib
+      value: [otelcol/hostmetricsreceiver/process]
+
+-
+  metricName: process.disk.io
+  namespace: {{testingId}}
+  dimensions:
+    -
+      name: direction
+      value: [read, write]
+    -
+      name: host.id
+      value: {{hostmetricsContext.hostId}}
+    -
+      name: process.command
+      value: {{hostmetricsContext.processCommand}}
+    -
+      name: process.command_line
+      value: {{hostmetricsContext.processCommandLine}}
+    -
+      name: process.executable.name
+      value: {{hostmetricsContext.processExecutableName}}
+    -
+      name: process.executable.path
+      value: {{hostmetricsContext.processExecutablePath}}
+    -
+      name: process.owner
+      value: [SKIP]
+    -
+      name: process.parent_pid
+      value: [-1]
+    -
+      name: process.pid
+      value: [1]
+    -
+      name: OTelLib
+      value: [otelcol/hostmetricsreceiver/process]
+
+-
+  metricName: process.context_switches
+  namespace: {{testingId}}
+  dimensions:
+    -
+      name: type
+      value: [involuntary, voluntary]
+    -
+      name: host.id
+      value: {{hostmetricsContext.hostId}}
+    -
+      name: process.command
+      value: {{hostmetricsContext.processCommand}}
+    -
+      name: process.command_line
+      value: {{hostmetricsContext.processCommandLine}}
+    -
+      name: process.executable.name
+      value: {{hostmetricsContext.processExecutableName}}
+    -
+      name: process.executable.path
+      value: {{hostmetricsContext.processExecutablePath}}
+    -
+      name: process.owner
+      value: [SKIP]
+    -
+      name: process.parent_pid
+      value: [-1]
+    -
+      name: process.pid
+      value: [1]
+    -
+      name: OTelLib
+      value: [otelcol/hostmetricsreceiver/process]
+
+-
+  metricName: process.cpu.utilization
+  namespace: {{testingId}}
+  dimensions:
+    -
+      name: state
+      value: [system, user, wait]
+    -
+      name: host.id
+      value: {{hostmetricsContext.hostId}}
+    -
+      name: process.command
+      value: {{hostmetricsContext.processCommand}}
+    -
+      name: process.command_line
+      value: {{hostmetricsContext.processCommandLine}}
+    -
+      name: process.executable.name
+      value: {{hostmetricsContext.processExecutableName}}
+    -
+      name: process.executable.path
+      value: {{hostmetricsContext.processExecutablePath}}
+    -
+      name: process.owner
+      value: [SKIP]
+    -
+      name: process.parent_pid
+      value: [-1]
+    -
+      name: process.pid
+      value: [1]
+    -
+      name: OTelLib
+      value: [otelcol/hostmetricsreceiver/process]
+
+-
+  metricName: process.memory.utilization
+  namespace: {{testingId}}
+  dimensions:
+    -
+      name: host.id
+      value: {{hostmetricsContext.hostId}}
+    -
+      name: process.command
+      value: {{hostmetricsContext.processCommand}}
+    -
+      name: process.command_line
+      value: {{hostmetricsContext.processCommandLine}}
+    -
+      name: process.executable.name
+      value: {{hostmetricsContext.processExecutableName}}
+    -
+      name: process.executable.path
+      value: {{hostmetricsContext.processExecutablePath}}
+    -
+      name: process.owner
+      value: [SKIP]
+    -
+      name: process.parent_pid
+      value: [-1]
+    -
+      name: process.pid
+      value: [1]
+    -
+      name: OTelLib
+      value: [otelcol/hostmetricsreceiver/process]
+
+-
+  metricName: process.open_file_descriptors
+  namespace: {{testingId}}
+  dimensions:
+    -
+      name: host.id
+      value: {{hostmetricsContext.hostId}}
+    -
+      name: process.command
+      value: {{hostmetricsContext.processCommand}}
+    -
+      name: process.command_line
+      value: {{hostmetricsContext.processCommandLine}}
+    -
+      name: process.executable.name
+      value: {{hostmetricsContext.processExecutableName}}
+    -
+      name: process.executable.path
+      value: {{hostmetricsContext.processExecutablePath}}
+    -
+      name: process.owner
+      value: [SKIP]
+    -
+      name: process.parent_pid
+      value: [-1]
+    -
+      name: process.pid
+      value: [1]
+    -
+      name: OTelLib
+      value: [otelcol/hostmetricsreceiver/process]
+
+-
+  metricName: process.paging.faults
+  namespace: {{testingId}}
+  dimensions:
+    -
+      name: type
+      value: [major, minor]
+    -
+      name: host.id
+      value: {{hostmetricsContext.hostId}}
+    -
+      name: process.command
+      value: {{hostmetricsContext.processCommand}}
+    -
+      name: process.command_line
+      value: {{hostmetricsContext.processCommandLine}}
+    -
+      name: process.executable.name
+      value: {{hostmetricsContext.processExecutableName}}
+    -
+      name: process.executable.path
+      value: {{hostmetricsContext.processExecutablePath}}
+    -
+      name: process.owner
+      value: [SKIP]
+    -
+      name: process.parent_pid
+      value: [-1]
+    -
+      name: process.pid
+      value: [1]
+    -
+      name: OTelLib
+      value: [otelcol/hostmetricsreceiver/process]
+
+-
+  metricName: process.signals_pending
+  namespace: {{testingId}}
+  dimensions:
+    -
+      name: host.id
+      value: {{hostmetricsContext.hostId}}
+    -
+      name: process.command
+      value: {{hostmetricsContext.processCommand}}
+    -
+      name: process.command_line
+      value: {{hostmetricsContext.processCommandLine}}
+    -
+      name: process.executable.name
+      value: {{hostmetricsContext.processExecutableName}}
+    -
+      name: process.executable.path
+      value: {{hostmetricsContext.processExecutablePath}}
+    -
+      name: process.owner
+      value: [SKIP]
+    -
+      name: process.parent_pid
+      value: [-1]
+    -
+      name: process.pid
+      value: [1]
+    -
+      name: OTelLib
+      value: [otelcol/hostmetricsreceiver/process]
+
+-
+  metricName: process.threads
+  namespace: {{testingId}}
+  dimensions:
+    -
+      name: host.id
+      value: {{hostmetricsContext.hostId}}
+    -
+      name: process.command
+      value: {{hostmetricsContext.processCommand}}
+    -
+      name: process.command_line
+      value: {{hostmetricsContext.processCommandLine}}
+    -
+      name: process.executable.name
+      value: {{hostmetricsContext.processExecutableName}}
+    -
+      name: process.executable.path
+      value: {{hostmetricsContext.processExecutablePath}}
+    -
+      name: process.owner
+      value: [SKIP]
+    -
+      name: process.parent_pid
+      value: [-1]
+    -
+      name: process.pid
+      value: [1]
+    -
+      name: OTelLib
+      value: [otelcol/hostmetricsreceiver/process]

--- a/validator/src/main/resources/validations/hostmetrics-metric-linux-validation.yml
+++ b/validator/src/main/resources/validations/hostmetrics-metric-linux-validation.yml
@@ -1,0 +1,4 @@
+-
+  validationType: "cw-metric"
+  callingType: "none"
+  expectedMetricTemplate: "HOSTMETRICS_CW_EXPECTED_METRIC_LINUX"


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Added `Hostmetrics` Receiver e2e testing 

- CW validator
- Linux expectation template
- testcase
- and ECS script

**Link to tracking Issue:** <Issue number if applicable>
https://github.com/aws-observability/aws-otel-ops/issues/137

**Testing:** <Describe what testing was performed and which tests were added.>
Manually testing on local box by running:
```
cd terraform/ecs
terraform init
terraform apply -auto-approve \
    -var="aoc_image_repo=public.ecr.aws/q1w6y6d0/hostmetricsamd" \
    -var="aoc_version=latest" \
    -var="testcase=../testcases/hostmetrics_receiver" \
    -var-file="../testcases/hostmetrics_receiver/parameters.tfvars"
```

Note - Requires Collector with `hostmetrics_reciever` component

**Documentation:** <Describe the documentation added.>

- [ ] Few metrics were not emitted through `cloudwatch` exporter. Details will be added. This is a todo item.


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

