### PR TITLE
Fix images that depended on outdated gradle version

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -23,6 +23,21 @@ jobs:
       run: chmod +x gradlew
     - name: Build with Gradle
       run: ./gradlew :validator:build
+  validator-image-build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+    - name: Build validator image
+      uses: docker/build-push-action@v4
+      with:
+        context: ./validator
+        push: false
+        tags: latest
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        platforms : linux/amd64, linux/arm64
   go-test:
     runs-on: ubuntu-latest
     steps:

--- a/load-generator/build.gradle
+++ b/load-generator/build.gradle
@@ -66,14 +66,10 @@ application {
 // to build using the local docker daemon execute jibDockerBuild, and use only one specific platforms.
 jib {
     from {
-          image = 'gradle:7.3.3-jdk11'
+          image = 'gradle:8.1.1-jdk17'
           platforms {
             platform {
               architecture = 'amd64'
-              os = 'linux'
-            }
-            platform {
-              architecture = 'arm64'
               os = 'linux'
             }
            }

--- a/load-generator/build.gradle
+++ b/load-generator/build.gradle
@@ -72,6 +72,10 @@ jib {
               architecture = 'amd64'
               os = 'linux'
             }
+            platform {
+              architecture = 'arm64'
+              os = 'linux'
+            }
            }
          }
     to {

--- a/sample-apps/jaeger-zipkin-sample-app/Dockerfile
+++ b/sample-apps/jaeger-zipkin-sample-app/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:7.3.3-jdk11 as builder
+FROM gradle:8.1.1-jdk17 as builder
 
 WORKDIR /app
 COPY ./build.gradle ./build.gradle
@@ -12,7 +12,7 @@ ARG VER=1.0
 # assume app is already built since it will not build in docker container
 RUN tar -xvf build/distributions/jaeger-zipkin-sample-app-${VER}.tar
 
-FROM amazoncorretto:11
+FROM amazoncorretto:17
 
 WORKDIR /app
 ARG VER=1.0

--- a/validator/Dockerfile
+++ b/validator/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:7.3.3-jdk11 as build
+FROM gradle:8.1.1-jdk17 as build
 
 WORKDIR /app
 COPY ./build.gradle ./build.gradle
@@ -7,7 +7,7 @@ COPY ./src ./src
 RUN gradle build
 RUN tar -xvf build/distributions/app.tar
 
-FROM amazoncorretto:11
+FROM amazoncorretto:17
 
 WORKDIR /app
 COPY --from=build /app/app .


### PR DESCRIPTION
**Description:** Update images in repository to use gradle v8.1.1. Also added a step in PR build workflow to build validator image. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

