### PR TITLE
Add configurable sort key for test case batching

### DIFF
--- a/terraform/checkCacheHit.sh
+++ b/terraform/checkCacheHit.sh
@@ -5,10 +5,21 @@
 # required env vars
 # DDB_TABLE_NAME: dyanmodb table name that will be queries
 # TF_VAR_aoc_version: test image version that was used
+# DDB_BATCH_CACHE_SK(OPTIONAL): If set then the prefix
+# of the sortkey will be set to this value. The default value is the 
+# value of TF_VAR_aoc_version. This is useful if testing
+# something other than the ADOT Collector and you would like to use a different
+# sort key. 
 
 test_framework_shortsha=$(git rev-parse --short HEAD)
 
-CACHE_HIT=$(aws dynamodb get-item --region=us-west-2 --table-name ${DDB_TABLE_NAME} --key {\"TestId\":{\"S\":\"$1$2$3\"}\,\"aoc_version\":{\"S\":\"${TF_VAR_aoc_version}$test_framework_shortsha\"}})
+if [[ -z "${DDB_BATCH_CACHE_SK}" ]]; then
+    DDB_SK_PREFIX=$TF_VAR_aoc_version
+else
+    DDB_SK_PREFIX=$DDB_BATCH_CACHE_SK
+fi
+
+CACHE_HIT=$(aws dynamodb get-item --region=us-west-2 --table-name ${DDB_TABLE_NAME} --key {\"TestId\":{\"S\":\"$1$2$3\"}\,\"aoc_version\":{\"S\":\"$DDB_SK_PREFIX$test_framework_shortsha\"}})
 
 if [ -z "${CACHE_HIT}" ]; then
     echo "Cache miss for $@"

--- a/terraform/checkCacheHit.sh
+++ b/terraform/checkCacheHit.sh
@@ -12,6 +12,9 @@
 # sort key. 
 
 test_framework_shortsha=$(git rev-parse --short HEAD)
+SERVICE="$1"
+TESTCASE=$2
+ADDTL_PARAMS=$3
 
 if [[ -z "${DDB_BATCH_CACHE_SK}" ]]; then
     DDB_SK_PREFIX=$TF_VAR_aoc_version
@@ -19,7 +22,7 @@ else
     DDB_SK_PREFIX=$DDB_BATCH_CACHE_SK
 fi
 
-CACHE_HIT=$(aws dynamodb get-item --region=us-west-2 --table-name ${DDB_TABLE_NAME} --key {\"TestId\":{\"S\":\"$1$2$3\"}\,\"aoc_version\":{\"S\":\"$DDB_SK_PREFIX$test_framework_shortsha\"}})
+CACHE_HIT=$(aws dynamodb get-item --region=us-west-2 --table-name ${DDB_TABLE_NAME} --key {\"TestId\":{\"S\":\"$SERVICE$TESTCASE$ADDTL_PARAMS\"}\,\"aoc_version\":{\"S\":\"$DDB_SK_PREFIX$test_framework_shortsha\"}})
 
 if [ -z "${CACHE_HIT}" ]; then
     echo "Cache miss for $@"

--- a/terraform/executeTerraformTest.sh
+++ b/terraform/executeTerraformTest.sh
@@ -99,7 +99,6 @@ while [ $ATTEMPTS_LEFT -gt 0 ] && ! ../checkCacheHit.sh $SERVICE $TESTCASE $ADDT
     ;;
     esac
 
-    ../checkCacheHit.sh $SERVICE $TESTCASE $ADDTL_PARAMS
     let ATTEMPTS_LEFT=ATTEMPTS_LEFT-1
 done
 

--- a/terraform/executeTerraformTest.sh
+++ b/terraform/executeTerraformTest.sh
@@ -28,7 +28,9 @@
 set -x
 
 echo "Test Case Args: $@"
-
+SERVICE="$1"
+TESTCASE=$2
+ADDTL_PARAMS=$3
 
 if [[ -z "${DDB_BATCH_CACHE_SK}" ]]; then
     DDB_SK_PREFIX=$TF_VAR_aoc_version
@@ -37,30 +39,29 @@ else
 fi
         
 opts=""
-if [[ -f ./testcases/$2/parameters.tfvars ]] ; then 
-    opts="-var-file=../testcases/$2/parameters.tfvars" ; 
+if [[ -f ./testcases/$TESTCASE/parameters.tfvars ]] ; then 
+    opts="-var-file=../testcases/$TESTCASE/parameters.tfvars" ; 
 fi
 
 APPLY_EXIT=0
 TEST_FOLDER=""
-service="$1"
 export AWS_REGION=us-west-2
-case "$service" in
+case "$SERVICE" in
     EC2) TEST_FOLDER="./ec2/";
-        opts+=" -var=testing_ami=$3";
+        opts+=" -var=testing_ami=$ADDTL_PARAMS";
     ;;
     EKS*) TEST_FOLDER="./eks/"
-        region=$(echo $3 | cut -d \| -f 1);
-        clustername=$(echo $3 | cut -d \| -f 2);
+        region=$(echo $ADDTL_PARAMS | cut -d \| -f 1);
+        clustername=$(echo $ADDTL_PARAMS | cut -d \| -f 2);
         export AWS_REGION=${region};
         opts+=" -var=region=${region}";
         opts+=" -var=eks_cluster_name=${clustername}";
     ;;
     ECS) TEST_FOLDER="./ecs/";
-        opts+=" -var=ecs_launch_type=$3";
+        opts+=" -var=ecs_launch_type=$ADDTL_PARAMS";
     ;;
     *)
-    echo "service ${service} is not valid";
+    echo "service ${SERVICE} is not valid";
     exit 1;
     ;;
 esac
@@ -76,21 +77,21 @@ test_framework_shortsha=$(git rev-parse --short HEAD)
 # Used as a retry mechanic.
 ATTEMPTS_LEFT=2
 cd ${TEST_FOLDER};
-while [ $ATTEMPTS_LEFT -gt 0 ] && ! ../checkCacheHit.sh $1 $2 $3; do
+while [ $ATTEMPTS_LEFT -gt 0 ] && ! ../checkCacheHit.sh $SERVICE $TESTCASE $ADDTL_PARAMS; do
     terraform init;
-    if timeout -k 5m --signal=SIGINT -v 45m terraform apply -auto-approve -lock=false $opts  -var="testcase=../testcases/$2" ; then
+    if timeout -k 5m --signal=SIGINT -v 45m terraform apply -auto-approve -lock=false $opts  -var="testcase=../testcases/$TESTCASE" ; then
         APPLY_EXIT=$?
         echo "Exit code: $?" 
-        aws dynamodb put-item --region=us-west-2 --table-name ${DDB_TABLE_NAME} --item {\"TestId\":{\"S\":\"$1$2$3\"}\,\"aoc_version\":{\"S\":\"$DDB_SK_PREFIX$test_framework_shortsha\"}\,\"TimeToExist\":{\"N\":\"${TTL_DATE}\"}} --return-consumed-capacity TOTAL
+        aws dynamodb put-item --region=us-west-2 --table-name ${DDB_TABLE_NAME} --item {\"TestId\":{\"S\":\"$SERVICE$TESTCASE$ADDTL_PARAMS\"}\,\"aoc_version\":{\"S\":\"$DDB_SK_PREFIX$test_framework_shortsha\"}\,\"TimeToExist\":{\"N\":\"${TTL_DATE}\"}} --return-consumed-capacity TOTAL
     else
         APPLY_EXIT=$?
         echo "Terraform apply failed"
         echo "Exit code: $?"
-        echo "AWS_service: $1"
-        echo "Testcase: $2" 
+        echo "AWS_service: $SERVICE"
+        echo "Testcase: $TESTCASE" 
     fi
 
-    case "$service" in
+    case "$SERVICE" in
         EKS*) terraform destroy --auto-approve $opts;
         ;;
     *)
@@ -98,7 +99,7 @@ while [ $ATTEMPTS_LEFT -gt 0 ] && ! ../checkCacheHit.sh $1 $2 $3; do
     ;;
     esac
 
-    ../checkCacheHit.sh $1 $2 $3
+    ../checkCacheHit.sh $SERVICE $TESTCASE $ADDTL_PARAMS
     let ATTEMPTS_LEFT=ATTEMPTS_LEFT-1
 done
 


### PR DESCRIPTION
**Description:** This PR adds a new enviornment variable option for executing batch tests. This is necessary because the cache will need to be used for more than just Collector tests. Previously the sort key of the DDB Table was `<Collector Version><Testing Framework Version>`. This needs to change because the collector version will not always be the unit under test. This makes the cache usable for testing things like the OpenTelemetry SDKs where the SDK Version could be in the sort key value while the primary key remains the unique test combination. 

The change was made this way so that it is backwards compatible with existing implementations. The collector CI will not need to be updated since it does not set the `DDB_BATCH_CACHE_SK` value. 

Testing was done with the custom script below
```
#!/bin/bash
if [[ -z "${DDB_BATCH_CACHE_SK}" ]]; then
    DDB_SK_PREFIX=$TF_VAR_aoc_version
else
    DDB_SK_PREFIX=$DDB_BATCH_CACHE_SK
fi
test_framework_shortsha=$(git rev-parse --short HEAD)
echo $DDB_SK_PREFIX$test_framework_shortsha
```
Results are below
```
bryaag@147ddac12c15 terraform % export TF_VAR_aoc_version=v0.99.0
bryaag@147ddac12c15 terraform % ./sktest.sh 
v0.99.0b7992972
bryaag@147ddac12c15 terraform % export DDB_BATCH_CACHE_SK=v0.88.0
bryaag@147ddac12c15 terraform % ./sktest.sh                      
v0.88.0b7992972
```

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

