### PR TITLE
Use root user for ecs_observer test

### DIFF
--- a/terraform/testcases/containerinsight_ecs_prometheus/ecs_taskdef.tpl
+++ b/terraform/testcases/containerinsight_ecs_prometheus/ecs_taskdef.tpl
@@ -2,6 +2,7 @@
     {
       "name": "aoc-collector",
       "image": "${aoc_image}",
+      "user": 0
       "cpu": 10,
       "memory": 256,
       "secrets": [


### PR DESCRIPTION
**Description:** ECS Observer requires elevated privileges. 
<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

