### PR TITLE
Use yum to install docker instead of amazon-linux-extra

### DIFF
--- a/terraform/ec2/main.tf
+++ b/terraform/ec2/main.tf
@@ -405,7 +405,7 @@ resource "null_resource" "setup_sample_app_and_mock_server" {
   provisioner "remote-exec" {
     inline = [
       "sudo yum update -y",
-      "sudo amazon-linux-extras install docker -y",
+      "sudo yum install -y docker",
       "sudo service docker start",
       "sudo usermod -a -G docker ec2-user",
       "sudo curl -L 'https://github.com/docker/compose/releases/download/1.27.4/docker-compose-Linux-x86_64' -o /usr/local/bin/docker-compose",

--- a/terraform/ec2/main.tf
+++ b/terraform/ec2/main.tf
@@ -405,6 +405,7 @@ resource "null_resource" "setup_sample_app_and_mock_server" {
   provisioner "remote-exec" {
     inline = [
       "sudo yum update -y",
+      "sudo yum install -y libxcrypt-compat",
       "sudo yum install -y docker",
       "sudo service docker start",
       "sudo usermod -a -G docker ec2-user",

--- a/terraform/ec2/main.tf
+++ b/terraform/ec2/main.tf
@@ -408,6 +408,7 @@ resource "null_resource" "setup_sample_app_and_mock_server" {
       "sudo yum install -y docker",
       "sudo service docker start",
       "sudo usermod -a -G docker ec2-user",
+      "sudo ln -s /usr/lib/libcrypt.so /usr/lib/libcrypt.so.1",
       "sudo curl -L 'https://github.com/docker/compose/releases/download/1.27.4/docker-compose-Linux-x86_64' -o /usr/local/bin/docker-compose",
       "sudo chmod +x /usr/local/bin/docker-compose",
       "sudo `aws ecr get-login --no-include-email --region ${var.region}`",


### PR DESCRIPTION
**Description:** 

- Use `yum` to install `docker` instead of `amazon-linux-extra` as Amazon linux 2023 does not have `amazon-linux-extra` included anymore. This was causing the installation failure of docker
- Change symbolic link from `libcrypt.so` to `libcrypt.so.1` to fix this workflow [failure](https://github.com/aws-observability/aws-otel-collector/actions/runs/6328429022/job/17188255940#step:9:820)
`Error loading Python lib '/tmp/_MEIaR70C0/libpython3.7m.so.1.0': dlopen: libcrypt.so.1: cannot open shared object file: No such file or directory`

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

