### PR TITLE
[release/v0.26.x] Update operator deployment name

### DIFF
--- a/terraform/eks/adot-operator/adot_operator.tf
+++ b/terraform/eks/adot-operator/adot_operator.tf
@@ -50,6 +50,6 @@ resource "helm_release" "adot-operator" {
   }
 
   provisioner "local-exec" {
-    command = "kubectl wait --kubeconfig=${var.kubeconfig} --timeout=5m --for=condition=available deployment opentelemetry-operator-controller-manager"
+    command = "kubectl wait --kubeconfig=${var.kubeconfig} --timeout=5m --for=condition=available deployment adot-operator-${var.testing_id}-opentelemetry-operator"
   }
 }


### PR DESCRIPTION
**Description:**  Update deployment name used for wait condition. Changes were made in `v0.22.0` of the helm chart to the deployment name used. https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-operator/UPGRADING.md#021-to-0220

install command test
```
helm install test-otel-operator open-telemetry/opentelemetry-operator
```
resulting deployment name
```
deployment.apps/test-otel-operator-opentelemetry-operator
```
I am actively seeking clarification upstream to see if appending `opentelemetry-operator` is intended. 
This PR should unblock the operator install in the CI test cases in the mean time. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

