### PR TITLE
Normalize aws.ecs.service.name resource attribute in ECS test

### DIFF
--- a/terraform/testcases/ecsmetrics/otconfig.tpl
+++ b/terraform/testcases/ecsmetrics/otconfig.tpl
@@ -82,6 +82,11 @@ processors:
       action: delete
     - key: aws.ecs.task.known_status
       action: delete
+      # We are normalizing this because of this issue: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/21412
+      # In ECS running in Fargate this resource attribute is currently an empty-string.
+    - key: aws.ecs.service.name
+      action: upsert
+      value: "NOOP"
 
 exporters:
   awsemf:

--- a/terraform/testcases/otlp_grpc_exporter_cw_amp_xray_ecs/otconfig.tpl
+++ b/terraform/testcases/otlp_grpc_exporter_cw_amp_xray_ecs/otconfig.tpl
@@ -105,6 +105,9 @@ processors:
         action: delete
       - key: aws.ecs.task.known_status
         action: delete
+      - key: aws.ecs.service.name
+        action: upsert
+        value: "NOOP"
 
 exporters:
   awsemf:


### PR DESCRIPTION
**Description:** Normalize aws.ecs.service.name resource attribute in ECS test

This has to be done because of this known issue: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/21412


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

