### PR TITLE
Add EKS v1.24 tests

### DIFF
--- a/tools/batchTestGenerator/testcases.json
+++ b/tools/batchTestGenerator/testcases.json
@@ -26,7 +26,10 @@
 				},
 				{
 					"name": "collector-ci-arm64-1-24",
-					"region": "us-west-2"
+					"region": "us-west-2",
+					"excluded_tests": [
+						"containerinsight_eks"
+					]
 				}
 			]
 		},
@@ -43,7 +46,10 @@
 				},
 				{
 					"name": "operator-ci-amd64-1-24",
-					"region": "us-west-2"
+					"region": "us-west-2",
+					"excluded_tests": [
+						"containerinsight_eks"
+					]
 				}
 			]
 		},

--- a/tools/batchTestGenerator/testcases.json
+++ b/tools/batchTestGenerator/testcases.json
@@ -23,6 +23,10 @@
 				{
 					"name": "collector-ci-arm64-1-23",
 					"region": "us-west-2"
+				},
+				{
+					"name": "collector-ci-arm64-1-24",
+					"region": "us-west-2"
 				}
 			]
 		},
@@ -35,6 +39,10 @@
 				},
 				{
 					"name": "operator-ci-amd64-1-23",
+					"region": "us-west-2"
+				},
+				{
+					"name": "operator-ci-amd64-1-24",
 					"region": "us-west-2"
 				}
 			]


### PR DESCRIPTION
**Description:** Adds eks tests for k8s v1.24. Excludes containerisnight_eks from these tests. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

