### PR TITLE
Add Tests for Storage Extension and File Rotation

### DIFF
--- a/adot-testbed/app/src/test/java/software/amazon/adot/testbed/LogsTests.java
+++ b/adot-testbed/app/src/test/java/software/amazon/adot/testbed/LogsTests.java
@@ -100,7 +100,7 @@ class LogsTests {
 
         List<String> logFilePaths = new ArrayList<>();
         logFilePaths.add("/logs/RFC5424.log");
-        validateLogs(logStreamName , logFilePaths, true);
+        validateLogs(logStreamName , logFilePaths);
         collector.stop();
     }
 
@@ -111,7 +111,7 @@ class LogsTests {
 
         List<String> logFilePaths = new ArrayList<>();
         logFilePaths.add("/logs/log4j.log");
-        validateLogs(logStreamName , logFilePaths, true);
+        validateLogs(logStreamName , logFilePaths);
         collector.stop();
     }
 
@@ -122,7 +122,7 @@ class LogsTests {
 
         List<String> logFilePaths = new ArrayList<>();
         logFilePaths.add("/logs/testingJSON.log");
-        validateLogs(logStreamName , logFilePaths, true);
+        validateLogs(logStreamName , logFilePaths);
         collector.stop();
     }
 
@@ -147,7 +147,7 @@ class LogsTests {
         String expectedLogPath = logDirectory.toString();
         logFilePaths.add(expectedLogPath + "/storageExtension.log");
 
-        validateLogs(logStreamName , logFilePaths, false);
+        validateLogs(logStreamName , logFilePaths);
 
         collector.stop();
 
@@ -166,7 +166,7 @@ class LogsTests {
        //restarting the collector
         collector.start();
 
-        validateLogs(logStreamName , logFilePaths, false);
+        validateLogs(logStreamName , logFilePaths);
         collector.stop();
     }
 
@@ -208,19 +208,19 @@ class LogsTests {
         logFilePaths.add(expectedLogPath + "/testlogA-1234.log");
         logFilePaths.add(expectedLogPath + "/testlogA.log");
 
-        validateLogs(logStreamName, logFilePaths, false);
+        validateLogs(logStreamName, logFilePaths);
 
         collector.stop();
     }
 
 
-    void validateLogs(String testLogStreamName, List<String> logFilePaths, boolean areResourceFiles) throws Exception {
+    void validateLogs(String testLogStreamName, List<String> logFilePaths) throws Exception {
         var lines = new HashSet<String>();
 
         for (String logFilePath : logFilePaths) {
             InputStream inputStream;
             //Check whether the filePath is from resource folder.
-            if (areResourceFiles) {
+            if (getClass().getResource(logFilePath) != null) {
                 inputStream = getClass().getResourceAsStream(logFilePath);
             } else {
                 inputStream = new FileInputStream(logFilePath);

--- a/adot-testbed/app/src/test/java/software/amazon/adot/testbed/LogsTests.java
+++ b/adot-testbed/app/src/test/java/software/amazon/adot/testbed/LogsTests.java
@@ -143,7 +143,7 @@ class LogsTests {
         PrintWriter printWriter = new PrintWriter(tempFile);
         printWriter.println("First Message, collector is running");
         printWriter.println("Second Message, collector is running");
-        printWriter.println("Third Message,  collector is running");
+        printWriter.println("Third Message, collector is running");
         printWriter.flush();
 
         Thread.sleep(5000);
@@ -154,7 +154,14 @@ class LogsTests {
         InputStream inputStream = new FileInputStream(logPath);
         inputStreams.add(inputStream);
 
+        validateLogs(logStreamName, inputStreams);
+
         collector.stop();
+
+        // Create a new InputStream for the second call
+        InputStream secondInputStream = new FileInputStream(logPath);
+        List<InputStream> secondInputStreams = new ArrayList<>();
+        secondInputStreams.add(secondInputStream);
 
         // write to the file when collector is stopped
         printWriter.println("First Message after collector is stopped");
@@ -163,10 +170,10 @@ class LogsTests {
         printWriter.flush();
 
         printWriter.close();
-        //restarting the collector
+        // Restart the collector
         collector.start();
 
-        validateLogs(logStreamName, inputStreams);
+        validateLogs(logStreamName, secondInputStreams);
 
         collector.stop();
     }

--- a/adot-testbed/app/src/test/java/software/amazon/adot/testbed/LogsTests.java
+++ b/adot-testbed/app/src/test/java/software/amazon/adot/testbed/LogsTests.java
@@ -84,7 +84,7 @@ class LogsTests {
             .waitingFor(Wait.forLogMessage(".*Everything is ready. Begin running and processing data.*", 1))
             .withEnv(envVariables)
             .withClasspathResourceMapping("/logs", "/logs", BindMode.READ_WRITE)
-            .withCommand("--config", "/etc/collector/config.yaml", "--feature-gates=+adot.filelog.receiver,+adot.awscloudwatchlogs.exporter,+adot.file_storage.extension");
+            .withCommand("--config", "/etc/collector/config.yaml", "--feature-gates=+adot.receiver.filelog,+adot.exporter.awscloudwatchlogs,+adot.extension.file_storage");
 
        //Mount the Temp directory
         collector.withFileSystemBind(logDirectory.toString(),"/tempLogs", BindMode.READ_WRITE);
@@ -146,7 +146,6 @@ class LogsTests {
         printWriter.println("Third Message, collector is running");
         printWriter.flush();
 
-        Thread.sleep(5000);
         List<InputStream> inputStreams = new ArrayList<>();
         String expectedLogPath = logDirectory.toString();
         String logPath = expectedLogPath + "/storageExtension.log";

--- a/adot-testbed/app/src/test/java/software/amazon/adot/testbed/LogsTests.java
+++ b/adot-testbed/app/src/test/java/software/amazon/adot/testbed/LogsTests.java
@@ -3,12 +3,16 @@ package software.amazon.adot.testbed;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
+import java.io.FileWriter;
+import java.io.FileInputStream;
+import java.io.InputStreamReader;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.nio.file.Path;
+import java.nio.file.Files;
 import java.net.URISyntaxException;
 import java.time.Duration;
 import java.time.Instant;
@@ -83,17 +87,19 @@ class LogsTests {
 //        collector.withCommand("sh", "-c", "chmod -R a+rw " + "/logs");
 
         collector.start();
-        collector.waitingFor(Wait.forHealthcheck());
+//        collector.waitingFor(Wait.forHealthcheck());
         return collector;
     }
 
+    LogsTests() throws Exception {
+    }
     @Test
     void testSyslog() throws Exception {
         String logStreamName = "rfcsyslog-logstream-" + uniqueID;
         collector = createAndStartCollector("/configurations/config-rfcsyslog.yaml", "/logs/RFC5424.log", logStreamName);
 
         List<String> logFilePaths = new ArrayList<>();
-        logFilePaths.add("/logs/testingJSON.log");
+        logFilePaths.add("/logs/RFC5424.log");
         validateLogs(logStreamName , logFilePaths, true);
         collector.stop();
     }
@@ -104,7 +110,7 @@ class LogsTests {
         collector = createAndStartCollector("/configurations/config-log4j.yaml", "/logs/log4j.log", logStreamName);
 
         List<String> logFilePaths = new ArrayList<>();
-        logFilePaths.add("/logs/testingJSON.log");
+        logFilePaths.add("/logs/log4j.log");
         validateLogs(logStreamName , logFilePaths, true);
         collector.stop();
     }
@@ -176,7 +182,7 @@ class LogsTests {
     @Test
     void testFileRotation() throws Exception {
         String logStreamName = "fileRotation-logstream-" + uniqueID;
-        String resourceFilePath = "/logs/filerotationlogs/log4j.log"; // Path to the resource file
+        String resourceFilePath = "/logs/log4j.log"; // Path to the resource file
         collector = createAndStartCollector("/configurations/config-fileRotation.yaml", resourceFilePath, logStreamName);
 
         Thread.sleep(10000);

--- a/adot-testbed/app/src/test/java/software/amazon/adot/testbed/LogsTests.java
+++ b/adot-testbed/app/src/test/java/software/amazon/adot/testbed/LogsTests.java
@@ -3,7 +3,7 @@ package software.amazon.adot.testbed;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileWriter;
+import java.io.PrintWriter;
 import java.io.FileInputStream;
 import java.io.InputStreamReader;
 import java.io.FileOutputStream;
@@ -140,11 +140,11 @@ class LogsTests {
         File tempFile = new File(logDirectory.toString(), "storageExtension.log");
         Thread.sleep(5000);
 
-        FileWriter fileWriter = new FileWriter(tempFile);
-        fileWriter.write("First Message, collector is running" + "\n");
-        fileWriter.write("Second Message, collector is running" + "\n");
-        fileWriter.write("Third Message,  collector is running" + "\n");
-        fileWriter.flush();
+        PrintWriter printWriter = new PrintWriter(tempFile);
+        printWriter.println("First Message, collector is running");
+        printWriter.println("Second Message, collector is running");
+        printWriter.println("Third Message,  collector is running");
+        printWriter.flush();
 
         Thread.sleep(5000);
         List<InputStream> inputStreams = new ArrayList<>();
@@ -157,12 +157,12 @@ class LogsTests {
         collector.stop();
 
         // write to the file when collector is stopped
-        fileWriter.write("First Message after collector is stopped" + "\n");
-        fileWriter.write("Second Message after the collector is stopped" + "\n");
-        fileWriter.write("Third Message after the collector is stopped" + "\n");
-        fileWriter.flush();
+        printWriter.println("First Message after collector is stopped");
+        printWriter.println("Second Message after the collector is stopped");
+        printWriter.println("Third Message after the collector is stopped");
+        printWriter.flush();
 
-        fileWriter.close();
+        printWriter.close();
         //restarting the collector
         collector.start();
 
@@ -181,10 +181,10 @@ class LogsTests {
         // Create and write data to File A
         File tempFile = new File(logDirectory.toString(), "testlogA.log");
 
-        FileWriter fileWriter = new FileWriter(tempFile);
-        fileWriter.write("Message in File A" + "\n");
-        fileWriter.flush();
-        fileWriter.close();
+        PrintWriter printWriter = new PrintWriter(tempFile);
+        printWriter.println("Message in File A");
+        printWriter.flush();
+        printWriter.close();
 
         Thread.sleep(5000);
 
@@ -195,13 +195,12 @@ class LogsTests {
         //Create testLogA again to imitate file rotation
         File tempFileB = new File(logDirectory.toString(), "testlogA.log");
 
-        FileWriter newfileWriter = new FileWriter(tempFileB);
-        newfileWriter.write("Message in renamed file - line 1" + "\n");
-        newfileWriter.write("Message in renamed file - line 2" + "\n");
-        newfileWriter.write("Message in renamed file - line 3" + "\n");
-        newfileWriter.flush();
-        newfileWriter.close();
-
+        PrintWriter newprintWriter = new PrintWriter(tempFileB);
+        newprintWriter.println("Message in renamed file - line 1");
+        newprintWriter.println("Message in renamed file - line 2");
+        newprintWriter.println("Message in renamed file - line 3");
+        newprintWriter.flush();
+        newprintWriter.close();
 
         List<InputStream> inputStreams = new ArrayList<>();
         String expectedLogPath = logDirectory.toString();

--- a/adot-testbed/app/src/test/java/software/amazon/adot/testbed/LogsTests.java
+++ b/adot-testbed/app/src/test/java/software/amazon/adot/testbed/LogsTests.java
@@ -186,7 +186,14 @@ class LogsTests {
         printWriter.flush();
         printWriter.close();
 
-        Thread.sleep(5000);
+        List<InputStream> inputStreams = new ArrayList<>();
+        String expectedLogPath = logDirectory.toString();
+
+        String logPath = expectedLogPath + "/testlogA.log";
+        InputStream inputStream = new FileInputStream(logPath);
+        inputStreams.add(inputStream);
+        validateLogs(logStreamName, inputStreams);
+        inputStreams.remove(inputStream);
 
        //Rename testLogA
         File renameFile = new File(logDirectory.toString(), "testlogA-1234.log");
@@ -202,8 +209,6 @@ class LogsTests {
         newprintWriter.flush();
         newprintWriter.close();
 
-        List<InputStream> inputStreams = new ArrayList<>();
-        String expectedLogPath = logDirectory.toString();
 
         String logPath1 = expectedLogPath + "/testlogA-1234.log";
         String logPath2 = expectedLogPath + "/testlogA.log";

--- a/adot-testbed/app/src/test/java/software/amazon/adot/testbed/LogsTests.java
+++ b/adot-testbed/app/src/test/java/software/amazon/adot/testbed/LogsTests.java
@@ -151,8 +151,6 @@ class LogsTests {
 
         collector.stop();
 
-        Thread.sleep(5000);
-
         // write to the file when collector is stopped
         try {
             fileWriter.write("First Message after collector is stopped" + "\n");
@@ -201,7 +199,6 @@ class LogsTests {
         } catch (IOException e) {
             throw new RuntimeException("Error writing to File B.", e);
         }
-        Thread.sleep(5000);
 
         List<String> logFilePaths = new ArrayList<>();
         String expectedLogPath = logDirectory.toString();

--- a/adot-testbed/app/src/test/resources/configurations/config-fileRotation.yaml
+++ b/adot-testbed/app/src/test/resources/configurations/config-fileRotation.yaml
@@ -1,11 +1,8 @@
 receivers:
   filelog:
     include: [/tempLogs/testlogA.log]
-    start_at: beginning
 
 exporters:
-  logging:
-    verbosity: detailed
   awscloudwatchlogs:
     log_group_name: "adot-testbed/logs-component-testing/logs"
     log_stream_name: ${LOG_STREAM_NAME}

--- a/adot-testbed/app/src/test/resources/configurations/config-fileRotation.yaml
+++ b/adot-testbed/app/src/test/resources/configurations/config-fileRotation.yaml
@@ -1,6 +1,6 @@
 receivers:
   filelog:
-    include: [/filerotation/testlogA.log]
+    include: [/tempLogs/testlogA.log]
     start_at: beginning
 
 exporters:

--- a/adot-testbed/app/src/test/resources/configurations/config-fileRotation.yaml
+++ b/adot-testbed/app/src/test/resources/configurations/config-fileRotation.yaml
@@ -1,0 +1,19 @@
+receivers:
+  filelog:
+    include: [/filerotation/testlogA.log]
+    start_at: beginning
+
+exporters:
+  logging:
+    verbosity: detailed
+  awscloudwatchlogs:
+    log_group_name: "adot-testbed/logs-component-testing/logs"
+    log_stream_name: ${LOG_STREAM_NAME}
+    log_retention: 7
+    raw_log: true
+
+service:
+  pipelines:
+    logs:
+      receivers: [filelog]
+      exporters: [logging,awscloudwatchlogs]

--- a/adot-testbed/app/src/test/resources/configurations/config-storageExtension.yaml
+++ b/adot-testbed/app/src/test/resources/configurations/config-storageExtension.yaml
@@ -1,17 +1,20 @@
+extensions:
+  file_storage:
+    directory: /logs/
+
 receivers:
   filelog:
-    include: [/filerotation/testlogA.log]
-    start_at: beginning
+    include: [/logs/storageExtension.log]
+    storage: file_storage
 
 exporters:
-  logging:
-    verbosity: detailed
   awscloudwatchlogs:
     log_group_name: "adot-testbed/logs-component-testing/logs"
     log_stream_name: ${LOG_STREAM_NAME}
     log_retention: 7
 
 service:
+  extensions: [ file_storage ]
   pipelines:
     logs:
       receivers: [filelog]

--- a/adot-testbed/app/src/test/resources/configurations/config-storageExtension.yaml
+++ b/adot-testbed/app/src/test/resources/configurations/config-storageExtension.yaml
@@ -4,7 +4,7 @@ extensions:
 
 receivers:
   filelog:
-    include: [/logs/storageExtension.log]
+    include: [/tempLogs/storageExtension.log]
     storage: file_storage
 
 exporters:

--- a/adot-testbed/app/src/test/resources/logs/filerotationlogs/log4j.log
+++ b/adot-testbed/app/src/test/resources/logs/filerotationlogs/log4j.log
@@ -1,0 +1,1 @@
+[otel.javaagent 2023-09-25 16:56:22:242 +0000] [OkHttp ConnectionPool] DEBUG okhttp3.internal.concurrent.TaskRunner - Q10002 run again after 300 s : File rotation First Line

--- a/adot-testbed/app/src/test/resources/logs/filerotationlogs/log4j.log
+++ b/adot-testbed/app/src/test/resources/logs/filerotationlogs/log4j.log
@@ -1,1 +1,0 @@
-[otel.javaagent 2023-09-25 16:56:22:242 +0000] [OkHttp ConnectionPool] DEBUG okhttp3.internal.concurrent.TaskRunner - Q10002 run again after 300 s : File rotation First Line


### PR DESCRIPTION
**Description:** 
PR to add Tests for Storage Extension Restart scenarios and File Rotation

Thread.sleep is used to give enough time for file operations, collector(stop/start).

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

