### PR TITLE
revert emitter instance to use AL2022

### DIFF
--- a/terraform/ec2/main.tf
+++ b/terraform/ec2/main.tf
@@ -94,7 +94,7 @@ locals {
 
 ## launch a sidecar instance to install data emitter and the mocked server
 resource "aws_instance" "sidecar" {
-  ami                         = data.aws_ami.amazonlinux3.id
+  ami                         = data.aws_ami.amazonlinux2.id
   instance_type               = var.sidecar_instance_type
   subnet_id                   = module.basic_components.random_subnet_instance_id
   vpc_security_group_ids      = [module.basic_components.aoc_security_group_id]


### PR DESCRIPTION
**Description:** 

The data emitter and mocked server fails to deploy correctly with AL2023 because of certain breaking changes. Notably the deprecation of `aws ecr get-login`. This require changes and testing to certain commands  during remote exec. So I am reverting the instances to use AL2022. Currently there is no advantage or tech debt pilling up on using AL2022 for these instances as we plan to test AL2023 with the deployment of the ADOT collector (These changes are already made). 

Amazon Linux 2 offers long-term support until June 30, 2025 ([ref](https://aws.amazon.com/amazon-linux-2/faqs/)) so there are no current security risks.

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

