### PR TITLE
[cdk_infra] Update clusters for EKS Supported Versions

### DIFF
--- a/cdk_infra/lib/config/cluster-config/clusters.yml
+++ b/cdk_infra/lib/config/cluster-config/clusters.yml
@@ -1,47 +1,6 @@
 ---
 clusters:
-  - name: collector-ci-amd64-1-22
-    version: "1.22"
-    launch_type: ec2
-    instance_type: "m5.large"
-  - name: collector-ci-arm64-1-22
-    version: "1.22"
-    launch_type: ec2
-    instance_type: m6g.large
-  - name: collector-ci-fargate-1-22
-    version: "1.22"
-    launch_type: fargate
-  - name: operator-ci-amd64-1-22
-    version: "1.22"
-    launch_type: ec2
-    instance_type: m5.large
-    cert_manager: true
-  - name: operator-ci-arm64-1-22
-    version: "1.22"
-    launch_type: ec2
-    instance_type: m6g.large
-    cert_manager: true
-  - name: collector-ci-arm64-1-23
-    version: "1.23"
-    launch_type: ec2
-    instance_type: m6g.large
-  - name: collector-ci-amd64-1-23
-    version: "1.23"
-    launch_type: ec2
-    instance_type: "m5.large"
-  - name: collector-ci-fargate-1-23
-    version: "1.23"
-    launch_type: fargate
-  - name: operator-ci-amd64-1-23
-    version: "1.23"
-    launch_type: ec2
-    instance_type: m5.large
-    cert_manager: true
-  - name: operator-ci-arm64-1-23
-    version: "1.23"
-    launch_type: ec2
-    instance_type: m6g.large
-    cert_manager: true
+# collector test clusters
   - name: collector-ci-arm64-1-24
     version: "1.24"
     launch_type: ec2
@@ -50,11 +9,9 @@ clusters:
     version: "1.24"
     launch_type: ec2
     instance_type: "m5.large"
-  - name: eks-addon-amd64-1-24
+  - name: collector-ci-fargate-1-24
     version: "1.24"
-    launch_type: ec2
-    instance_type: "m5.large"
-    cert_manager: true
+    launch_type: fargate
   - name: collector-ci-arm64-1-25
     version: "1.25"
     launch_type: ec2
@@ -63,6 +20,9 @@ clusters:
     version: "1.25"
     launch_type: ec2
     instance_type: "m5.large"
+  - name: collector-ci-fargate-1-25
+    version: "1.25"
+    launch_type: fargate
   - name: collector-ci-arm64-1-26
     version: "1.26"
     launch_type: ec2
@@ -71,39 +31,79 @@ clusters:
     version: "1.26"
     launch_type: ec2
     instance_type: "m5.large"
-  - name: java-instrumentation-operator-ci-amd64-1-23
-    version: "1.23"
+  - name: collector-ci-fargate-1-26
+    version: "1.26"
+    launch_type: fargate
+  - name: collector-ci-arm64-1-27
+    version: "1.27"
+    launch_type: ec2
+    instance_type: m6g.large
+  - name: collector-ci-amd64-1-27
+    version: "1.27"
+    launch_type: ec2
+    instance_type: "m5.large"
+  - name: collector-ci-fargate-1-27
+    version: "1.27"
+    launch_type: fargate
+# java agent test clustesr
+  - name: java-instrumentation-operator-ci-amd64-1-24
+    version: "1.24"
     launch_type: ec2
     instance_type: m5.large
     cert_manager: true
-  - name: java-instrumentation-operator-ci-amd64-1-26
+  - name: java-instrumentation-operator-ci-amd64-1-27
+    version: "1.27"
+    launch_type: ec2
+    instance_type: m5.large
+    cert_manager: true
+  - name: java-instrumentation-operator-ci-arm64-1-24
+    version: "1.24"
+    launch_type: ec2
+    instance_type: m6g.large
+    cert_manager: true
+  - name: java-instrumentation-operator-ci-arm64-1-27
+    version: "1.27"
+    launch_type: ec2
+    instance_type: m6g.large
+    cert_manager: true
+# operator test clusters
+  - name: operator-ci-amd64-1-24
+    version: "1.24"
+    launch_type: ec2
+    instance_type: m5.large
+    cert_manager: true
+  - name: operator-ci-arm64-1-24
+    version: "1.24"
+    launch_type: ec2
+    instance_type: m6g.large
+    cert_manager: true
+  - name: operator-ci-amd64-1-25
+    version: "1.25"
+    launch_type: ec2
+    instance_type: m5.large
+    cert_manager: true
+  - name: operator-ci-arm64-1-25
+    version: "1.25"
+    launch_type: ec2
+    instance_type: m6g.large
+    cert_manager: true
+  - name: operator-ci-amd64-1-26
     version: "1.26"
     launch_type: ec2
     instance_type: m5.large
     cert_manager: true
-  - name: java-instrumentation-operator-ci-arm64-1-23
-    version: "1.23"
-    launch_type: ec2
-    instance_type: m6g.large
-    cert_manager: true
-  - name: java-instrumentation-operator-ci-arm64-1-26
+  - name: operator-ci-arm64-1-26
     version: "1.26"
     launch_type: ec2
     instance_type: m6g.large
     cert_manager: true
-  - name: dev-collector-ci-amd64-1-23
-    version: "1.23"
+  - name: operator-ci-amd64-1-27
+    version: "1.27"
     launch_type: ec2
-    instance_type: "m5.large"
-  - name: dev-collector-ci-arm64-1-23
-    version: "1.23"
-    launch_type: ec2
-    instance_type: m6g.large
-  - name: dev-collector-ci-arm64-1-26
-    version: "1.26"
+    instance_type: m5.large
+    cert_manager: true
+  - name: operator-ci-arm64-1-27
+    version: "1.27"
     launch_type: ec2
     instance_type: m6g.large
-  - name: dev-collector-ci-amd64-1-26
-    version: "1.26"
-    launch_type: ec2
-    instance_type: "m5.large"
+    cert_manager: true

--- a/cdk_infra/lib/utils/eks/kubectlLayer.ts
+++ b/cdk_infra/lib/utils/eks/kubectlLayer.ts
@@ -1,30 +1,24 @@
-import { KubectlV22Layer } from '@aws-cdk/lambda-layer-kubectl-v22';
-import { KubectlV23Layer } from '@aws-cdk/lambda-layer-kubectl-v23';
-import { KubectlLayer } from '@aws-cdk/lambda-layer-kubectl-v21';
 import { aws_eks } from 'aws-cdk-lib';
 import { ILayerVersion } from 'aws-cdk-lib/aws-lambda';
 import { Construct } from 'constructs/lib/construct';
 import { KubectlV24Layer } from '@aws-cdk/lambda-layer-kubectl-v24';
 import { KubectlV25Layer } from '@aws-cdk/lambda-layer-kubectl-v25';
 import { KubectlV26Layer } from '@aws-cdk/lambda-layer-kubectl-v26';
+import { KubectlV27Layer } from '@aws-cdk/lambda-layer-kubectl-v27';
 
 export function GetLayer(
   scope: Construct,
   k8sVersion: aws_eks.KubernetesVersion
 ): ILayerVersion {
   switch (k8sVersion.version) {
-    case '1.21':
-      return new KubectlLayer(scope, 'v21Layer');
-    case '1.22':
-      return new KubectlV22Layer(scope, 'v22Layer');
-    case '1.23':
-      return new KubectlV23Layer(scope, 'v23Layer');
     case '1.24':
       return new KubectlV24Layer(scope, 'v24Layer');
     case '1.25':
       return new KubectlV25Layer(scope, 'v25Layer');
     case '1.26':
       return new KubectlV26Layer(scope, 'v26Layer');
+    case '1.27':
+      return new KubectlV27Layer(scope, 'v27Layer');
     default:
       throw new Error(`invalid kubernetes version: ${k8sVersion.version}`);
   }

--- a/cdk_infra/lib/utils/eks/validate-interface-schema.ts
+++ b/cdk_infra/lib/utils/eks/validate-interface-schema.ts
@@ -4,7 +4,7 @@ import { ec2ClusterInterface } from '../../interfaces/eks/ec2cluster-interface';
 const validateSchema = require('yaml-schema-validator');
 
 const supportedLaunchTypes = new Set(['fargate', 'ec2']);
-const supportedVersions = new Set(['1.22', '1.23', '1.24', '1.25', '1.26']);
+const supportedVersions = new Set(['1.24', '1.25', '1.26', '1.27']);
 const supportedCPUArchitectures = new Set(['m5', 'm6g', 't4g']);
 const supportedNodeSizes = new Set([
   'medium',

--- a/cdk_infra/package-lock.json
+++ b/cdk_infra/package-lock.json
@@ -19,6 +19,7 @@
         "@aws-cdk/lambda-layer-kubectl-v24": "^2.0.242",
         "@aws-cdk/lambda-layer-kubectl-v25": "^2.0.4",
         "@aws-cdk/lambda-layer-kubectl-v26": "^2.0.1",
+        "@aws-cdk/lambda-layer-kubectl-v27": "^2.0.0",
         "aws-cdk-lib": "^2.100.0",
         "constructs": "^10.3.0",
         "js-yaml": "^4.1.0",
@@ -1428,6 +1429,15 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@aws-cdk/lambda-layer-kubectl-v26/-/lambda-layer-kubectl-v26-2.0.1.tgz",
       "integrity": "sha512-xnrCzYgIKEL+Ad1QqTpN4Wsly8mVVvVGsgu1+xKcOCS6IL3Rz1AMUUtpJoEjVjq/UdJl2oJ/KmD3am+hV86scQ==",
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.28.0",
+        "constructs": "^10.0.5"
+      }
+    },
+    "node_modules/@aws-cdk/lambda-layer-kubectl-v27": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/lambda-layer-kubectl-v27/-/lambda-layer-kubectl-v27-2.0.0.tgz",
+      "integrity": "sha512-BBh4ScPHaD82e7Z3PYXqyLjqfk/3/PRDTJW3x2j4l5f6sHXU041TaXKcFAGBHb1m4aq2UK+fwkIq95mgs3c0dg==",
       "peerDependencies": {
         "aws-cdk-lib": "^2.28.0",
         "constructs": "^10.0.5"
@@ -7750,6 +7760,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@aws-cdk/lambda-layer-kubectl-v26/-/lambda-layer-kubectl-v26-2.0.1.tgz",
       "integrity": "sha512-xnrCzYgIKEL+Ad1QqTpN4Wsly8mVVvVGsgu1+xKcOCS6IL3Rz1AMUUtpJoEjVjq/UdJl2oJ/KmD3am+hV86scQ==",
+      "requires": {}
+    },
+    "@aws-cdk/lambda-layer-kubectl-v27": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/lambda-layer-kubectl-v27/-/lambda-layer-kubectl-v27-2.0.0.tgz",
+      "integrity": "sha512-BBh4ScPHaD82e7Z3PYXqyLjqfk/3/PRDTJW3x2j4l5f6sHXU041TaXKcFAGBHb1m4aq2UK+fwkIq95mgs3c0dg==",
       "requires": {}
     },
     "@aws-cdk/lambda-layer-node-proxy-agent": {

--- a/cdk_infra/package.json
+++ b/cdk_infra/package.json
@@ -39,6 +39,7 @@
     "@aws-cdk/lambda-layer-kubectl-v24": "^2.0.242",
     "@aws-cdk/lambda-layer-kubectl-v25": "^2.0.4",
     "@aws-cdk/lambda-layer-kubectl-v26": "^2.0.1",
+    "@aws-cdk/lambda-layer-kubectl-v27": "^2.0.0",
     "aws-cdk-lib": "^2.100.0",
     "constructs": "^10.3.0",
     "js-yaml": "^4.1.0",

--- a/cdk_infra/test/test_config/test_clusters.yml
+++ b/cdk_infra/test/test_config/test_clusters.yml
@@ -3,19 +3,19 @@ clusters:
   - name: m5-amd64-Cluster
     launch_type: ec2
     instance_type: m5.large
-    version: "1.22"
+    version: "1.24"
   - name: t4g-arm64-Cluster
     launch_type: ec2
     instance_type: t4g.large
-    version: "1.23"
+    version: "1.24"
   - name: m6g-arm64-Cluster
     launch_type: ec2
     instance_type: m6g.large
-    version: "1.24"
+    version: "1.25"
   - name: fargateCluster0
     launch_type: fargate
-    version: "1.25"
-  - name: m6g-arm64-Cluster-1-26
+    version: "1.26"
+  - name: m6g-arm64-Cluster-1-27
     launch_type: ec2
     instance_type: m6g.large
-    version: "1.26"
+    version: "1.27"


### PR DESCRIPTION
**Description:** 

This PR:
1. Adds the capability to create eks v1.27 clusters. 
2. Removes clusters from configs for EKS Versions that are no longer supported


This PR DOES NOT delete any clusters. Cluster stack deletion must be done manually after testcase files are updated across repositories. I will create follow up issues in each repository after this PR is merged and clusters are deployed for what steps to take. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

