### PR TITLE
[dev] Add additional safety checks for creating KubernetesContext

### DIFF
--- a/terraform/templates/defaults/validator_docker_compose.tpl
+++ b/terraform/templates/defaults/validator_docker_compose.tpl
@@ -7,7 +7,7 @@ services:
     volumes:
       - ~/.aws:/root/.aws
       - ./output:/var/output
-      - ${kubecfg_file_path}:/root/kubecfg
+      - ${kubecfg_volume_source}:/root/kubecfg
     environment:
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY
@@ -34,6 +34,6 @@ services:
       - "--alarm-names=${incoming_packets_alarm}"
       - "--cortex-instance-endpoint=${cortex_instance_endpoint}"
       - "--rollup=${rollup}"
-      - "--kubecfg-file-path=/root/kubecfg"
+      - "--kubecfg-file-path=${kubecfg_file_path}"
       - "--k8s-deployment-name=${k8s_deployment_name}"
       - "--k8s-namespace=${k8s_namespace}"

--- a/terraform/validation/main.tf
+++ b/terraform/validation/main.tf
@@ -50,9 +50,13 @@ data "template_file" "docker_compose" {
 
     cortex_instance_endpoint = var.cortex_instance_endpoint
     rollup                   = var.rollup
-    kubecfg_file_path        = var.kubecfg_file_path
-    k8s_deployment_name      = var.k8s_deployment_name
-    k8s_namespace            = var.k8s_namespace
+    // a volume source must always be provided to prevent docker startup failures
+    kubecfg_volume_source = var.kubecfg_file_path
+    // only provide a kubecfg filepath to validator flag if the default variable value has been overridden.
+    kubecfg_file_path = var.kubecfg_file_path == "/dev/null" ? "" : "/root/kubecfg"
+
+    k8s_deployment_name = var.k8s_deployment_name
+    k8s_namespace       = var.k8s_namespace
   }
 
 }

--- a/validator/src/main/java/com/amazon/aoc/App.java
+++ b/validator/src/main/java/com/amazon/aoc/App.java
@@ -164,12 +164,16 @@ public class App implements Callable<Integer> {
   }
 
   // Deserialize kubernetes context passed in at validation start time and then build expected
-  // metrics.
+  // metrics. Only builds context if a kubecfg file path is given.
   private KubernetesContext buildKubernetesContext() throws Exception {
-    KubernetesContextFactory factory =
-        new KubernetesContextFactory(
-            this.kubeCfgFilePath, this.k8sDeploymentName, this.k8sNamespace);
-    return factory.create();
+    if (!this.kubeCfgFilePath.isEmpty()) {
+      KubernetesContextFactory factory =
+          new KubernetesContextFactory(
+              this.kubeCfgFilePath, this.k8sDeploymentName, this.k8sNamespace);
+      return factory.create();
+    }
+    log.info("did not build kubernetes context. kubecfg file path was empty");
+    return null;
   }
 
   private void validate(Context context, List<ValidationConfig> validationConfigList)

--- a/validator/src/main/java/com/amazon/aoc/App.java
+++ b/validator/src/main/java/com/amazon/aoc/App.java
@@ -166,14 +166,10 @@ public class App implements Callable<Integer> {
   // Deserialize kubernetes context passed in at validation start time and then build expected
   // metrics. Only builds context if a kubecfg file path is given.
   private KubernetesContext buildKubernetesContext() throws Exception {
-    if (!this.kubeCfgFilePath.isEmpty()) {
-      KubernetesContextFactory factory =
-          new KubernetesContextFactory(
-              this.kubeCfgFilePath, this.k8sDeploymentName, this.k8sNamespace);
-      return factory.create();
-    }
-    log.info("did not build kubernetes context. kubecfg file path was empty");
-    return null;
+    KubernetesContextFactory factory =
+        new KubernetesContextFactory(
+            this.kubeCfgFilePath, this.k8sDeploymentName, this.k8sNamespace);
+    return factory.create();
   }
 
   private void validate(Context context, List<ValidationConfig> validationConfigList)

--- a/validator/src/main/java/com/amazon/aoc/models/kubernetes/KubernetesContextFactory.java
+++ b/validator/src/main/java/com/amazon/aoc/models/kubernetes/KubernetesContextFactory.java
@@ -2,22 +2,24 @@ package com.amazon.aoc.models.kubernetes;
 
 import com.amazon.aoc.services.KubernetesService;
 import io.kubernetes.client.openapi.models.V1Pod;
+import java.io.IOException;
 import java.util.Objects;
+import lombok.extern.log4j.Log4j2;
 
+@Log4j2
 public class KubernetesContextFactory {
   private final String kubeConfigFilePath;
   private final String deploymentName;
 
   private final String namespace;
 
-  private final KubernetesService kubernetesService;
+  private KubernetesService kubernetesService;
 
   public KubernetesContextFactory(
-      String kubeConfigFilePath, String deploymentName, String namespace) throws Exception {
+      String kubeConfigFilePath, String deploymentName, String namespace) {
     this.kubeConfigFilePath = kubeConfigFilePath;
     this.deploymentName = deploymentName;
     this.namespace = namespace;
-    this.kubernetesService = new KubernetesService(this.kubeConfigFilePath);
   }
 
   KubernetesContextFactory(
@@ -32,6 +34,15 @@ public class KubernetesContextFactory {
   }
 
   public KubernetesContext create() throws Exception {
+    if (this.kubernetesService == null) {
+      try {
+        this.kubernetesService = new KubernetesService(this.kubeConfigFilePath);
+      } catch (IOException e) {
+        log.error("failed to build kubernetes service", e);
+        return null;
+      }
+    }
+
     KubernetesContext kubernetesContext =
         new KubernetesContext(this.deploymentName, this.namespace);
 

--- a/validator/src/main/java/com/amazon/aoc/models/kubernetes/KubernetesContextFactory.java
+++ b/validator/src/main/java/com/amazon/aoc/models/kubernetes/KubernetesContextFactory.java
@@ -2,7 +2,6 @@ package com.amazon.aoc.models.kubernetes;
 
 import com.amazon.aoc.services.KubernetesService;
 import io.kubernetes.client.openapi.models.V1Pod;
-import java.io.IOException;
 import java.util.Objects;
 import lombok.extern.log4j.Log4j2;
 
@@ -35,11 +34,11 @@ public class KubernetesContextFactory {
 
   public KubernetesContext create() throws Exception {
     if (this.kubernetesService == null) {
-      try {
-        this.kubernetesService = new KubernetesService(this.kubeConfigFilePath);
-      } catch (IOException e) {
-        log.error("failed to build kubernetes service", e);
+      if (this.kubeConfigFilePath.isEmpty()) {
+        log.info("did not build kubernetes context. kubecfg file path was empty");
         return null;
+      } else {
+        this.kubernetesService = new KubernetesService(this.kubeConfigFilePath);
       }
     }
 

--- a/validator/src/test/java/com/amazon/aoc/models/kubernetes/KubernetesContextFactoryTest.java
+++ b/validator/src/test/java/com/amazon/aoc/models/kubernetes/KubernetesContextFactoryTest.java
@@ -1,6 +1,7 @@
 package com.amazon.aoc.models.kubernetes;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.*;
 
 import com.amazon.aoc.services.KubernetesService;
@@ -10,6 +11,13 @@ import io.kubernetes.client.openapi.models.V1PodSpec;
 import org.junit.Test;
 
 public class KubernetesContextFactoryTest {
+
+  @Test
+  public void testCreateContextEmptyStrings() throws Exception {
+    KubernetesContextFactory mockFactory = new KubernetesContextFactory("", "", "");
+    KubernetesContext actualKubernetesContext = mockFactory.create();
+    assertNull(actualKubernetesContext);
+  }
 
   @Test
   public void testCreateContextHappyPath() throws Exception {


### PR DESCRIPTION
**Description:** This PR adds additional logic for when the validator attempts to build the kubernetesContext object. The object should only be created if a kubecfg file path is given.

The test framework validator docker compose was also adjusted. The volume source path must always be given but the flag value given to the validator requires a conditional check. 

**Testing:** Ran ec2 otlp_metric and eks otlp_metric_k8sattr tests.


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

