### PR TITLE
Add proper validation_config for eks_containerinsights_fargate_docker

### DIFF
--- a/terraform/testcases/eks_containerinsights_fargate_docker/parameters.tfvars
+++ b/terraform/testcases/eks_containerinsights_fargate_docker/parameters.tfvars
@@ -1,5 +1,5 @@
 # this file is defined in validator/src/main/resources/validations
-validation_config = "eks-cw-container-insight.yml"
+validation_config = "eks-cw-container-insight-docker.yml"
 
 aoc_base_scenario = "infra"
 


### PR DESCRIPTION
**Description:** Add proper validation_config for eks_containerinsights_fargate_docker
This was missing in previous PR: https://github.com/aws-observability/aws-otel-test-framework/pull/1131


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

