### PR TITLE
[chore] Fix otlp typo

### DIFF
--- a/terraform/eks/main.tf
+++ b/terraform/eks/main.tf
@@ -228,7 +228,7 @@ module "validator" {
   rollup                   = var.rollup
 
   depends_on = [
-    module.aoc_oltp,
+    module.aoc_otlp,
     module.adot_operator,
     kubectl_manifest.logs_sample_fargate_deploy,
     null_resource.prom_base_ready_check,

--- a/terraform/eks/variables.tf
+++ b/terraform/eks/variables.tf
@@ -31,9 +31,9 @@ variable "sample_app_image_repo" {
 }
 
 // aoc_base_scenario refers to the base scenario that the aoc is used for.
-// options: oltp, prometheus, infra
+// options: otlp, prometheus, infra
 variable "aoc_base_scenario" {
-  default = "oltp"
+  default = "otlp"
 }
 
 // aoc_deploy_mode refers to the mode to deploy the Collector CR. This is only used when we test the Operator.


### PR DESCRIPTION
**Description:** Fix typo in terraform eks module where `oltp` was used instead of `otlp`

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

