### PR TITLE
Remove private subnet data block

### DIFF
--- a/terraform/eks/main.tf
+++ b/terraform/eks/main.tf
@@ -108,14 +108,6 @@ resource "kubernetes_namespace" "aoc_fargate_ns" {
   }
 }
 
-data "aws_subnet_ids" "private_subnets" {
-  vpc_id = data.aws_eks_cluster.testing_cluster.vpc_config[0].vpc_id
-  filter {
-    name   = "mapPublicIpOnLaunch"
-    values = ["false"] # insert values here
-  }
-}
-
 resource "kubernetes_service_account" "aoc-role" {
   metadata {
     name      = "aoc-role-${module.common.testing_id}"


### PR DESCRIPTION
**Description:** This was causing failures when running tests in a cluster where no private subnets existed. This data block is not used anywhere in the terraform test modules. I have performed a search for `data.aws_subnet_ids.private_subnets` and no results were found. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

