### PR TITLE
Add load test testcase for group by trace and tail sampling processors

### DIFF
--- a/terraform/testcases/otlp_groupbytrace_tailsampling_mock/README.md
+++ b/terraform/testcases/otlp_groupbytrace_tailsampling_mock/README.md
@@ -1,0 +1,9 @@
+# Introduction
+
+This directory holds the performance tests for the Group by Trace and Tail Sampling processors.
+
+We are scaling the configuration of the two components so that it can handle the maximum load applied during the load tests which is 5000 samples per second.
+
+We are using `wait_duration` of 2s in the groupytrace procssor. That means that in this interval we would have 10000 samples buffered. We are doubling this value in the `num_traces` property to be on the safe side.
+
+In the Tail sampling processor there is a single policy based on latency.

--- a/terraform/testcases/otlp_groupbytrace_tailsampling_mock/otconfig.tpl
+++ b/terraform/testcases/otlp_groupbytrace_tailsampling_mock/otconfig.tpl
@@ -1,0 +1,40 @@
+extensions:
+  pprof:
+    endpoint: 0.0.0.0:1777
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:${grpc_port}
+
+processors:
+  groupbytrace:
+    wait_duration: 2s
+    num_traces: 20000
+  tail_sampling:
+    decision_wait: 1s
+    policies:
+      - name: latancy_based
+        type: latency
+        latency:
+          threshold_ms: 200
+
+exporters:
+  logging:
+    verbosity: detailed
+  awsxray:
+    region: ${region}
+    local_mode: true
+    no_verify_ssl: false
+    endpoint: "${mock_endpoint}"
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [groupbytrace, tail_sampling]
+      exporters: [awsxray]
+  extensions: [pprof]
+  telemetry:
+    logs:
+      level: ${log_level}

--- a/terraform/testcases/otlp_groupbytrace_tailsampling_mock/parameters.tfvars
+++ b/terraform/testcases/otlp_groupbytrace_tailsampling_mock/parameters.tfvars
@@ -1,0 +1,6 @@
+# data type will be emitted. Possible values: metric or trace
+soaking_data_mode = "trace"
+
+sample_app = "spark"
+
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"


### PR DESCRIPTION
**Description:** Add load test testcase for group by trace and tail sampling processors

NOTE: Even if this gets merged into `terraform` branch, these tests will not be activated until we change the list of testcases in the aws-ote-collector repository.

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

