### PR TITLE
Pin version of AWS provider in canary tests

### DIFF
--- a/terraform/canary/versions.tf
+++ b/terraform/canary/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}


### PR DESCRIPTION
**Description:**  Pin version of `hashicorp/aws` provider in canary tests as `v5.0.0` was released to day and has incompatibilities.

**Link to tracking Issue:** https://github.com/aws-observability/aws-otel-collector/actions/runs/5084557460

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

