### PR TITLE
Create 1.23 clusters as dev test

### DIFF
--- a/cdk_infra/lib/config/cluster-config/clusters.yml
+++ b/cdk_infra/lib/config/cluster-config/clusters.yml
@@ -96,7 +96,7 @@ clusters:
     launch_type: ec2
     instance_type: "m5.large"
   - name: dev-collector-ci-arm64-1-23
-    version: "1.22"
+    version: "1.23"
     launch_type: ec2
     instance_type: m6g.large
   - name: dev-collector-ci-arm64-1-26

--- a/cdk_infra/lib/config/cluster-config/clusters.yml
+++ b/cdk_infra/lib/config/cluster-config/clusters.yml
@@ -92,7 +92,7 @@ clusters:
     instance_type: m6g.large
     cert_manager: true
   - name: dev-collector-ci-amd64-1-23
-    version: "1.22"
+    version: "1.23"
     launch_type: ec2
     instance_type: "m5.large"
   - name: dev-collector-ci-arm64-1-23

--- a/cdk_infra/lib/config/cluster-config/clusters.yml
+++ b/cdk_infra/lib/config/cluster-config/clusters.yml
@@ -91,11 +91,11 @@ clusters:
     launch_type: ec2
     instance_type: m6g.large
     cert_manager: true
-  - name: dev-collector-ci-amd64-1-22
+  - name: dev-collector-ci-amd64-1-23
     version: "1.22"
     launch_type: ec2
     instance_type: "m5.large"
-  - name: dev-collector-ci-arm64-1-22
+  - name: dev-collector-ci-arm64-1-23
     version: "1.22"
     launch_type: ec2
     instance_type: m6g.large


### PR DESCRIPTION
**Description:** switch to v1.23 for minimum version for dev testing. v1.22 is no longer supported by EKS. v1.22 clusters will be cleaned up manually when non-dev clusters are cleaned up. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

