### PR TITLE
[dev] Add StatsD feature gate tests

### DIFF
--- a/terraform/eks/otlp.tf
+++ b/terraform/eks/otlp.tf
@@ -145,6 +145,11 @@ resource "kubernetes_config_map" "mocked_server_cert" {
 
 locals {
   configuration_uri = var.configuration_source == "file" ? "/aoc/aoc-config.yml" : module.remote_configuration[0].configuration_uri
+  collector_args = length(var.feature_gate) != 0 ? [
+    "--config", local.configuration_uri, "--feature-gates", var.feature_gate
+    ] : [
+    "--config", local.configuration_uri
+  ]
 }
 
 # deploy aoc and mocked server
@@ -213,8 +218,7 @@ resource "kubernetes_deployment" "aoc_deployment" {
           name              = "aoc"
           image             = module.common.aoc_image
           image_pull_policy = "Always"
-          args = [
-          "--config", local.configuration_uri]
+          args              = local.collector_args
 
           resources {
             limits = {

--- a/terraform/eks/variables.tf
+++ b/terraform/eks/variables.tf
@@ -103,3 +103,12 @@ variable "ignore_empty_dim_set" {
 
   description = "Toggles whether or not the validator will ignore an empty EMF dimension set"
 }
+
+variable "feature_gate" {
+  type        = string
+  default     = ""
+  description = <<EOT
+  Used to toggle a single feature gate in the collector during startup. Pass in only the feature gate name
+  for example +aws.statsd.populateInstrumentationScope
+  EOT
+}

--- a/terraform/testcases/statsd_nootellib_instScopeEnabled/otconfig.tpl
+++ b/terraform/testcases/statsd_nootellib_instScopeEnabled/otconfig.tpl
@@ -1,0 +1,27 @@
+receivers:
+  statsd:
+    endpoint: 0.0.0.0:${udp_port}
+    aggregation_interval: 20s
+exporters:
+  awsemf:
+    namespace: '${otel_service_namespace}/${otel_service_name}'
+    region: '${region}'
+    dimension_rollup_option: "NoDimensionRollup"
+    metric_declarations:
+      - dimensions: [[mykey1, mykey2], [mykey1], [mykey2], [mykey4],[mykey5],[mykey3], []]
+        metric_name_selectors:
+          - "statsdTestMetric1g_*"
+          - "statsdTestMetric1ms_*"
+          - "statsdTestMetric1h_*"
+          - "statsdTestMetric1c_*"
+
+  logging:
+    verbosity: detailed
+service:
+  pipelines:
+    metrics:
+      receivers: [statsd]
+      exporters: [awsemf, logging]
+  telemetry:
+    logs:
+      level: ${log_level}

--- a/terraform/testcases/statsd_nootellib_instScopeEnabled/parameters.tfvars
+++ b/terraform/testcases/statsd_nootellib_instScopeEnabled/parameters.tfvars
@@ -1,0 +1,13 @@
+# this file is defined in validator/src/main/resources/validations
+validation_config = "statsd-metric-validation.yml"
+
+# sample application image to emit the trace data
+sample_app = "statsd"
+
+# data type will be emitted. Possible values: metric or trace
+soaking_data_mode = "metric"
+
+# data model type. possible values: otlp, xray, etc
+soaking_data_type = "statsd"
+
+feature_gate = "+aws.statsd.populateInstrumentationScope"

--- a/terraform/testcases/statsd_nootellib_instScopeEnabled/soaking_docker_compose.tpl
+++ b/terraform/testcases/statsd_nootellib_instScopeEnabled/soaking_docker_compose.tpl
@@ -1,0 +1,24 @@
+version: "3.8"
+services:
+  mocked_server:
+    image: ${mocked_server_image}
+    ports:
+      - "80:8080"
+      - "443:443"
+    deploy:
+      resources:
+        limits:
+          memory: 4G
+  ot-metric-emitter:
+    privileged: true
+    image: ${sample_app_image}
+    command: ["${data_mode}", "-r=${rate}", "-u=${udp_endpoint}", "-d=${data_type}"]
+    environment:
+      OTEL_RESOURCE_ATTRIBUTES: ${otel_resource_attributes}
+      AWS_XRAY_DAEMON_ADDRESS: ${udp_endpoint}
+      COLLECTOR_UDP_ADDRESS: ${udp_endpoint}
+      AWS_REGION: ${region}
+    deploy:
+      resources:
+        limits:
+          memory: 16G

--- a/terraform/testcases/statsd_otellib_instScopeEnabled/otconfig.tpl
+++ b/terraform/testcases/statsd_otellib_instScopeEnabled/otconfig.tpl
@@ -1,0 +1,18 @@
+receivers:
+  statsd:
+    endpoint: 0.0.0.0:${udp_port}
+    aggregation_interval: 20s
+exporters:
+  awsemf:
+    namespace: '${otel_service_namespace}/${otel_service_name}'
+    region: '${region}'
+  logging:
+    verbosity: detailed
+service:
+  pipelines:
+    metrics:
+      receivers: [statsd]
+      exporters: [awsemf, logging]
+  telemetry:
+    logs:
+      level: ${log_level}

--- a/terraform/testcases/statsd_otellib_instScopeEnabled/parameters.tfvars
+++ b/terraform/testcases/statsd_otellib_instScopeEnabled/parameters.tfvars
@@ -1,0 +1,17 @@
+# this file is defined in validator/src/main/resources/validations
+validation_config = "statsd-otellib-metric-validation.yml"
+
+# sample application image to emit the trace data
+sample_app = "statsd"
+
+# data type will be emitted. Possible values: metric or trace
+soaking_data_mode = "metric"
+
+# data model type. possible values: otlp, xray, etc
+soaking_data_type = "statsd"
+
+feature_gate = "+aws.statsd.populateInstrumentationScope"
+
+aoc_image_repo = "public.ecr.aws/aws-otel-test/adot-collector-integration-test"
+
+aoc_version = "v0.30.0-9468cd0"

--- a/terraform/testcases/statsd_otellib_instScopeEnabled/soaking_docker_compose.tpl
+++ b/terraform/testcases/statsd_otellib_instScopeEnabled/soaking_docker_compose.tpl
@@ -1,0 +1,24 @@
+version: "3.8"
+services:
+  mocked_server:
+    image: ${mocked_server_image}
+    ports:
+      - "80:8080"
+      - "443:443"
+    deploy:
+      resources:
+        limits:
+          memory: 4G
+  ot-metric-emitter:
+    privileged: true
+    image: ${sample_app_image}
+    command: ["${data_mode}", "-r=${rate}", "-u=${udp_endpoint}", "-d=${data_type}"]
+    environment:
+      OTEL_RESOURCE_ATTRIBUTES: ${otel_resource_attributes}
+      AWS_XRAY_DAEMON_ADDRESS: ${udp_endpoint}
+      COLLECTOR_UDP_ADDRESS: ${udp_endpoint}
+      AWS_REGION: ${region}
+    deploy:
+      resources:
+        limits:
+          memory: 16G

--- a/validator/src/main/java/com/amazon/aoc/fileconfigs/PredefinedExpectedTemplate.java
+++ b/validator/src/main/java/com/amazon/aoc/fileconfigs/PredefinedExpectedTemplate.java
@@ -31,6 +31,7 @@ public enum PredefinedExpectedTemplate implements FileConfig {
   ENHANCED_EXPECTED_METRIC_TESTING_ID(
       "/expected-data-template/enhancedExpectedMetricTestingId.mustache"),
   STATSD_EXPECTED_METRIC("/expected-data-template/statsdExpectedMetric.mustache"),
+  STATSD_OTELLIB_EXPECTED_METRIC("/expected-data-template/statsDOtelLibExpectedMetric.mustache"),
   ECS_CONTAINER_EXPECTED_METRIC("/expected-data-template/ecsContainerExpectedMetric.mustache"),
   CONTAINER_INSIGHT_EKS_PROMETHEUS_METRIC(
       "/expected-data-template/container-insight/eks/prometheus"),

--- a/validator/src/main/resources/expected-data-template/statsDOtelLibExpectedMetric.mustache
+++ b/validator/src/main/resources/expected-data-template/statsDOtelLibExpectedMetric.mustache
@@ -1,0 +1,46 @@
+-
+  metricName: statsdTestMetric1g_{{testingId}}
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: OTelLib
+      value: otelcol/statsdreceiver
+    -
+      name: mykey1
+      value: myvalue1
+    -
+      name: mykey2
+      value: myvalue2
+
+-
+  metricName: statsdTestMetric1c_{{testingId}}
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: OTelLib
+      value: otelcol/statsdreceiver
+    -
+      name: mykey3
+      value: myvalue3
+
+-
+  metricName: statsdTestMetric1ms_{{testingId}}
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: OTelLib
+      value: otelcol/statsdreceiver
+    -
+      name: mykey4
+      value: myvalue4
+
+-
+  metricName: statsdTestMetric1h_{{testingId}}
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: OTelLib
+      value: otelcol/statsdreceiver
+    -
+      name: mykey5
+      value: myvalue5

--- a/validator/src/main/resources/validations/statsd-otellib-metric-validation.yml
+++ b/validator/src/main/resources/validations/statsd-otellib-metric-validation.yml
@@ -1,0 +1,6 @@
+-
+  validationType: "cw-metric"
+  httpMethod: "get"
+  httpPath: "/statsd"
+  callingType: "http"
+  expectedMetricTemplate: "STATSD_OTELLIB_EXPECTED_METRIC"


### PR DESCRIPTION
**Description:** Follow up to #1354 
Test cases added
1. Enable feature gate, custom collector config. Ensures backwards compatibility is possible with new collector configuration
2. Enable feature gate, new expected data template. New expected data template contains `otellib` dimension value that will now be populated.

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

