### PR TITLE
Add ec2 resource detect testcase and add ignore dimension set var

### DIFF
--- a/terraform/ecs/main.tf
+++ b/terraform/ecs/main.tf
@@ -528,6 +528,12 @@ module "validator" {
     ecsLaunchType : aws_ecs_service.aoc[0].launch_type
   })
 
+  cloudwatch_context_json = jsonencode({
+    ignoreEmptyDimSet : var.ignore_empty_dim_set
+  })
+
+  rollup = var.rollup
+
   depends_on = [aws_ecs_service.aoc]
 }
 

--- a/terraform/ecs/variables.tf
+++ b/terraform/ecs/variables.tf
@@ -79,3 +79,15 @@ variable "configuration_source" {
     error_message = "Invalid configuration_source for ecs"
   }
 }
+
+variable "ignore_empty_dim_set" {
+  type    = bool
+  default = false
+
+  description = "Toggles whether or not the validator will ignore an empty EMF dimension set"
+}
+
+variable "rollup" {
+  type    = bool
+  default = true
+}

--- a/terraform/testcases/ec2_resource_detect_metric/otconfig.tpl
+++ b/terraform/testcases/ec2_resource_detect_metric/otconfig.tpl
@@ -1,0 +1,60 @@
+extensions:
+  pprof:
+    endpoint: 0.0.0.0:1777
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:${grpc_port}
+
+processors:
+  batch:
+  resourcedetection:
+    detectors:
+      - ec2
+    timeout: 5s
+    override: false
+    ec2:
+  resource:
+    attributes:
+    - key: host.id
+      value: "123"
+      action: update
+    - key: host.image.id
+      value: "1234"
+      action: update
+    - key: host.name
+      value: "testname"
+      action: update
+    - key: host.type
+      value: "testtype"
+      action: update
+
+exporters:
+  logging:
+    verbosity: detailed
+  awsemf:
+    region: '${region}'
+    resource_to_telemetry_conversion:
+      enabled: true
+    dimension_rollup_option: "NoDimensionRollup"
+    metric_declarations:
+      - dimensions: [[host.id, host.image.id, host.name, host.type]]
+        metric_name_selectors:
+          - "latency_*"
+          - "apiBytesSent_*"
+          - "totalApiBytesSent_*"
+          - "queueSizeChange_*"
+          - "actualQueueSize_*"
+          - "lastLatency_*"
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [batch, resourcedetection, resource]
+      exporters: [logging, awsemf]
+  extensions: [pprof]
+  telemetry:
+    logs:
+      level: ${log_level}

--- a/terraform/testcases/ec2_resource_detect_metric/parameters.tfvars
+++ b/terraform/testcases/ec2_resource_detect_metric/parameters.tfvars
@@ -1,0 +1,9 @@
+validation_config = "ec2-resource-detect-validation.yml"
+
+sample_app = "spark"
+
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
+
+ignore_empty_dim_set = true
+
+rollup = false

--- a/validator/src/main/java/com/amazon/aoc/fileconfigs/PredefinedExpectedTemplate.java
+++ b/validator/src/main/java/com/amazon/aoc/fileconfigs/PredefinedExpectedTemplate.java
@@ -37,6 +37,7 @@ public enum PredefinedExpectedTemplate implements FileConfig {
       "/expected-data-template/container-insight/ecs/prometheus"),
   FARGATE_EXPECTED_METRIC("/expected-data-template/EKSFargateCWCIExpectedMetric.mustache"),
   STANDARD_EXPECTED_METRIC("/expected-data-template/standard/standardExpectedMetric.mustache"),
+  EC2_RESOURCE_DETECT_EXPECTED_METRIC("/expected-data-template/ec2ResourceDetectMetric.mustache"),
 
   /** trace template, defined in resources. */
   // not use default expected trace any more

--- a/validator/src/main/resources/expected-data-template/ec2ResourceDetectMetric.mustache
+++ b/validator/src/main/resources/expected-data-template/ec2ResourceDetectMetric.mustache
@@ -1,0 +1,101 @@
+-
+  metricName: latency_{{testingId}}
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: host.id
+      value: 123
+    -
+      name: host.image.id
+      value: 1234
+    -
+      name: host.name
+      value: testname
+    -
+      name: host.type
+      value: testtype
+
+-
+  metricName: apiBytesSent_{{testingId}}
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: host.id
+      value: 123
+    -
+      name: host.image.id
+      value: 1234
+    -
+      name: host.name
+      value: testname
+    -
+      name: host.type
+      value: testtype
+
+-
+  metricName: totalApiBytesSent_{{testingId}}
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: host.id
+      value: 123
+    -
+      name: host.image.id
+      value: 1234
+    -
+      name: host.name
+      value: testname
+    -
+      name: host.type
+      value: testtype
+
+-
+  metricName: queueSizeChange_{{testingId}}
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: host.id
+      value: 123
+    -
+      name: host.image.id
+      value: 1234
+    -
+      name: host.name
+      value: testname
+    -
+      name: host.type
+      value: testtype
+
+-
+  metricName: actualQueueSize_{{testingId}}
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: host.id
+      value: 123
+    -
+      name: host.image.id
+      value: 1234
+    -
+      name: host.name
+      value: testname
+    -
+      name: host.type
+      value: testtype
+
+-
+  metricName: lastLatency_{{testingId}}
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: host.id
+      value: 123
+    -
+      name: host.image.id
+      value: 1234
+    -
+      name: host.name
+      value: testname
+    -
+      name: host.type
+      value: testtype

--- a/validator/src/main/resources/validations/ec2-resource-detect-validation.yml
+++ b/validator/src/main/resources/validations/ec2-resource-detect-validation.yml
@@ -1,0 +1,6 @@
+-
+  validationType: "cw-metric"
+  httpPath: "/outgoing-http-call"
+  httpMethod: "get"
+  callingType: "http"
+  expectedMetricTemplate: "EC2_RESOURCE_DETECT_EXPECTED_METRIC"


### PR DESCRIPTION
**Description:** Add a new testcase to verify that the ec2 resource detect is working as intended for metrics.  Also, added the ignore dimension variable to the ecs parameters.

**Testing:** Local testing passed for ECS using `awsvpc` network mode but `bridge` network mode leads to an error in the sample app as of right now.  Investigating currently.

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

