### PR TITLE
Remove eks 1.21 clusters and testcases

### DIFF
--- a/cdk_infra/lib/config/cluster-config/clusters.yml
+++ b/cdk_infra/lib/config/cluster-config/clusters.yml
@@ -1,26 +1,5 @@
 ---
 clusters:
-  - name: collector-ci-arm64-1-21
-    version: "1.21"
-    launch_type: ec2
-    instance_type: m6g.medium
-  - name: collector-ci-amd64-1-21
-    version: "1.21"
-    launch_type: ec2
-    instance_type: m5.large
-  - name: collector-ci-fargate-1-21
-    version: "1.21"
-    launch_type: fargate
-  - name: operator-ci-amd64-1-21
-    version: "1.21"
-    launch_type: ec2
-    instance_type: m5.large
-    cert_manager: true
-  - name: operator-ci-arm64-1-21
-    version: "1.21"
-    launch_type: ec2
-    instance_type: m6g.medium
-    cert_manager: true
   - name: collector-ci-amd64-1-22
     version: "1.22"
     launch_type: ec2

--- a/tools/batchTestGenerator/testcases.json
+++ b/tools/batchTestGenerator/testcases.json
@@ -4,10 +4,6 @@
 			"type": "EKS",
 			"targets": [
 				{
-					"name": "collector-ci-amd64-1-21",
-					"region": "us-west-2"
-				},
-				{
 					"name": "collector-ci-amd64-1-22",
 					"region": "us-west-2"
 				},
@@ -20,10 +16,6 @@
 		{
 			"type": "EKS_ARM64",
 			"targets": [
-				{
-					"name": "collector-ci-arm64-1-21",
-					"region": "us-west-2"
-				},
 				{
 					"name": "collector-ci-arm64-1-22",
 					"region": "us-west-2"
@@ -38,10 +30,6 @@
 			"type": "EKS_ADOT_OPERATOR",
 			"targets": [
 				{
-					"name": "operator-ci-amd64-1-21",
-					"region": "us-west-2"
-				},
-				{
 					"name": "operator-ci-amd64-1-22",
 					"region": "us-west-2"
 				},
@@ -55,10 +43,6 @@
 			"type": "EKS_ADOT_OPERATOR_ARM64",
 			"targets": [
 				{
-					"name": "operator-ci-arm64-1-21",
-					"region": "us-west-2"
-				},
-				{
 					"name": "operator-ci-arm64-1-22",
 					"region": "us-west-2"
 				},
@@ -71,10 +55,6 @@
 		{
 			"type": "EKS_FARGATE",
 			"targets": [
-				{
-					"name": "collector-ci-fargate-1-21",
-					"region": "us-west-2"
-				},
 				{
 					"name": "collector-ci-fargate-1-22",
 					"region": "us-west-2"


### PR DESCRIPTION
**Description:** EKS versions 1.21 is no longer supported and we no longer have to test against it. This PR removes test case targets and cluster deployments in `cdk_infra`. 

Note: Cloudformation stacks for each cluster will need to be manually deleted after this PR is merged. 
<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

