### PR TITLE
[release/v0.26.x] remove v1.21 cluster targets

### DIFF
--- a/terraform/eks/adot-operator/adot_operator.tf
+++ b/terraform/eks/adot-operator/adot_operator.tf
@@ -50,6 +50,6 @@ resource "helm_release" "adot-operator" {
   }
 
   provisioner "local-exec" {
-    command = "kubectl wait --kubeconfig=${var.kubeconfig} --timeout=5m --for=condition=available deployment opentelemetry-operator-controller-manager"
+    command = "kubectl wait --kubeconfig=${var.kubeconfig} --timeout=5m --for=condition=available deployment adot-operator-${var.testing_id}-opentelemetry-operator"
   }
 }

--- a/tools/batchTestGenerator/testcases.json
+++ b/tools/batchTestGenerator/testcases.json
@@ -4,10 +4,6 @@
 			"type": "EKS",
 			"targets": [
 				{
-					"name": "collector-ci-amd64-1-21",
-					"region": "us-west-2"
-				},
-				{
 					"name": "collector-ci-amd64-1-22",
 					"region": "us-west-2"
 				},
@@ -20,10 +16,6 @@
 		{
 			"type": "EKS_ARM64",
 			"targets": [
-				{
-					"name": "collector-ci-arm64-1-21",
-					"region": "us-west-2"
-				},
 				{
 					"name": "collector-ci-arm64-1-22",
 					"region": "us-west-2"
@@ -38,10 +30,6 @@
 			"type": "EKS_ADOT_OPERATOR",
 			"targets": [
 				{
-					"name": "operator-ci-amd64-1-21",
-					"region": "us-west-2"
-				},
-				{
 					"name": "operator-ci-amd64-1-22",
 					"region": "us-west-2"
 				},
@@ -55,10 +43,6 @@
 			"type": "EKS_ADOT_OPERATOR_ARM64",
 			"targets": [
 				{
-					"name": "operator-ci-arm64-1-21",
-					"region": "us-west-2"
-				},
-				{
 					"name": "operator-ci-arm64-1-22",
 					"region": "us-west-2"
 				},
@@ -71,10 +55,6 @@
 		{
 			"type": "EKS_FARGATE",
 			"targets": [
-				{
-					"name": "collector-ci-fargate-1-21",
-					"region": "us-west-2"
-				},
 				{
 					"name": "collector-ci-fargate-1-22",
 					"region": "us-west-2"


### PR DESCRIPTION
**Description:** Remove EKS v1.21 cluster targets from release/v0.26.x branch

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

