### PR TITLE
Using kubectl_manifest instead of kubernetes_manifest

### DIFF
--- a/terraform/eks/otlp.tf
+++ b/terraform/eks/otlp.tf
@@ -107,7 +107,7 @@ module "aoc_oltp" {
   is_adot_operator                = replace(var.testcase, "_adot_operator", "") != var.testcase
   is_inject_auto_instrumentation  = var.is_inject_auto_instrumentation
 
-  depends_on = [module.iam_assumable_role_sample_app, kubernetes_manifest.java_auto_instrumentation_deployment]
+  depends_on = [module.iam_assumable_role_sample_app, kubectl_manifest.java_auto_instrumentation_deployment]
 }
 
 locals {
@@ -293,28 +293,22 @@ resource "null_resource" "aoc_deployment_adot_operator" {
   depends_on = [module.adot_operator]
 }
 
-resource "kubernetes_manifest" "java_auto_instrumentation_deployment" {
+resource "kubectl_manifest" "java_auto_instrumentation_deployment" {
   count = var.aoc_base_scenario == "oltp" && replace(var.testcase, "_adot_operator", "") != var.testcase && var.is_inject_auto_instrumentation ? 1 : 0
 
-  manifest = {
-    apiVersion = "opentelemetry.io/v1alpha1"
-    kind       = "Instrumentation"
-
-    metadata = {
-      name      = "my-instrumentation"
-      namespace = var.deployment_type == "fargate" ? kubernetes_namespace.aoc_fargate_ns.metadata[0].name : kubernetes_namespace.aoc_ns.metadata[0].name
-    }
-
-    spec = {
-      sampler = {
-        type     = "parentbased_traceidratio"
-        argument = "1.0"
-      }
-      java = {
-        image = "${var.java_auto_instrumentation_repository}:${var.java_auto_instrumentation_tag}"
-      }
-    }
-  }
+  yaml_body  = <<-EOF
+    apiVersion: opentelemetry.io/v1alpha1
+    kind: Instrumentation
+    metadata:
+      name: my-instrumentation
+      namespace: ${var.deployment_type == "fargate" ? kubernetes_namespace.aoc_fargate_ns.metadata[0].name : kubernetes_namespace.aoc_ns.metadata[0].name}
+    spec:
+      sampler:
+        type: parentbased_traceidratio
+        argument: "1.0"
+      java:
+        image: ${var.java_auto_instrumentation_repository}:${var.java_auto_instrumentation_tag}
+    EOF
   depends_on = [module.adot_operator]
 }
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
To resolve the error here: https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/5492244739/jobs/10053153423#step:9:1016
reverting to use `kubectl_manifest` instead as `kubernetes_manifest` requires CRD to exist during planning phase.  

**Testing:** <Describe what testing was performed and which tests were added.>
manually tested on local

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

