### PR TITLE
Switch to aws_ecs_cluster resource from ecs-cluster module and require IMDSv2

### DIFF
--- a/terraform/ecs/efs.tf
+++ b/terraform/ecs/efs.tf
@@ -81,7 +81,7 @@ resource "aws_instance" "collector_efs_ec2" {
   }
 
   tags = {
-    Name = "Integ-test-aoc"
+    Name  = "Integ-test-aoc"
     Patch = var.patch
   }
 

--- a/terraform/ecs/efs.tf
+++ b/terraform/ecs/efs.tf
@@ -82,6 +82,7 @@ resource "aws_instance" "collector_efs_ec2" {
 
   tags = {
     Name = "Integ-test-aoc"
+    Patch = var.patch
   }
 
   metadata_options {

--- a/terraform/ecs/extra_apps.tf
+++ b/terraform/ecs/extra_apps.tf
@@ -28,7 +28,7 @@ resource "aws_ecs_task_definition" "extra_apps" {
 resource "aws_ecs_service" "extra_apps" {
   for_each         = var.ecs_extra_apps
   name             = "aocservice-${module.common.testing_id}-${each.value.service_name}"
-  cluster          = module.ecs_cluster.cluster_id
+  cluster          = aws_ecs_cluster.ecscluster.id
   task_definition  = "${aws_ecs_task_definition.extra_apps[each.key].family}:1"
   desired_count    = each.value.replicas
   launch_type      = each.value.launch_type

--- a/terraform/ecs/main.tf
+++ b/terraform/ecs/main.tf
@@ -106,7 +106,6 @@ resource "aws_launch_template" "launchtemp" {
 
 resource "aws_autoscaling_group" "clusterasg" {
   name = "clusterasg"
-  #availability_zones = ["us-west-2a", "us-west-2b", "us-west-2c"]
   vpc_zone_identifier = module.basic_components.aoc_private_subnet_ids
   desired_capacity   = 1
   max_size           = 10

--- a/terraform/ecs/main.tf
+++ b/terraform/ecs/main.tf
@@ -151,7 +151,7 @@ data "aws_instances" "ecs-instances" {
     values = ["Integ-test-ecs-instance"]
   }
 
-  instance_state_names = ["running", "stopped"]
+  instance_state_names = ["running"]
 
   depends_on = [aws_autoscaling_group.clusterasg]
 }

--- a/terraform/ecs/main.tf
+++ b/terraform/ecs/main.tf
@@ -170,7 +170,7 @@ resource "null_resource" "iam_wait" {
   ]
 
   provisioner "local-exec" {
-    command = "sleep 30"
+    command = "echo iam_wait done"
   }
 }
 

--- a/terraform/ecs/main.tf
+++ b/terraform/ecs/main.tf
@@ -81,9 +81,19 @@ resource "aws_ecs_capacity_provider" "capacityprovider" {
   }
 }
 
+data "aws_ami" "amazon_linux_2" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-ecs-hvm-*-x86_64-ebs"]
+  }
+}
+
 resource "aws_launch_template" "launchtemp" {
   name_prefix   = "launchtemp"
-  image_id      = "ami-0ae546d2dd33d2039"
+  image_id      =  data.aws_ami.amazon_linux_2.image_id
   instance_type = "t2.medium"
   user_data            = "${base64encode("#!/bin/bash\necho ECS_CLUSTER=${module.common.testing_id} >> /etc/ecs/ecs.config")}"
   metadata_options {

--- a/terraform/ecs/main.tf
+++ b/terraform/ecs/main.tf
@@ -227,14 +227,14 @@ resource "aws_ssm_parameter" "otconfig" {
 
 resource "null_resource" "check_patch" {
   depends_on = [
-    data.aws_instances.ecs-instances, aws_instance.collector_efs_ec2]
+  data.aws_instances.ecs-instances, aws_instance.collector_efs_ec2]
   count = var.patch ? 1 : 0
 
   # https://discuss.hashicorp.com/t/how-to-rewrite-null-resource-with-local-exec-provisioner-when-destroy-to-prepare-for-deprecation-after-0-12-8/4580/2
   triggers = {
-    ecs_id = data.aws_instances.ecs-instances.ids[0]
-    aoc_id     = aws_instance.collector_efs_ec2.id
-    aotutil    = var.aotutil
+    ecs_id  = data.aws_instances.ecs-instances.ids[0]
+    aoc_id  = aws_instance.collector_efs_ec2.id
+    aotutil = var.aotutil
   }
 
   provisioner "local-exec" {

--- a/terraform/ecs/main.tf
+++ b/terraform/ecs/main.tf
@@ -88,7 +88,7 @@ resource "aws_ecs_cluster_capacity_providers" "clustercapacity" {
   default_capacity_provider_strategy {
     base              = 1
     weight            = 100
-    capacity_provider = aws_ecs_capacity_provider.example.name
+    capacity_provider = aws_ecs_capacity_provider.capacityprovider.name
   }
 }
 
@@ -102,13 +102,13 @@ resource "aws_ecs_capacity_provider" "capacityprovider" {
 
 resource "aws_launch_template" "foobar" {
   name_prefix   = "foobar"
-  image_id      = "ami-1a2b3c"
+  image_id      = "ami-0ae546d2dd33d2039"
   instance_type = "t2.medium"
 }
 
 resource "aws_autoscaling_group" "clusterasg" {
   name = "clusterasg"
-  availability_zones = ["us-east-1a"]
+  availability_zones = ["us-west-2a"]
   desired_capacity   = 1
   max_size           = 1
   min_size           = 1

--- a/terraform/ecs/main.tf
+++ b/terraform/ecs/main.tf
@@ -93,9 +93,9 @@ data "aws_ami" "amazon_linux_2" {
 
 resource "aws_launch_template" "launchtemp" {
   name_prefix   = "launchtemp"
-  image_id      =  data.aws_ami.amazon_linux_2.image_id
+  image_id      = data.aws_ami.amazon_linux_2.image_id
   instance_type = "t2.medium"
-  user_data            = "${base64encode("#!/bin/bash\necho ECS_CLUSTER=${module.common.testing_id} >> /etc/ecs/ecs.config")}"
+  user_data     = base64encode("#!/bin/bash\necho ECS_CLUSTER=${module.common.testing_id} >> /etc/ecs/ecs.config")
   metadata_options {
     http_endpoint               = "enabled"
     http_tokens                 = "required"
@@ -104,7 +104,7 @@ resource "aws_launch_template" "launchtemp" {
   }
   network_interfaces {
     associate_public_ip_address = true
-    security_groups = [module.basic_components.aoc_security_group_id]
+    security_groups             = [module.basic_components.aoc_security_group_id]
   }
   iam_instance_profile {
     name = aws_iam_instance_profile.cluster.name
@@ -115,11 +115,11 @@ resource "aws_launch_template" "launchtemp" {
 }
 
 resource "aws_autoscaling_group" "clusterasg" {
-  name = "clusterasg"
+  name                = "clusterasg"
   vpc_zone_identifier = module.basic_components.aoc_private_subnet_ids
-  desired_capacity   = 1
-  max_size           = 10
-  min_size           = 1
+  desired_capacity    = 1
+  max_size            = 10
+  min_size            = 1
 
   launch_template {
     id      = aws_launch_template.launchtemp.id
@@ -147,7 +147,7 @@ resource "aws_iam_role" "cluster_instance_role" {
 }
 
 resource "aws_iam_policy" "cluster_instance_policy" {
-  policy      = file("instance-policy.json")
+  policy = file("instance-policy.json")
 }
 
 resource "aws_iam_policy_attachment" "cluster_instance_policy_attachment" {

--- a/terraform/ecs/main.tf
+++ b/terraform/ecs/main.tf
@@ -109,6 +109,17 @@ resource "aws_launch_template" "launchtemp" {
   iam_instance_profile {
     name = aws_iam_instance_profile.cluster.name
   }
+  tag_specifications {
+    resource_type = "instance"
+
+    tags = {
+      Name      = "Integ-test-ecs-instance"
+      Patch     = var.patch
+      TestCase  = var.testcase
+      TestID    = module.common.testing_id
+      ephemeral = "true"
+    }
+  }
   depends_on = [
     null_resource.iam_wait
   ]

--- a/terraform/ecs/variables.tf
+++ b/terraform/ecs/variables.tf
@@ -39,6 +39,13 @@ variable "ecs_taskdef_network_mode" {
   default = "awsvpc"
 }
 
+# if patch is true, we will wait until the instance gets patched after launching the instance,
+# also set a patch tag onto the instance so that the instance get picked by the ssm patching process.
+# and then start the installation of collector.
+variable "patch" {
+  default = true
+}
+
 variable "ecs_extra_apps_image_repo" {
   # When empty will use sample image repo
   default = ""


### PR DESCRIPTION
**Description:** The switch to building a aws_ecs_cluster resource replicates what we previous had from the ecs-cluster module except we are able to configure the ec2 launch template to require IMDSv2

**Testing:** Local testing passed for ecs tests in test framework launched through EC2 and FARGATE

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

