### PR TITLE
Add resources used by config map providers

### DIFF
--- a/cdk_infra/lib/app.ts
+++ b/cdk_infra/lib/app.ts
@@ -21,6 +21,6 @@ new MSKClustersStack(app, 'msk-clusters', {
   eksVPC: vpcStack.vpc
 });
 new ConfigMapProvidersStack(app, 'config-map-providers', {
-  suffix: process.env.CONFIG_BUCKET_SUFFIX || ''
+  suffix: process.env.CONFIG_BUCKET_SUFFIX
 });
 deployClusters(app, vpcStack.vpc, envDefault);

--- a/cdk_infra/lib/app.ts
+++ b/cdk_infra/lib/app.ts
@@ -21,6 +21,6 @@ new MSKClustersStack(app, 'msk-clusters', {
   eksVPC: vpcStack.vpc
 });
 new ConfigMapProvidersStack(app, 'config-map-providers', {
-  suffix: process.env.CONFIG_BUCKET_SUFFIX
+  env: envDefault
 });
 deployClusters(app, vpcStack.vpc, envDefault);

--- a/cdk_infra/lib/app.ts
+++ b/cdk_infra/lib/app.ts
@@ -4,6 +4,7 @@ import * as cdk from 'aws-cdk-lib';
 import { deployClusters } from './cluster-deployment';
 import { VPCStack } from './stacks/vpc/vpc-stack';
 import { MSKClustersStack } from './stacks/msk/msk-stack';
+import { ConfigMapProvidersStack } from './stacks/config-map-providers/config-map-providers-stack';
 
 const envDefault = {
   account: process.env.CDK_DEFAULT_ACCOUNT,
@@ -18,5 +19,8 @@ const vpcStack = new VPCStack(app, 'EKSVpc', {
 new MSKClustersStack(app, 'msk-clusters', {
   env: envDefault,
   eksVPC: vpcStack.vpc
+});
+new ConfigMapProvidersStack(app, 'config-map-providers', {
+  suffix: process.env.CONFIG_BUCKET_SUFFIX || ''
 });
 deployClusters(app, vpcStack.vpc, envDefault);

--- a/cdk_infra/lib/constructs/msk/test-cluster.ts
+++ b/cdk_infra/lib/constructs/msk/test-cluster.ts
@@ -4,7 +4,7 @@ import { aws_msk, RemovalPolicy } from 'aws-cdk-lib';
 import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
 
 export interface MSKTestClusterProps {
-  readonly namePrefix: String;
+  readonly namePrefix: string;
   readonly kafkaVersion: string;
   readonly vpc: IVpc;
   // Kafka server.properties file https://kafka.apache.org/documentation/#configuration

--- a/cdk_infra/lib/stacks/config-map-providers/config-map-providers-stack.ts
+++ b/cdk_infra/lib/stacks/config-map-providers/config-map-providers-stack.ts
@@ -8,7 +8,7 @@ import { Bucket, BucketEncryption } from 'aws-cdk-lib/aws-s3';
 import { Construct } from 'constructs';
 
 export interface ConfigMapProvidersStackProps extends StackProps {
-  // Suffix used to test the stack and avoid collisions with s3 buckets names, that must be globally unique.
+  // Suffix used to test the stack
   suffix?: string;
 }
 
@@ -24,7 +24,14 @@ export class ConfigMapProvidersStack extends Stack {
   ) {
     super(scope, id, props);
 
-    const suffix = props.suffix || '';
+    // We need a suffix for testing deployments in local accounts and in unit tests
+    // We are "hiding" this here so that this detail does not leak when we instantiate
+    // the stack. The order of precedence when evaluating the suffix is:
+    // * environment CONFIG_MAP_PROVIDERS_BUCKET_SUFFIX variable: used when testing locally in dev account.
+    // * props.suffix: used in unit tests
+    // * the default is an empty suffix ''
+    const suffix = process.env.CONFIG_MAP_PROVIDERS_BUCKET_SUFFIX || props.suffix || '';
+
     const bucketName = `adot-collector-integ-test-configurations${suffix}`;
 
     const bucket = new Bucket(this, 'configuration-bucket', {

--- a/cdk_infra/lib/stacks/config-map-providers/config-map-providers-stack.ts
+++ b/cdk_infra/lib/stacks/config-map-providers/config-map-providers-stack.ts
@@ -8,7 +8,8 @@ import { Bucket, BucketEncryption } from 'aws-cdk-lib/aws-s3';
 import { Construct } from 'constructs';
 
 export interface ConfigMapProvidersStackProps extends StackProps {
-  suffix: string;
+  // Suffix used to test the stack and avoid collisions with s3 buckets names, that must be globally unique.
+  suffix: string | undefined;
 }
 
 /**
@@ -23,7 +24,8 @@ export class ConfigMapProvidersStack extends Stack {
   ) {
     super(scope, id, props);
 
-    const bucketName = `aws-otel-collector-integ-test-configurations${props.suffix}`;
+    const suffix = props.suffix || '';
+    const bucketName = `aws-otel-collector-integ-test-configurations${suffix}`;
 
     const bucket = new Bucket(this, 'configuration-bucket', {
       bucketName: bucketName,

--- a/cdk_infra/lib/stacks/config-map-providers/config-map-providers-stack.ts
+++ b/cdk_infra/lib/stacks/config-map-providers/config-map-providers-stack.ts
@@ -14,7 +14,8 @@ export interface ConfigMapProvidersStackProps extends StackProps {
 
 /**
  * Stack containing resources used by config map providers in the integration
- * tests.
+ * tests. The limitation is that only one stack of this type can be deployed per
+ * region.
  */
 export class ConfigMapProvidersStack extends Stack {
   constructor(
@@ -24,15 +25,9 @@ export class ConfigMapProvidersStack extends Stack {
   ) {
     super(scope, id, props);
 
-    // We need a suffix for testing deployments in local accounts and in unit tests
-    // We are "hiding" this here so that this detail does not leak when we instantiate
-    // the stack. The order of precedence when evaluating the suffix is:
-    // * environment CONFIG_MAP_PROVIDERS_BUCKET_SUFFIX variable: used when testing locally in dev account.
-    // * props.suffix: used in unit tests
-    // * the default is an empty suffix ''
-    const suffix = process.env.CONFIG_MAP_PROVIDERS_BUCKET_SUFFIX || props.suffix || '';
-
-    const bucketName = `adot-collector-integ-test-configurations${suffix}`;
+    // We need a globally unique bucket name that can be used in local development as well,
+    // therefore we are using the region and account id as part of the bucket name.
+    const bucketName = `adot-collector-integ-test-configurations-${this.region}-${this.account}`;
 
     const bucket = new Bucket(this, 'configuration-bucket', {
       bucketName: bucketName,

--- a/cdk_infra/lib/stacks/config-map-providers/config-map-providers-stack.ts
+++ b/cdk_infra/lib/stacks/config-map-providers/config-map-providers-stack.ts
@@ -1,0 +1,45 @@
+import { Duration, Stack, StackProps } from 'aws-cdk-lib';
+import {
+  Effect,
+  PolicyStatement,
+  AccountRootPrincipal
+} from 'aws-cdk-lib/aws-iam';
+import { Bucket, BucketEncryption } from 'aws-cdk-lib/aws-s3';
+import { Construct } from 'constructs';
+
+export interface ConfigMapProvidersStackProps extends StackProps {
+  suffix: string;
+}
+
+/**
+ * Stack containing resources used by config map providers in the integration
+ * tests.
+ */
+export class ConfigMapProvidersStack extends Stack {
+  constructor(
+    scope: Construct,
+    id: string,
+    props: ConfigMapProvidersStackProps
+  ) {
+    super(scope, id, props);
+
+    const bucketName = `aws-otel-collector-integ-test-configurations${props.suffix}`;
+
+    const bucket = new Bucket(this, 'configuration-bucket', {
+      bucketName: bucketName,
+      // Auto delete objects in 3 days
+      lifecycleRules: [{ expiration: Duration.days(3) }],
+      encryption: BucketEncryption.S3_MANAGED,
+      versioned: false
+    });
+
+    const bucketPolicy = new PolicyStatement({
+      effect: Effect.ALLOW,
+      actions: ['s3:*'],
+      resources: [`arn:aws:s3:::${bucketName}`, `arn:aws:s3:::${bucketName}/*`],
+      principals: [new AccountRootPrincipal()]
+    });
+
+    bucket.addToResourcePolicy(bucketPolicy);
+  }
+}

--- a/cdk_infra/lib/stacks/config-map-providers/config-map-providers-stack.ts
+++ b/cdk_infra/lib/stacks/config-map-providers/config-map-providers-stack.ts
@@ -7,22 +7,13 @@ import {
 import { Bucket, BucketEncryption } from 'aws-cdk-lib/aws-s3';
 import { Construct } from 'constructs';
 
-export interface ConfigMapProvidersStackProps extends StackProps {
-  // Suffix used to test the stack
-  suffix?: string;
-}
-
 /**
  * Stack containing resources used by config map providers in the integration
  * tests. The limitation is that only one stack of this type can be deployed per
  * region.
  */
 export class ConfigMapProvidersStack extends Stack {
-  constructor(
-    scope: Construct,
-    id: string,
-    props: ConfigMapProvidersStackProps
-  ) {
+  constructor(scope: Construct, id: string, props: StackProps) {
     super(scope, id, props);
 
     // We need a globally unique bucket name that can be used in local development as well,

--- a/cdk_infra/lib/stacks/config-map-providers/config-map-providers-stack.ts
+++ b/cdk_infra/lib/stacks/config-map-providers/config-map-providers-stack.ts
@@ -25,7 +25,7 @@ export class ConfigMapProvidersStack extends Stack {
     super(scope, id, props);
 
     const suffix = props.suffix || '';
-    const bucketName = `aws-otel-collector-integ-test-configurations${suffix}`;
+    const bucketName = `adot-collector-integ-test-configurations${suffix}`;
 
     const bucket = new Bucket(this, 'configuration-bucket', {
       bucketName: bucketName,

--- a/cdk_infra/lib/stacks/config-map-providers/config-map-providers-stack.ts
+++ b/cdk_infra/lib/stacks/config-map-providers/config-map-providers-stack.ts
@@ -9,7 +9,7 @@ import { Construct } from 'constructs';
 
 export interface ConfigMapProvidersStackProps extends StackProps {
   // Suffix used to test the stack and avoid collisions with s3 buckets names, that must be globally unique.
-  suffix: string | undefined;
+  suffix?: string;
 }
 
 /**

--- a/cdk_infra/test/config-map-providers-stack.test.ts
+++ b/cdk_infra/test/config-map-providers-stack.test.ts
@@ -6,7 +6,8 @@ test('Config map providers', () => {
   // prepare
   const stack = new cdk.App();
   const env = {
-    region: 'us-west-2'
+    region: 'us-west-2',
+    account: '123456789012'
   };
 
   // Act
@@ -26,12 +27,7 @@ test('Config map providers', () => {
   const template = Template.fromStack(configMapProvidersStack);
 
   template.hasResourceProperties('AWS::S3::Bucket', {
-    BucketName: 'adot-collector-integ-test-configurationsfoo'
+    BucketName: 'adot-collector-integ-test-configurations-us-west-2-123456789012'
   });
 
-  const noSuffixTemplate = Template.fromStack(noSuffixConfigMapProvidersStack);
-
-  noSuffixTemplate.hasResourceProperties('AWS::S3::Bucket', {
-    BucketName: 'adot-collector-integ-test-configurations'
-  }); 
 });

--- a/cdk_infra/test/config-map-providers-stack.test.ts
+++ b/cdk_infra/test/config-map-providers-stack.test.ts
@@ -1,0 +1,26 @@
+import * as cdk from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { ConfigMapProvidersStack } from '../lib/stacks/config-map-providers/config-map-providers-stack';
+
+test('Config map providers', () => {
+  // prepare
+  const stack = new cdk.App();
+  const env = {
+    region: 'us-west-2'
+  };
+
+  // Act
+  const configMapProvidersStack = new ConfigMapProvidersStack(
+    stack,
+    'config-map-providers',
+    { suffix: 'foo' ,
+    env: env
+  });
+
+  // Assert
+  const template = Template.fromStack(configMapProvidersStack);
+
+  template.hasResourceProperties('AWS::S3::Bucket', {
+    BucketName: 'aws-otel-collector-integ-test-configurationsfoo'
+  });
+});

--- a/cdk_infra/test/config-map-providers-stack.test.ts
+++ b/cdk_infra/test/config-map-providers-stack.test.ts
@@ -26,12 +26,12 @@ test('Config map providers', () => {
   const template = Template.fromStack(configMapProvidersStack);
 
   template.hasResourceProperties('AWS::S3::Bucket', {
-    BucketName: 'aws-otel-collector-integ-test-configurationsfoo'
+    BucketName: 'adot-collector-integ-test-configurationsfoo'
   });
 
   const noSuffixTemplate = Template.fromStack(noSuffixConfigMapProvidersStack);
 
   noSuffixTemplate.hasResourceProperties('AWS::S3::Bucket', {
-    BucketName: 'aws-otel-collector-integ-test-configurations'
+    BucketName: 'adot-collector-integ-test-configurations'
   }); 
 });

--- a/cdk_infra/test/config-map-providers-stack.test.ts
+++ b/cdk_infra/test/config-map-providers-stack.test.ts
@@ -13,21 +13,17 @@ test('Config map providers', () => {
   // Act
   const configMapProvidersStack = new ConfigMapProvidersStack(
     stack,
-    'config-map-providers', {
-      suffix: 'foo',
+    'config-map-providers',
+    {
       env: env
-  });
-
-  const noSuffixConfigMapProvidersStack = new ConfigMapProvidersStack(stack,
-    'no-suffix', {
-    env: env
-  });
+    }
+  );
 
   // Assert
   const template = Template.fromStack(configMapProvidersStack);
 
   template.hasResourceProperties('AWS::S3::Bucket', {
-    BucketName: 'adot-collector-integ-test-configurations-us-west-2-123456789012'
+    BucketName:
+      'adot-collector-integ-test-configurations-us-west-2-123456789012'
   });
-
 });

--- a/cdk_infra/test/config-map-providers-stack.test.ts
+++ b/cdk_infra/test/config-map-providers-stack.test.ts
@@ -12,8 +12,13 @@ test('Config map providers', () => {
   // Act
   const configMapProvidersStack = new ConfigMapProvidersStack(
     stack,
-    'config-map-providers',
-    { suffix: 'foo' ,
+    'config-map-providers', {
+      suffix: 'foo',
+      env: env
+  });
+
+  const noSuffixConfigMapProvidersStack = new ConfigMapProvidersStack(stack,
+    'no-suffix', {
     env: env
   });
 
@@ -23,4 +28,10 @@ test('Config map providers', () => {
   template.hasResourceProperties('AWS::S3::Bucket', {
     BucketName: 'aws-otel-collector-integ-test-configurationsfoo'
   });
+
+  const noSuffixTemplate = Template.fromStack(noSuffixConfigMapProvidersStack);
+
+  noSuffixTemplate.hasResourceProperties('AWS::S3::Bucket', {
+    BucketName: 'aws-otel-collector-integ-test-configurations'
+  }); 
 });


### PR DESCRIPTION
**Description:** Add resources used by the config map providers in the integration tests. For now we just have a bucket that will be used to store configurations used during the tests by the following config map providers:
* s3
* http
* https

**Testing:** Tested in my own account

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

