### PR TITLE
Update arm64 node groups to use m6g.large

### DIFF
--- a/cdk_infra/lib/config/cluster-config/clusters.yml
+++ b/cdk_infra/lib/config/cluster-config/clusters.yml
@@ -7,7 +7,7 @@ clusters:
   - name: collector-ci-arm64-1-22
     version: "1.22"
     launch_type: ec2
-    instance_type: m6g.medium
+    instance_type: m6g.large
   - name: collector-ci-fargate-1-22
     version: "1.22"
     launch_type: fargate
@@ -19,12 +19,12 @@ clusters:
   - name: operator-ci-arm64-1-22
     version: "1.22"
     launch_type: ec2
-    instance_type: m6g.medium
+    instance_type: m6g.large
     cert_manager: true
   - name: collector-ci-arm64-1-23
     version: "1.23"
     launch_type: ec2
-    instance_type: m6g.medium
+    instance_type: m6g.large
   - name: collector-ci-amd64-1-23
     version: "1.23"
     launch_type: ec2
@@ -40,12 +40,12 @@ clusters:
   - name: operator-ci-arm64-1-23
     version: "1.23"
     launch_type: ec2
-    instance_type: m6g.medium
+    instance_type: m6g.large
     cert_manager: true
   - name: collector-ci-arm64-1-24
     version: "1.24"
     launch_type: ec2
-    instance_type: m6g.medium
+    instance_type: m6g.large
   - name: collector-ci-amd64-1-24
     version: "1.24"
     launch_type: ec2
@@ -58,7 +58,7 @@ clusters:
   - name: collector-ci-arm64-1-25
     version: "1.25"
     launch_type: ec2
-    instance_type: m6g.medium
+    instance_type: m6g.large
   - name: collector-ci-amd64-1-25
     version: "1.25"
     launch_type: ec2
@@ -66,7 +66,7 @@ clusters:
   - name: collector-ci-arm64-1-26
     version: "1.26"
     launch_type: ec2
-    instance_type: m6g.medium
+    instance_type: m6g.large
   - name: collector-ci-amd64-1-26
     version: "1.26"
     launch_type: ec2


### PR DESCRIPTION
**Description:** Changes EC2 instance size to m6g.large to increase available CPU and mem

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

