### PR TITLE
Add 1.25 1.26 test cases

### DIFF
--- a/tools/batchTestGenerator/testcases.json
+++ b/tools/batchTestGenerator/testcases.json
@@ -23,6 +23,20 @@
 					"excluded_tests": [
 						"containerinsight_eks"
 					]
+				},
+				{
+					"name": "collector-ci-amd64-1-25",
+					"region": "us-west-2",
+					"excluded_tests": [
+						"containerinsight_eks"
+					]
+				},
+				{
+					"name": "collector-ci-amd64-1-26",
+					"region": "us-west-2",
+					"excluded_tests": [
+						"containerinsight_eks"
+					]
 				}
 			]
 		},
@@ -45,6 +59,20 @@
 				},
 				{
 					"name": "collector-ci-arm64-1-24",
+					"region": "us-west-2",
+					"excluded_tests": [
+						"containerinsight_eks"
+					]
+				},
+				{
+					"name": "collector-ci-arm64-1-25",
+					"region": "us-west-2",
+					"excluded_tests": [
+						"containerinsight_eks"
+					]
+				}
+				{
+					"name": "collector-ci-arm64-1-26",
 					"region": "us-west-2",
 					"excluded_tests": [
 						"containerinsight_eks"


### PR DESCRIPTION
**Description:** Add EKS cluster test targets for 1.25 and 1.26 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

