### PR TITLE
[dev] Add ability to define a feature gate for EKS tests

### DIFF
--- a/terraform/eks/otlp.tf
+++ b/terraform/eks/otlp.tf
@@ -145,6 +145,11 @@ resource "kubernetes_config_map" "mocked_server_cert" {
 
 locals {
   configuration_uri = var.configuration_source == "file" ? "/aoc/aoc-config.yml" : module.remote_configuration[0].configuration_uri
+  collector_args = length(var.feature_gate) != 0 ? [
+    "--config", local.configuration_uri, "--feature-gates", var.feature_gate
+    ] : [
+    "--config", local.configuration_uri
+  ]
 }
 
 # deploy aoc and mocked server
@@ -213,8 +218,7 @@ resource "kubernetes_deployment" "aoc_deployment" {
           name              = "aoc"
           image             = module.common.aoc_image
           image_pull_policy = "Always"
-          args = [
-          "--config", local.configuration_uri]
+          args              = local.collector_args
 
           resources {
             limits = {

--- a/terraform/eks/variables.tf
+++ b/terraform/eks/variables.tf
@@ -103,3 +103,12 @@ variable "ignore_empty_dim_set" {
 
   description = "Toggles whether or not the validator will ignore an empty EMF dimension set"
 }
+
+variable "feature_gate" {
+  type        = string
+  default     = ""
+  description = <<EOT
+  Used to toggle a single feature gate in the collector during startup. Pass in only the feature gate name
+  for example +aws.statsd.populateInstrumentationScope
+  EOT
+}


### PR DESCRIPTION
**Description:** This PR:
1.  modifies the EKS module to allow a single feature gate to be passed to the collector. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

