### PR TITLE
[release/v0.31.x] Set default value to avoid input block

### DIFF
--- a/terraform/eks/variables.tf
+++ b/terraform/eks/variables.tf
@@ -94,6 +94,7 @@ variable "java_auto_instrumentation_repository" {
 # latest tag is not available
 variable "java_auto_instrumentation_tag" {
   type = string
+  default = ""
 }
 
 variable "ignore_empty_dim_set" {

--- a/terraform/eks/variables.tf
+++ b/terraform/eks/variables.tf
@@ -93,7 +93,7 @@ variable "java_auto_instrumentation_repository" {
 
 # latest tag is not available
 variable "java_auto_instrumentation_tag" {
-  type = string
+  type    = string
   default = ""
 }
 


### PR DESCRIPTION
**Description:** Terraform will prompt a user to  input a value for any variable that is not explicitly set and missing a default value. This caused the Collector CI to lock while it waited for user input. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

