### PR TITLE
Make autoscalinggroup names unique to avoid duplicate asgs being created

### DIFF
--- a/terraform/ecs/main.tf
+++ b/terraform/ecs/main.tf
@@ -133,7 +133,7 @@ resource "aws_autoscaling_group" "clusterasg" {
   min_size            = 1
   tags = [
     {
-      "key"                 = "ephermeral"
+      "key"                 = "ephemeral"
       "value"               = "true"
       "propagate_at_launch" = false
     },

--- a/terraform/ecs/main.tf
+++ b/terraform/ecs/main.tf
@@ -126,7 +126,7 @@ resource "aws_launch_template" "launchtemp" {
 }
 
 resource "aws_autoscaling_group" "clusterasg" {
-  name_prefix         = "clusterasg" 
+  name_prefix         = "clusterasg"
   vpc_zone_identifier = module.basic_components.aoc_private_subnet_ids
   desired_capacity    = 1
   max_size            = 10

--- a/terraform/ecs/main.tf
+++ b/terraform/ecs/main.tf
@@ -126,7 +126,7 @@ resource "aws_launch_template" "launchtemp" {
 }
 
 resource "aws_autoscaling_group" "clusterasg" {
-  name                = "clusterasg"
+  name_prefix         = "clusterasg" 
   vpc_zone_identifier = module.basic_components.aoc_private_subnet_ids
   desired_capacity    = 1
   max_size            = 10


### PR DESCRIPTION
**Description:** Changed the asg naming to `name_prefix` which will take the prefix and add create a unique asg name afterwards.

**Testing:** Local testing passed.

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

