### PR TITLE
Add creation time tag to ECS Clusters

### DIFF
--- a/terraform/common/main.tf
+++ b/terraform/common/main.tf
@@ -19,3 +19,5 @@
 resource "random_id" "testing_id" {
   byte_length = 8
 }
+
+resource "time_static" "startTime" {}

--- a/terraform/common/outputs.tf
+++ b/terraform/common/outputs.tf
@@ -118,7 +118,7 @@ output "amp_testing_framework" {
   value = "amp_testing_framework"
 }
 
-output "start_time_3339"{
+output "start_time_3339" {
   value = time_static.startTime.rfc3339
 }
 

--- a/terraform/common/outputs.tf
+++ b/terraform/common/outputs.tf
@@ -118,3 +118,7 @@ output "amp_testing_framework" {
   value = "amp_testing_framework"
 }
 
+output "start_time_3339"{
+  value = time_static.startTime.rfc3339
+}
+

--- a/terraform/ecs/main.tf
+++ b/terraform/ecs/main.tf
@@ -92,7 +92,7 @@ resource "aws_ecs_cluster" "ecscluster" {
   name = "aoc-testing-${module.common.testing_id}"
   tags = {
     creation_time_rfc3339 = module.common.start_time_3339
-    ephemeral = "true"
+    ephemeral             = "true"
   }
   depends_on = [
     null_resource.iam_wait

--- a/terraform/ecs/main.tf
+++ b/terraform/ecs/main.tf
@@ -90,7 +90,9 @@ data "aws_caller_identity" "current" {
 # Builds the ecs cluster to run the tests.  Name must start with "aoc-testing" to be picked up by resource cleaner
 resource "aws_ecs_cluster" "ecscluster" {
   name = "aoc-testing-${module.common.testing_id}"
-
+  tags = {
+    creation_time_rfc3339 = module.common.start_time_3339
+  }
   depends_on = [
     null_resource.iam_wait
   ]

--- a/terraform/ecs/main.tf
+++ b/terraform/ecs/main.tf
@@ -92,6 +92,7 @@ resource "aws_ecs_cluster" "ecscluster" {
   name = "aoc-testing-${module.common.testing_id}"
   tags = {
     creation_time_rfc3339 = module.common.start_time_3339
+    ephemeral = "true"
   }
   depends_on = [
     null_resource.iam_wait


### PR DESCRIPTION
**Description:** Add a start time output to the common module. Use this start time to tag the ECS Cluster with a `creation_time` tag. Also tag cluster with `ephemeral:true`. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

