### PR TITLE
[dev] Give default volume path for kubecfg

### DIFF
--- a/terraform/validation/variables.tf
+++ b/terraform/validation/variables.tf
@@ -89,7 +89,7 @@ variable "rollup" {
 }
 
 variable "kubecfg_file_path" {
-  default = ""
+  default = "/dev/null"
   type    = string
 }
 


### PR DESCRIPTION
**Description:** Provide a default value for kubecfg file path so the validator docker compose will not fail on non eks tests. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

