### PR TITLE
Add eks clusters for k8s 1.25 1.26

### DIFF
--- a/cdk_infra/lib/config/cluster-config/clusters.yml
+++ b/cdk_infra/lib/config/cluster-config/clusters.yml
@@ -55,3 +55,19 @@ clusters:
     launch_type: ec2
     instance_type: "m5.large"
     cert_manager: true
+  - name: collector-ci-arm64-1-25
+    version: "1.25"
+    launch_type: ec2
+    instance_type: m6g.medium
+  - name: collector-ci-amd64-1-25
+    version: "1.25"
+    launch_type: ec2
+    instance_type: "m5.large"
+  - name: collector-ci-arm64-1-26
+    version: "1.26"
+    launch_type: ec2
+    instance_type: m6g.medium
+  - name: collector-ci-amd64-1-26
+    version: "1.26"
+    launch_type: ec2
+    instance_type: "m5.large"


### PR DESCRIPTION
**Description:** Add tests clusters for k8s 1.25 and 1.26

Test case targets will be updated in a subsequent PR that will target the dev branch. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

