### PR TITLE
User as root in ecs task def

### DIFF
--- a/terraform/testcases/containerinsight_ecs_prometheus/ecs_taskdef.tpl
+++ b/terraform/testcases/containerinsight_ecs_prometheus/ecs_taskdef.tpl
@@ -2,7 +2,7 @@
     {
       "name": "aoc-collector",
       "image": "${aoc_image}",
-      "user": 0,
+      "user": "root",
       "cpu": 10,
       "memory": 256,
       "secrets": [


### PR DESCRIPTION
**Description:** 

changing the user as a root, should be in format "user": "string" as [per here  ](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#container_definitions)

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

