### PR TITLE
Skip service name validation for awsecscontainermetrics

### DIFF
--- a/validator/src/main/resources/expected-data-template/ecsContainerExpectedMetric.mustache
+++ b/validator/src/main/resources/expected-data-template/ecsContainerExpectedMetric.mustache
@@ -10,7 +10,7 @@
       value: SKIP
     -
       name: aws.ecs.service.name
-      value: aocservice-{{testingId}}
+      value: SKIP
     -
       name: aws.ecs.task.arn
       value: SKIP
@@ -41,7 +41,7 @@
       value: SKIP
     -
       name: aws.ecs.service.name
-      value: aocservice-{{testingId}}
+      value: SKIP
     -
       name: aws.ecs.task.arn
       value: SKIP
@@ -72,7 +72,7 @@
       value: SKIP
     -
       name: aws.ecs.service.name
-      value: aocservice-{{testingId}}
+      value: SKIP
     -
       name: aws.ecs.task.arn
       value: SKIP
@@ -103,7 +103,7 @@
       value: SKIP
     -
       name: aws.ecs.service.name
-      value: aocservice-{{testingId}}
+      value: SKIP
     -
       name: aws.ecs.task.arn
       value: SKIP
@@ -134,7 +134,7 @@
       value: SKIP
     -
       name: aws.ecs.service.name
-      value: aocservice-{{testingId}}
+      value: SKIP
     -
       name: aws.ecs.task.arn
       value: SKIP
@@ -165,7 +165,7 @@
       value: SKIP
     -
       name: aws.ecs.service.name
-      value: aocservice-{{testingId}}
+      value: SKIP
     -
       name: aws.ecs.task.arn
       value: SKIP
@@ -196,7 +196,7 @@
       value: SKIP
     -
       name: aws.ecs.service.name
-      value: aocservice-{{testingId}}
+      value: SKIP
     -
       name: aws.ecs.task.arn
       value: SKIP
@@ -227,7 +227,7 @@
       value: SKIP
     -
       name: aws.ecs.service.name
-      value: aocservice-{{testingId}}
+      value: SKIP
     -
       name: aws.ecs.task.arn
       value: SKIP


### PR DESCRIPTION
**Description:** Skip service name validation for awsecscontainermetrics

This has to be done because the behaviour between ECS/Fargate and ECS/EC2 is not consistent.

https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/19744 added support to ServiceName metadata but that is not working in ECS on Fargate.

This PR is basically reverting what was done here: https://github.com/aws-observability/aws-otel-test-framework/pull/1192

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

