### PR TITLE
Refactor CWMetricValidator Compare and perform cleanup

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -73,4 +73,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -59,7 +59,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -58,8 +58,8 @@ jobs:
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+    #- name: Autobuild
+    #  uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -68,9 +68,8 @@ jobs:
     #    and modify them (or add more) to build your code if your project
     #    uses a compiled language
 
-    #- run: |
-    #   make bootstrap
-    #   make release
+    - run: |
+       ./gradlew build
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -58,8 +58,9 @@ jobs:
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
-    #- name: Autobuild
-    #  uses: github/codeql-action/autobuild@v2
+    - name: Autobuild
+      if: matrix.language != 'java'
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -70,6 +71,7 @@ jobs:
 
     - run: |
        ./gradlew build
-
+      if: matrix.language == 'java'
+      
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/validator/src/main/java/com/amazon/aoc/exception/ExceptionCode.java
+++ b/validator/src/main/java/com/amazon/aoc/exception/ExceptionCode.java
@@ -22,6 +22,7 @@ public enum ExceptionCode {
   S3_BUCKET_IS_EXISTED_GLOBALLY(20014, "s3 bucket is already existed globally"),
 
   EXPECTED_METRIC_NOT_FOUND(30001, "expected metric not found"),
+  UNEXPECTED_METRIC_FOUND(30002, "unexpected metric found"),
 
   // validating errors
   TRACE_ID_NOT_MATCHED(50001, "trace id not matched"),

--- a/validator/src/main/java/com/amazon/aoc/validators/CWMetricValidator.java
+++ b/validator/src/main/java/com/amazon/aoc/validators/CWMetricValidator.java
@@ -40,9 +40,6 @@ import org.jetbrains.annotations.NotNull;
 
 @Log4j2
 public class CWMetricValidator implements IValidator {
-  private static int DEFAULT_MAX_RETRY_COUNT = 30;
-
-  private MustacheHelper mustacheHelper = new MustacheHelper();
   private ICaller caller;
   private Context context;
   private FileConfig expectedMetric;
@@ -139,7 +136,7 @@ public class CWMetricValidator implements IValidator {
       if (!expectedMetricSet.contains(metric)) {
         throw new BaseException(
             ExceptionCode.UNEXPECTED_METRIC_FOUND,
-            String.format("unexpected metric %s found in actual metric list %n"));
+            String.format("unexpected metric %s found in actual metric list %n", metric));
       }
     }
   }
@@ -203,6 +200,7 @@ public class CWMetricValidator implements IValidator {
     this.expectedMetric = expectedMetricTemplate;
     this.cloudWatchService = new CloudWatchService(context.getRegion());
     this.cwMetricHelper = new CWMetricHelper();
+    int DEFAULT_MAX_RETRY_COUNT = 30;
     this.maxRetryCount = DEFAULT_MAX_RETRY_COUNT;
   }
 }

--- a/validator/src/main/java/com/amazon/aoc/validators/CWMetricValidator.java
+++ b/validator/src/main/java/com/amazon/aoc/validators/CWMetricValidator.java
@@ -197,7 +197,6 @@ public class CWMetricValidator implements IValidator {
     this.expectedMetric = expectedMetricTemplate;
     this.cloudWatchService = new CloudWatchService(context.getRegion());
     this.cwMetricHelper = new CWMetricHelper();
-    int DEFAULT_MAX_RETRY_COUNT = 30;
-    this.maxRetryCount = DEFAULT_MAX_RETRY_COUNT;
+    this.maxRetryCount = 30;
   }
 }

--- a/validator/src/main/java/com/amazon/aoc/validators/CWMetricValidator.java
+++ b/validator/src/main/java/com/amazon/aoc/validators/CWMetricValidator.java
@@ -165,9 +165,7 @@ public class CWMetricValidator implements IValidator {
 
               return dimensionList1.toString().compareTo(dimensionList2.toString());
             });
-    for (Metric metric : inputMetricList) {
-      metricSet.add(metric);
-    }
+    metricSet.addAll(inputMetricList);
     return metricSet;
   }
 

--- a/validator/src/main/java/com/amazon/aoc/validators/CWMetricValidator.java
+++ b/validator/src/main/java/com/amazon/aoc/validators/CWMetricValidator.java
@@ -20,7 +20,6 @@ import com.amazon.aoc.exception.BaseException;
 import com.amazon.aoc.exception.ExceptionCode;
 import com.amazon.aoc.fileconfigs.FileConfig;
 import com.amazon.aoc.helpers.CWMetricHelper;
-import com.amazon.aoc.helpers.MustacheHelper;
 import com.amazon.aoc.helpers.RetryHelper;
 import com.amazon.aoc.models.Context;
 import com.amazon.aoc.models.ValidationConfig;

--- a/validator/src/main/java/com/amazon/aoc/validators/CWMetricValidator.java
+++ b/validator/src/main/java/com/amazon/aoc/validators/CWMetricValidator.java
@@ -26,7 +26,6 @@ import com.amazon.aoc.models.ValidationConfig;
 import com.amazon.aoc.services.CloudWatchService;
 import com.amazonaws.services.cloudwatch.model.Dimension;
 import com.amazonaws.services.cloudwatch.model.Metric;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -170,7 +169,7 @@ public class CWMetricValidator implements IValidator {
   }
 
   private List<Metric> listMetricFromCloudWatch(
-      CloudWatchService cloudWatchService, List<Metric> expectedMetricList) throws IOException {
+      CloudWatchService cloudWatchService, List<Metric> expectedMetricList) {
     // put namespace into the map key, so that we can use it to search metric
     HashMap<String, String> metricNameMap = new HashMap<>();
     for (Metric metric : expectedMetricList) {

--- a/validator/src/main/java/com/amazon/aoc/validators/CWMetricValidator.java
+++ b/validator/src/main/java/com/amazon/aoc/validators/CWMetricValidator.java
@@ -106,9 +106,6 @@ public class CWMetricValidator implements IValidator {
           log.info("expected metricList is {}", expectedMetricList);
 
           compareMetricLists(expectedMetricList, actualMetricList);
-
-          log.info("check if there're unexpected additional metric getting fetched");
-          compareMetricLists(actualMetricList, expectedMetricList);
         });
 
     log.info("finish metric validation");
@@ -132,6 +129,17 @@ public class CWMetricValidator implements IValidator {
         throw new BaseException(
             ExceptionCode.EXPECTED_METRIC_NOT_FOUND,
             String.format("expected metric %s is not found in actual metric list %n", metric));
+      }
+    }
+
+    // check if any additional metric and dimension set combinations are present in actual metric
+    // list
+    Set<Metric> expectedMetricSet = buildMetricSet(expectedMetricList);
+    for (Metric metric : actualMetricList) {
+      if (!expectedMetricSet.contains(metric)) {
+        throw new BaseException(
+            ExceptionCode.UNEXPECTED_METRIC_FOUND,
+            String.format("unexpected metric %s found in actual metric list %n"));
       }
     }
   }


### PR DESCRIPTION
**Description:** This PR makes some refactorings to the CWMetricValidator.java file.

1. This moves all comparison between `expected` and `actual` lists into the `compareMetricLists` method. Previously this method was called twice to perform the strict equality between sets. Instead of having to call this method twice I have added logic inside the method so that it also performs a check for extra metric in the `actualMetricList` rather than having to swap parametes in a followup method call. 
2. I have reduced some logging statements generated by this validator. It now logs the expected metric list once before retires start. This expected metric list does not change throughout retries. I have then adjusted so that the actual metric list is only logged when relevant. This should reduce the amount of unnecessary logs created by this Validator which should assist in log diving. 
3. I have made some cleanups throughout the file such as removing unused imports and unnecessary class level variables. Most of these changes were driven by IntelliJ warnings. 

This PR does not intend to change any functionality but is intended to help readability and also facilitate future changes if necessary.

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

