### PR TITLE
Changing base Golang in Prometheus Sample App from 1.19 to 1.19.9

### DIFF
--- a/sample-apps/prometheus/Dockerfile
+++ b/sample-apps/prometheus/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.19 AS mod
+FROM golang:1.19.9 AS mod
 WORKDIR $GOPATH/main
 COPY go.mod .
 COPY go.sum .
 RUN go env -w GOPROXY=direct
 RUN GO111MODULE=on go mod download
 
-FROM golang:1.19 as build
+FROM golang:1.19.9 as build
 COPY --from=mod $GOCACHE $GOCACHE
 COPY --from=mod $GOPATH/pkg/mod $GOPATH/pkg/mod
 WORKDIR $GOPATH/main


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Changing base image of Prometheus Sample App docker file to fix the below error:
```
 => ERROR [build 2/6] COPY --from=mod                                                                                                                                                                      0.0s
 > [build 2/6] COPY --from=mod  :
cannot replace to directory /var/lib/docker/overlay2/plg7akehutb5zddh4zr78j2js/merged/go/bin with file
```
Also here: https://github.com/aws-observability/aws-otel-collector/actions/runs/5286937477/jobs/9580400004

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>
Tested on local.

**Documentation:** <Describe the documentation added.>

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

