### PR TITLE
Fix AMI for ec2 tests sidecar instance

### DIFF
--- a/terraform/ec2/amis.tf
+++ b/terraform/ec2/amis.tf
@@ -428,6 +428,12 @@ data "aws_ami" "amazonlinux2" {
     "available"]
   }
 
+  // sidecar instance should be fixed in x86_64 instance types
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
   owners = [
   "amazon"]
 }


### PR DESCRIPTION
**Description:** Fix AMI for ec2 tests sidecar instance

The sidecar instance uses m5.2xlarge for performance tests and c5a.large for other ec2 tests. Those instance types are x86_64, so it makes sense to hard the AMI used by those instances to be x86_64.


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

