### PR TITLE
Add configurable sleep duration for load balancing tests

### DIFF
--- a/validator/src/main/java/com/amazon/aoc/validators/LoadBalancingValidator.java
+++ b/validator/src/main/java/com/amazon/aoc/validators/LoadBalancingValidator.java
@@ -102,8 +102,8 @@ public class LoadBalancingValidator extends XrayValidator {
     return sampleAppResponse.getTraceId();
   }
 
-  private boolean checkSpanCount(List<String> spanSet) {
-    if (spanSet.size() < 2) {
+  private boolean checkSpanCount(List<String> spanList) {
+    if (spanList.size() < 2) {
       log.error("not enough spans in trace map (need at least 2)");
       log.info("==========================================");
       return false;

--- a/validator/src/main/java/com/amazon/aoc/validators/LoadBalancingValidator.java
+++ b/validator/src/main/java/com/amazon/aoc/validators/LoadBalancingValidator.java
@@ -33,14 +33,19 @@ import lombok.extern.log4j.Log4j2;
 @Log4j2
 public class LoadBalancingValidator extends XrayValidator {
 
+  private int retrySleepDurationMs =
+      Integer.parseInt(GenericConstants.SLEEP_IN_MILLISECONDS.getVal());
+
   public void init(
       Context context,
       ValidationConfig validationConfig,
       ICaller caller,
       FileConfig expectedTrace,
-      XRayService xrayService)
+      XRayService xrayService,
+      Integer retrySleepDurationMs)
       throws Exception {
     init(context, validationConfig, caller, expectedTrace);
+    this.retrySleepDurationMs = retrySleepDurationMs;
     this.xrayService = xrayService;
   }
 
@@ -57,7 +62,7 @@ public class LoadBalancingValidator extends XrayValidator {
       // Retry 5 times to since segments might not be immediately available in X-Ray service
       RetryHelper.retry(
           5,
-          Integer.parseInt(GenericConstants.SLEEP_IN_MILLISECONDS.getVal()),
+          retrySleepDurationMs,
           true,
           () -> {
             // get retrieved trace from x-ray service
@@ -97,7 +102,7 @@ public class LoadBalancingValidator extends XrayValidator {
     return sampleAppResponse.getTraceId();
   }
 
-  private boolean checkSpanCount(List<String> spanSet) throws Exception {
+  private boolean checkSpanCount(List<String> spanSet) {
     if (spanSet.size() < 2) {
       log.error("not enough spans in trace map (need at least 2)");
       log.info("==========================================");

--- a/validator/src/test/java/com/amazon/aoc/validators/LoadBalancingValidatorTest.java
+++ b/validator/src/test/java/com/amazon/aoc/validators/LoadBalancingValidatorTest.java
@@ -141,7 +141,8 @@ public class LoadBalancingValidatorTest {
         validationConfig,
         httpCaller,
         validationConfig.getExpectedTraceTemplate(),
-        xrayService);
+        xrayService,
+        1);
     validator.validate();
   }
 }


### PR DESCRIPTION
**Description:** While building locally I noticed that the validator was taking 2+ minutes to complete the load balancing validator tests. This is due to the sleep duration constant that was used for its retry behavior. I have made changes to the validator to allow it to be configured in the `init` method used by the tests. This speeds up validator build time dramatically which will translate to faster collector CI run times.  

I have also changed a method signature which would never throw an exception. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

