### PR TITLE
Root User Priviledge for awscontainerinsightsreceiver testcases

### DIFF
--- a/terraform/eks/container-insights-agent/daemonset.tpl
+++ b/terraform/eks/container-insights-agent/daemonset.tpl
@@ -16,6 +16,9 @@ spec:
       containers:
         - name: aws-otel-collector
           image: ${OTELIMAGE}
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
           env:
             - name: K8S_NODE_NAME
               valueFrom:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Root-User priviledges for running `awscontainerinsightsreceiver` test-cases to fix the failure here: https://github.com/aws-observability/aws-otel-collector/actions/runs/5835067209/job/15883784297 of test-cases:

EKS `containerinsights_eks_containerd` us-west-2|dev-collector-ci-amd64-1-26
EKS_ARM64 `containerinsights_eks_containerd` us-west-2|dev-collector-ci-arm64-1-26

EKS `containerinsight_eks` us-west-2|dev-collector-ci-amd64-1-23
EKS_ARM64 `containerinsight_eks` us-west-2|dev-collector-ci-arm64-1-23


**Link to tracking Issue:** <Issue number if applicable>
https://github.com/aws-observability/aws-otel-collector/issues/2222

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

