### PR TITLE
Use single build stage in prom sample app

### DIFF
--- a/sample-apps/prometheus/Dockerfile
+++ b/sample-apps/prometheus/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19 AS mod
+FROM golang:1.19 as build
 WORKDIR $GOPATH/main
 COPY . .
 RUN go env -w GOPROXY=direct

--- a/sample-apps/prometheus/Dockerfile
+++ b/sample-apps/prometheus/Dockerfile
@@ -1,15 +1,8 @@
 FROM golang:1.19 AS mod
 WORKDIR $GOPATH/main
-COPY go.mod .
-COPY go.sum .
+COPY . .
 RUN go env -w GOPROXY=direct
 RUN GO111MODULE=on go mod download
-
-FROM golang:1.19 as build
-COPY --from=mod $GOCACHE $GOCACHE
-COPY --from=mod $GOPATH/pkg/mod $GOPATH/pkg/mod
-WORKDIR $GOPATH/main
-COPY . .
 RUN GO111MODULE=on CGO_ENABLED=0 GOOS=linux go build -o=/bin/main .
 
 FROM scratch


### PR DESCRIPTION
**Description:** Condense mod and build into single stage to avoid overlay failures when copying from mod to build in latest golang patch version. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

