### PR TITLE
Rapphil fix cdk error

### DIFF
--- a/cdk_infra/package-lock.json
+++ b/cdk_infra/package-lock.json
@@ -31,7 +31,7 @@
         "@typescript-eslint/parser": "^5.31.0",
         "ajv": "^8.11.2",
         "ajv-errors": "^3.0.0",
-        "aws-cdk": "2.52.0",
+        "aws-cdk": "2.63.1",
         "eslint": "^8.31.0",
         "jest": "^27.5.1",
         "prettier": "^2.8.1",
@@ -8637,9 +8637,9 @@
       "dev": true
     },
     "node_modules/aws-cdk": {
-      "version": "2.52.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.52.0.tgz",
-      "integrity": "sha512-48MO8W2l+m+vGWmV3yPO67MBP/U1AjmNDhiWpxvGUcPuHHNe6C86/m5yhieXmB8j/WeMxG6p7GsLcjQtwoFvTA==",
+      "version": "2.63.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.63.1.tgz",
+      "integrity": "sha512-NJpKtbbyafwl2n3vAOE/AbZQ4r/8YZajUl389CNIB75QMkZ2ShxkdYzsvQ6WRfYS+u1U0+NMQ72KLqzb+Rv3NA==",
       "dev": true,
       "bin": {
         "cdk": "bin/cdk"
@@ -18430,9 +18430,9 @@
       "dev": true
     },
     "aws-cdk": {
-      "version": "2.52.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.52.0.tgz",
-      "integrity": "sha512-48MO8W2l+m+vGWmV3yPO67MBP/U1AjmNDhiWpxvGUcPuHHNe6C86/m5yhieXmB8j/WeMxG6p7GsLcjQtwoFvTA==",
+      "version": "2.63.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.63.1.tgz",
+      "integrity": "sha512-NJpKtbbyafwl2n3vAOE/AbZQ4r/8YZajUl389CNIB75QMkZ2ShxkdYzsvQ6WRfYS+u1U0+NMQ72KLqzb+Rv3NA==",
       "dev": true,
       "requires": {
         "fsevents": "2.3.2"

--- a/cdk_infra/package-lock.json
+++ b/cdk_infra/package-lock.json
@@ -31,7 +31,7 @@
         "@typescript-eslint/parser": "^5.31.0",
         "ajv": "^8.11.2",
         "ajv-errors": "^3.0.0",
-        "aws-cdk": "2.63.1",
+        "aws-cdk": "^2.63.1",
         "eslint": "^8.31.0",
         "jest": "^27.5.1",
         "prettier": "^2.8.1",

--- a/cdk_infra/package.json
+++ b/cdk_infra/package.json
@@ -18,7 +18,7 @@
     "@typescript-eslint/parser": "^5.31.0",
     "ajv": "^8.11.2",
     "ajv-errors": "^3.0.0",
-    "aws-cdk": "2.52.0",
+    "aws-cdk": "2.63.1",
     "eslint": "^8.31.0",
     "jest": "^27.5.1",
     "prettier": "^2.8.1",

--- a/cdk_infra/package.json
+++ b/cdk_infra/package.json
@@ -18,7 +18,7 @@
     "@typescript-eslint/parser": "^5.31.0",
     "ajv": "^8.11.2",
     "ajv-errors": "^3.0.0",
-    "aws-cdk": "2.63.1",
+    "aws-cdk": "^2.63.1",
     "eslint": "^8.31.0",
     "jest": "^27.5.1",
     "prettier": "^2.8.1",


### PR DESCRIPTION
**Description:** Fix error 
```
This CDK CLI is not compatible with the CDK library used by your application. Please upgrade the CLI to the latest version.
(Cloud assembly schema version mismatch: Maximum schema version supported is 21.0.0, but found 29.0.0)
```

when trying to execute `npm run cdk synthesize`.

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

