### PR TITLE
Update configurations to use verbosity instead of loglevel

### DIFF
--- a/centralized-sampling-tests/collector-config.yml
+++ b/centralized-sampling-tests/collector-config.yml
@@ -13,7 +13,7 @@ receivers:
 
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
   awsxray:
     local_mode: true
     region: 'us-west-2'

--- a/centralized-sampling-tests/example-collector-config.yaml
+++ b/centralized-sampling-tests/example-collector-config.yaml
@@ -13,7 +13,7 @@ receivers:
 
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
   awsxray:
     local_mode: true
     region: 'us-west-2'

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -59,7 +59,7 @@ receivers:
   awsecscontainermetrics:
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
   awsemf:
     namespace: '${otel_service_namespace}/${otel_service_name}'
     region: '${region}'

--- a/terraform/eks/container-insights-agent/config_map_fargate.yml
+++ b/terraform/eks/container-insights-agent/config_map_fargate.yml
@@ -430,7 +430,7 @@ data:
               - pod_network_tx_bytes
 
       logging:
-        loglevel: debug
+        verbosity: detailed
 
     extensions:
       health_check:

--- a/terraform/templates/defaults/otconfig.tpl
+++ b/terraform/templates/defaults/otconfig.tpl
@@ -21,7 +21,7 @@ processors:
 
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
   awsxray:
     local_mode: true
     region: '${region}'

--- a/terraform/testcases/configmap_provider_http/otconfig.tpl
+++ b/terraform/testcases/configmap_provider_http/otconfig.tpl
@@ -21,7 +21,7 @@ processors:
 
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
   awsemf:
     region: '${region}'
 

--- a/terraform/testcases/configmap_provider_https/otconfig.tpl
+++ b/terraform/testcases/configmap_provider_https/otconfig.tpl
@@ -21,7 +21,7 @@ processors:
 
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
   awsemf:
     region: '${region}'
 

--- a/terraform/testcases/configmap_provider_s3/otconfig.tpl
+++ b/terraform/testcases/configmap_provider_s3/otconfig.tpl
@@ -21,7 +21,7 @@ processors:
 
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
   awsemf:
     region: '${region}'
 

--- a/terraform/testcases/containerinsight_ecs_prometheus/otconfig.tpl
+++ b/terraform/testcases/containerinsight_ecs_prometheus/otconfig.tpl
@@ -155,7 +155,7 @@ exporters:
           - "^envoy_http_downstream_rq_xx$"
 
   logging:
-    loglevel: debug
+    verbosity: detailed
 
 service:
   telemetry:

--- a/terraform/testcases/datadog_exporter_metric_mock/otconfig.tpl
+++ b/terraform/testcases/datadog_exporter_metric_mock/otconfig.tpl
@@ -12,7 +12,7 @@ processors:
 
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
   datadog:
     api:
       key: testapikey

--- a/terraform/testcases/datadog_exporter_trace_mock/otconfig.tpl
+++ b/terraform/testcases/datadog_exporter_trace_mock/otconfig.tpl
@@ -12,7 +12,7 @@ processors:
 
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
   datadog:
     api:
       key: testapikey

--- a/terraform/testcases/dynatrace_exporter_metric_mock/otconfig.tpl
+++ b/terraform/testcases/dynatrace_exporter_metric_mock/otconfig.tpl
@@ -12,7 +12,7 @@ processors:
 
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
   dynatrace:
     api_token: mytoken
     endpoint: "https://${mock_endpoint}"

--- a/terraform/testcases/ecs_instance_metrics/otconfig.tpl
+++ b/terraform/testcases/ecs_instance_metrics/otconfig.tpl
@@ -40,7 +40,7 @@ exporters:
           - instance_memory_working_set
           - instance_memory_limit
   logging:
-    loglevel: debug
+    verbosity: detailed
 service:
   pipelines:
     metrics:

--- a/terraform/testcases/ecshealthcheck/otconfig.tpl
+++ b/terraform/testcases/ecshealthcheck/otconfig.tpl
@@ -11,7 +11,7 @@ receivers:
         - targets: [ ${sample_app_listen_address_host}:${sample_app_listen_address_port} ]
 exporters:
   logging:
-      loglevel: debug
+      verbosity: detailed
 service:
   pipelines:
     metrics:

--- a/terraform/testcases/ecsmetrics/otconfig.tpl
+++ b/terraform/testcases/ecsmetrics/otconfig.tpl
@@ -90,7 +90,7 @@ exporters:
     resource_to_telemetry_conversion:
       enabled: true
   logging:
-    loglevel: debug
+    verbosity: detailed
 
 service:
   pipelines:

--- a/terraform/testcases/jaeger_mock/otconfig.tpl
+++ b/terraform/testcases/jaeger_mock/otconfig.tpl
@@ -12,7 +12,7 @@ processors:
 
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
   otlphttp:
     traces_endpoint: "https://${mock_endpoint}"
     tls:

--- a/terraform/testcases/kafka_otlp_metric_2_8_1/otconfig.tpl
+++ b/terraform/testcases/kafka_otlp_metric_2_8_1/otconfig.tpl
@@ -21,7 +21,7 @@ processors:
 
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
   awsemf:
     region: '${region}'
   kafka/exporter:

--- a/terraform/testcases/kafka_otlp_metric_3_2_0/otconfig.tpl
+++ b/terraform/testcases/kafka_otlp_metric_3_2_0/otconfig.tpl
@@ -21,7 +21,7 @@ processors:
 
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
   awsemf:
     region: '${region}'
   kafka/exporter:

--- a/terraform/testcases/kafka_otlp_metric_mock_2_8_1/otconfig.tpl
+++ b/terraform/testcases/kafka_otlp_metric_mock_2_8_1/otconfig.tpl
@@ -21,7 +21,7 @@ processors:
 
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
   awsemf:
     region: '${region}'
     endpoint: "https://${mock_endpoint}"

--- a/terraform/testcases/kafka_otlp_metric_mock_3_2_0/otconfig.tpl
+++ b/terraform/testcases/kafka_otlp_metric_mock_3_2_0/otconfig.tpl
@@ -21,7 +21,7 @@ processors:
 
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
   awsemf:
     region: '${region}'
     endpoint: "https://${mock_endpoint}"

--- a/terraform/testcases/kafka_otlp_mock_2_8_1/otconfig.tpl
+++ b/terraform/testcases/kafka_otlp_mock_2_8_1/otconfig.tpl
@@ -21,7 +21,7 @@ processors:
 
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
   awsxray:
     region: '${region}'
     local_mode: true

--- a/terraform/testcases/kafka_otlp_mock_3_2_0/otconfig.tpl
+++ b/terraform/testcases/kafka_otlp_mock_3_2_0/otconfig.tpl
@@ -21,7 +21,7 @@ processors:
 
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
   awsxray:
     region: '${region}'
     local_mode: true

--- a/terraform/testcases/kafka_otlp_trace_2_8_1/otconfig.tpl
+++ b/terraform/testcases/kafka_otlp_trace_2_8_1/otconfig.tpl
@@ -21,7 +21,7 @@ processors:
 
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
   awsxray:
     local_mode: true
     region: '${region}'

--- a/terraform/testcases/kafka_otlp_trace_3_2_0/otconfig.tpl
+++ b/terraform/testcases/kafka_otlp_trace_3_2_0/otconfig.tpl
@@ -21,7 +21,7 @@ processors:
 
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
   awsxray:
     local_mode: true
     region: '${region}'

--- a/terraform/testcases/logzio_exporter_trace_mock/otconfig.tpl
+++ b/terraform/testcases/logzio_exporter_trace_mock/otconfig.tpl
@@ -12,7 +12,7 @@ processors:
 
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
   logzio/traces:
     account_token: testToken
     endpoint: "https://${mock_endpoint}"

--- a/terraform/testcases/newrelic_exporter_metric_mock/otconfig.tpl
+++ b/terraform/testcases/newrelic_exporter_metric_mock/otconfig.tpl
@@ -12,7 +12,7 @@ processors:
 
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
   newrelic:
     apikey: super-secret-api-key
     traces:

--- a/terraform/testcases/newrelic_exporter_trace_mock/otconfig.tpl
+++ b/terraform/testcases/newrelic_exporter_trace_mock/otconfig.tpl
@@ -12,7 +12,7 @@ processors:
 
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
   newrelic:
     apikey: super-secret-api-key
     traces:

--- a/terraform/testcases/otlp_grpc_exporter_cw_amp_xray_ecs/otconfig.tpl
+++ b/terraform/testcases/otlp_grpc_exporter_cw_amp_xray_ecs/otconfig.tpl
@@ -122,7 +122,7 @@ exporters:
     local_mode: true
     region: '${region}'
   logging:
-    loglevel: debug
+    verbosity: detailed
 
 service:
   pipelines:

--- a/terraform/testcases/otlp_grpc_exporter_metric_mock/otconfig.tpl
+++ b/terraform/testcases/otlp_grpc_exporter_metric_mock/otconfig.tpl
@@ -12,7 +12,7 @@ processors:
 
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
   otlp:
     endpoint: ${mock_endpoint}
     tls:

--- a/terraform/testcases/otlp_grpc_exporter_trace_mock/otconfig.tpl
+++ b/terraform/testcases/otlp_grpc_exporter_trace_mock/otconfig.tpl
@@ -12,7 +12,7 @@ processors:
 
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
   otlp:
     endpoint: ${mock_endpoint}
     tls:

--- a/terraform/testcases/otlp_http_exporter_metric_mock/otconfig.tpl
+++ b/terraform/testcases/otlp_http_exporter_metric_mock/otconfig.tpl
@@ -12,7 +12,7 @@ processors:
 
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
   otlphttp:
     metrics_endpoint: "https://${mock_endpoint}"
     tls:

--- a/terraform/testcases/otlp_http_exporter_trace_mock/otconfig.tpl
+++ b/terraform/testcases/otlp_http_exporter_trace_mock/otconfig.tpl
@@ -12,7 +12,7 @@ processors:
 
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
   otlphttp:
     traces_endpoint: "https://${mock_endpoint}"
     tls:

--- a/terraform/testcases/otlp_metric/otconfig.tpl
+++ b/terraform/testcases/otlp_metric/otconfig.tpl
@@ -12,7 +12,7 @@ processors:
 
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
   awsemf:
     region: '${region}'
 

--- a/terraform/testcases/otlp_metric_adot_operator/otconfig.tpl
+++ b/terraform/testcases/otlp_metric_adot_operator/otconfig.tpl
@@ -12,7 +12,7 @@ extensions:
 
     exporters:
       logging:
-        loglevel: debug
+        verbosity: detailed
       awsemf:
         region: '${region}'
 

--- a/terraform/testcases/otlp_metric_amp/otconfig.tpl
+++ b/terraform/testcases/otlp_metric_amp/otconfig.tpl
@@ -15,7 +15,7 @@ processors:
 
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
   prometheusremotewrite:
     endpoint: ${cortex_instance_endpoint}/api/v1/remote_write
     timeout: 10s

--- a/terraform/testcases/otlp_metric_mock/otconfig.tpl
+++ b/terraform/testcases/otlp_metric_mock/otconfig.tpl
@@ -12,7 +12,7 @@ processors:
 
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
   awsemf:
     region: ${region}
     endpoint: "https://${mock_endpoint}"

--- a/terraform/testcases/otlp_mock/otconfig.tpl
+++ b/terraform/testcases/otlp_mock/otconfig.tpl
@@ -12,7 +12,7 @@ processors:
 
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
   awsxray:
     region: ${region}
     local_mode: true

--- a/terraform/testcases/otlp_trace/otconfig.tpl
+++ b/terraform/testcases/otlp_trace/otconfig.tpl
@@ -12,7 +12,7 @@ processors:
 
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
   awsxray:
     local_mode: true
     region: '${region}'

--- a/terraform/testcases/otlp_trace_adot_operator/otconfig.tpl
+++ b/terraform/testcases/otlp_trace_adot_operator/otconfig.tpl
@@ -12,7 +12,7 @@ extensions:
 
     exporters:
       logging:
-        loglevel: debug
+        verbosity: detailed
       awsxray:
         local_mode: true
         region: '${region}'

--- a/terraform/testcases/otlp_trace_resourcedetection_ec2/otconfig.tpl
+++ b/terraform/testcases/otlp_trace_resourcedetection_ec2/otconfig.tpl
@@ -20,7 +20,7 @@ processors:
 
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
   awsxray:
     local_mode: true
     region: '${region}'

--- a/terraform/testcases/otlp_trace_resourcedetection_ecs/otconfig.tpl
+++ b/terraform/testcases/otlp_trace_resourcedetection_ecs/otconfig.tpl
@@ -16,7 +16,7 @@ processors:
 
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
   awsxray:
     local_mode: true
     region: '${region}'

--- a/terraform/testcases/otlp_trace_resourcedetection_eks/otconfig.tpl
+++ b/terraform/testcases/otlp_trace_resourcedetection_eks/otconfig.tpl
@@ -16,7 +16,7 @@ processors:
 
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
   awsxray:
     local_mode: true
     region: '${region}'

--- a/terraform/testcases/prometheus_sd/otconfig.tpl
+++ b/terraform/testcases/prometheus_sd/otconfig.tpl
@@ -23,7 +23,7 @@ exporters:
     auth:
       authenticator: sigv4auth
   logging:
-    loglevel: debug
+    verbosity: detailed
 service:
   pipelines:
     metrics:

--- a/terraform/testcases/prometheus_sd_adot_operator/otconfig.tpl
+++ b/terraform/testcases/prometheus_sd_adot_operator/otconfig.tpl
@@ -23,7 +23,7 @@ extensions:
         auth:
           authenticator: sigv4auth
       logging:
-        loglevel: debug
+        verbosity: detailed
     service:
       pipelines:
         metrics:

--- a/terraform/testcases/sapm_exporter_trace_mock/otconfig.tpl
+++ b/terraform/testcases/sapm_exporter_trace_mock/otconfig.tpl
@@ -12,7 +12,7 @@ processors:
 
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
   sapm:
     endpoint: "https://${mock_endpoint}"
 

--- a/terraform/testcases/signalfx_exporter_metric_mock/otconfig.tpl
+++ b/terraform/testcases/signalfx_exporter_metric_mock/otconfig.tpl
@@ -12,7 +12,7 @@ processors:
 
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
   signalfx:
     access_token: dummytoken
     ingest_url: "https://${mock_endpoint}"

--- a/terraform/testcases/signalfxcorrelation_exporter_trace_mock/otconfig.tpl
+++ b/terraform/testcases/signalfxcorrelation_exporter_trace_mock/otconfig.tpl
@@ -12,7 +12,7 @@ processors:
 
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
   signalfx_correlation:
     endpoint: "https://${mock_endpoint}"
 

--- a/terraform/testcases/splunkhec_exporter_trace_mock/otconfig.tpl
+++ b/terraform/testcases/splunkhec_exporter_trace_mock/otconfig.tpl
@@ -12,7 +12,7 @@ processors:
 
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
   splunk_hec:
     endpoint: "https://${mock_endpoint}"
     token: dummytoken

--- a/terraform/testcases/standard_otlp_metric_trace/otconfig.tpl
+++ b/terraform/testcases/standard_otlp_metric_trace/otconfig.tpl
@@ -12,7 +12,7 @@ processors:
 
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
   awsemf:
     region: ${region}
     no_verify_ssl: false

--- a/terraform/testcases/statsd/otconfig.tpl
+++ b/terraform/testcases/statsd/otconfig.tpl
@@ -7,7 +7,7 @@ exporters:
     namespace: '${otel_service_namespace}/${otel_service_name}'
     region: '${region}'
   logging:
-    loglevel: debug
+    verbosity: detailed
 service:
   pipelines:
     metrics:

--- a/terraform/testcases/statsd_mock/otconfig.tpl
+++ b/terraform/testcases/statsd_mock/otconfig.tpl
@@ -4,7 +4,7 @@ receivers:
     aggregation_interval: 20s
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
   otlphttp:
     metrics_endpoint: "https://${mock_endpoint}"
     tls:

--- a/terraform/testcases/xrayreceiver/otconfig.tpl
+++ b/terraform/testcases/xrayreceiver/otconfig.tpl
@@ -11,7 +11,7 @@ processors:
 
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
   awsxray:
     local_mode: true
     region: '${region}'

--- a/terraform/testcases/xrayreceiver_mock/otconfig.tpl
+++ b/terraform/testcases/xrayreceiver_mock/otconfig.tpl
@@ -11,7 +11,7 @@ processors:
 
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
   awsxray:
     region: ${region}
     local_mode: true

--- a/terraform/testcases/zipkin_mock/otconfig.tpl
+++ b/terraform/testcases/zipkin_mock/otconfig.tpl
@@ -10,7 +10,7 @@ processors:
 
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
   otlphttp:
     traces_endpoint: "https://${mock_endpoint}"
     tls:


### PR DESCRIPTION
The loglevel configuration property in the logging exporter is deprecated. We should use verbosity across the board.
https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/loggingexporter/README.md


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

