### PR TITLE
Fix tests that rely on awsecscontainermetricsreceiver

### DIFF
--- a/validator/src/main/resources/expected-data-template/ecsContainerExpectedMetric.mustache
+++ b/validator/src/main/resources/expected-data-template/ecsContainerExpectedMetric.mustache
@@ -10,7 +10,7 @@
       value: SKIP
     -
       name: aws.ecs.service.name
-      value: undefined
+      value: aocservice-{{testingId}}
     -
       name: aws.ecs.task.arn
       value: SKIP
@@ -41,7 +41,7 @@
       value: SKIP
     -
       name: aws.ecs.service.name
-      value: undefined
+      value: aocservice-{{testingId}}
     -
       name: aws.ecs.task.arn
       value: SKIP
@@ -72,7 +72,7 @@
       value: SKIP
     -
       name: aws.ecs.service.name
-      value: undefined
+      value: aocservice-{{testingId}}
     -
       name: aws.ecs.task.arn
       value: SKIP
@@ -103,7 +103,7 @@
       value: SKIP
     -
       name: aws.ecs.service.name
-      value: undefined
+      value: aocservice-{{testingId}}
     -
       name: aws.ecs.task.arn
       value: SKIP
@@ -134,7 +134,7 @@
       value: SKIP
     -
       name: aws.ecs.service.name
-      value: undefined
+      value: aocservice-{{testingId}}
     -
       name: aws.ecs.task.arn
       value: SKIP
@@ -165,7 +165,7 @@
       value: SKIP
     -
       name: aws.ecs.service.name
-      value: undefined
+      value: aocservice-{{testingId}}
     -
       name: aws.ecs.task.arn
       value: SKIP
@@ -196,7 +196,7 @@
       value: SKIP
     -
       name: aws.ecs.service.name
-      value: undefined
+      value: aocservice-{{testingId}}
     -
       name: aws.ecs.task.arn
       value: SKIP
@@ -227,7 +227,7 @@
       value: SKIP
     -
       name: aws.ecs.service.name
-      value: undefined
+      value: aocservice-{{testingId}}
     -
       name: aws.ecs.task.arn
       value: SKIP


### PR DESCRIPTION
**Description:** Fix tests that rely on awsecscontainermetricsreceiver

In this PR https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/19744 we started to properly populate the aws.ecs.service.name resource attribute.

This broke our CI https://github.com/aws-observability/aws-otel-collector/actions/runs/4726620152/jobs/8473578308 (for a good reason).

Therefore we need to update the validator accordingly.

When running tests in ECS the value for the service name is populated here: https://github.com/aws-observability/aws-otel-test-framework/blob/terraform/terraform/ecs/main.tf#L450


