### PR TITLE
[Draft] Remvoe otlp_logging variable from ecs

### DIFF
--- a/terraform/templates/defaults/ecs_taskdef.tpl
+++ b/terraform/templates/defaults/ecs_taskdef.tpl
@@ -48,14 +48,6 @@
         {
             "name": "ZIPKIN_RECEIVER_ENDPOINT",
             "value": "127.0.0.1:${http_port}"
-        },
-        {
-            "name": "OTEL_LOGS_EXPORTER",
-            "value": "otlp"
-        },
-        {
-            "name": "SAMPLE_APP_LOG_LEVEL",
-            "value": "INFO"
         }
       ],
       "dependsOn": [

--- a/terraform/testcases/configmap_provider_http/otconfig.tpl
+++ b/terraform/testcases/configmap_provider_http/otconfig.tpl
@@ -20,8 +20,6 @@ processors:
             new_value: "${testing_id}"
 
 exporters:
-  logging:
-    verbosity: detailed
   awsemf:
     region: '${region}'
 
@@ -30,7 +28,7 @@ service:
     metrics:
       receivers: [otlp]
       processors: [metricstransform, batch]
-      exporters: [logging, awsemf]
+      exporters: [awsemf]
   extensions: [pprof]
   telemetry:
     logs:

--- a/terraform/testcases/configmap_provider_https/otconfig.tpl
+++ b/terraform/testcases/configmap_provider_https/otconfig.tpl
@@ -20,8 +20,6 @@ processors:
             new_value: "${testing_id}"
 
 exporters:
-  logging:
-    verbosity: detailed
   awsemf:
     region: '${region}'
 
@@ -30,7 +28,7 @@ service:
     metrics:
       receivers: [otlp]
       processors: [metricstransform, batch]
-      exporters: [logging, awsemf]
+      exporters: [awsemf]
   extensions: [pprof]
   telemetry:
     logs:

--- a/terraform/testcases/configmap_provider_s3/otconfig.tpl
+++ b/terraform/testcases/configmap_provider_s3/otconfig.tpl
@@ -20,8 +20,6 @@ processors:
             new_value: "${testing_id}"
 
 exporters:
-  logging:
-    verbosity: detailed
   awsemf:
     region: '${region}'
 
@@ -30,7 +28,7 @@ service:
     metrics:
       receivers: [otlp]
       processors: [metricstransform, batch]
-      exporters: [logging, awsemf]
+      exporters: [awsemf]
   extensions: [pprof]
   telemetry:
     logs:

--- a/terraform/testcases/containerinsight_ecs_prometheus/otconfig.tpl
+++ b/terraform/testcases/containerinsight_ecs_prometheus/otconfig.tpl
@@ -154,8 +154,6 @@ exporters:
         metric_name_selectors:
           - "^envoy_http_downstream_rq_xx$"
 
-  logging:
-    verbosity: detailed
 
 service:
   telemetry:

--- a/terraform/testcases/datadog_exporter_metric_mock/otconfig.tpl
+++ b/terraform/testcases/datadog_exporter_metric_mock/otconfig.tpl
@@ -11,8 +11,6 @@ processors:
   batch:
 
 exporters:
-  logging:
-    verbosity: detailed
   datadog:
     api:
       key: testapikey

--- a/terraform/testcases/datadog_exporter_trace_mock/otconfig.tpl
+++ b/terraform/testcases/datadog_exporter_trace_mock/otconfig.tpl
@@ -11,8 +11,6 @@ processors:
   batch:
 
 exporters:
-  logging:
-    verbosity: detailed
   datadog:
     api:
       key: testapikey

--- a/terraform/testcases/dynatrace_exporter_metric_mock/otconfig.tpl
+++ b/terraform/testcases/dynatrace_exporter_metric_mock/otconfig.tpl
@@ -11,8 +11,6 @@ processors:
   batch:
 
 exporters:
-  logging:
-    verbosity: detailed
   dynatrace:
     api_token: mytoken
     endpoint: "https://${mock_endpoint}"

--- a/terraform/testcases/ecs_instance_metrics/otconfig.tpl
+++ b/terraform/testcases/ecs_instance_metrics/otconfig.tpl
@@ -39,14 +39,12 @@ exporters:
           - instance_cpu_limit
           - instance_memory_working_set
           - instance_memory_limit
-  logging:
-    verbosity: detailed
 service:
   pipelines:
     metrics:
       receivers: [awscontainerinsightreceiver]
       processors: [batch/metrics]
-      exporters: [awsemf,logging]
+      exporters: [awsemf]
   telemetry:
     logs:
       level: ${log_level}

--- a/terraform/testcases/ecshealthcheck/otconfig.tpl
+++ b/terraform/testcases/ecshealthcheck/otconfig.tpl
@@ -11,7 +11,6 @@ receivers:
         - targets: [ ${sample_app_listen_address_host}:${sample_app_listen_address_port} ]
 exporters:
   logging:
-      verbosity: detailed
 service:
   pipelines:
     metrics:

--- a/terraform/testcases/ecsmetrics/otconfig.tpl
+++ b/terraform/testcases/ecsmetrics/otconfig.tpl
@@ -94,15 +94,13 @@ exporters:
     region: '${region}'
     resource_to_telemetry_conversion:
       enabled: true
-  logging:
-    verbosity: detailed
 
 service:
   pipelines:
     metrics:
       receivers: [awsecscontainermetrics]
       processors: [filter, metricstransform, resource]
-      exporters: [awsemf,logging]
+      exporters: [awsemf]
   extensions: [pprof]
   telemetry:
     logs:

--- a/terraform/testcases/jaeger_mock/otconfig.tpl
+++ b/terraform/testcases/jaeger_mock/otconfig.tpl
@@ -11,8 +11,6 @@ processors:
   batch:
 
 exporters:
-  logging:
-    verbosity: detailed
   otlphttp:
     traces_endpoint: "https://${mock_endpoint}"
     tls:
@@ -24,7 +22,7 @@ service:
     traces:
       receivers: [jaeger]
       processors: [batch]
-      exporters: [otlphttp, logging]
+      exporters: [otlphttp]
   extensions: [pprof]
   telemetry:
     logs:

--- a/terraform/testcases/kafka_otlp_metric_2_8_1/otconfig.tpl
+++ b/terraform/testcases/kafka_otlp_metric_2_8_1/otconfig.tpl
@@ -20,8 +20,6 @@ processors:
   batch:
 
 exporters:
-  logging:
-    verbosity: detailed
   awsemf:
     region: '${region}'
   kafka/exporter:
@@ -39,10 +37,10 @@ service:
     metrics:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging, kafka/exporter]
+      exporters: [kafka/exporter]
     metrics/2:
       receivers: [kafka/receiver]
-      exporters: [logging, awsemf]
+      exporters: [awsemf]
   extensions: [pprof]
   telemetry:
     logs:

--- a/terraform/testcases/kafka_otlp_metric_3_2_0/otconfig.tpl
+++ b/terraform/testcases/kafka_otlp_metric_3_2_0/otconfig.tpl
@@ -20,8 +20,6 @@ processors:
   batch:
 
 exporters:
-  logging:
-    verbosity: detailed
   awsemf:
     region: '${region}'
   kafka/exporter:
@@ -39,10 +37,10 @@ service:
     metrics:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging, kafka/exporter]
+      exporters: [kafka/exporter]
     metrics/2:
       receivers: [kafka/receiver]
-      exporters: [logging, awsemf]
+      exporters: [awsemf]
   extensions: [pprof]
   telemetry:
     logs:

--- a/terraform/testcases/kafka_otlp_metric_mock_2_8_1/otconfig.tpl
+++ b/terraform/testcases/kafka_otlp_metric_mock_2_8_1/otconfig.tpl
@@ -20,8 +20,6 @@ processors:
   batch:
 
 exporters:
-  logging:
-    verbosity: detailed
   awsemf:
     region: '${region}'
     endpoint: "https://${mock_endpoint}"
@@ -40,10 +38,10 @@ service:
     metrics:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging, kafka/exporter]
+      exporters: [kafka/exporter]
     metrics/2:
       receivers: [kafka/receiver]
-      exporters: [logging, awsemf]
+      exporters: [awsemf]
   extensions: [pprof]
   telemetry:
     logs:

--- a/terraform/testcases/kafka_otlp_metric_mock_3_2_0/otconfig.tpl
+++ b/terraform/testcases/kafka_otlp_metric_mock_3_2_0/otconfig.tpl
@@ -20,8 +20,6 @@ processors:
   batch:
 
 exporters:
-  logging:
-    verbosity: detailed
   awsemf:
     region: '${region}'
     endpoint: "https://${mock_endpoint}"
@@ -40,10 +38,10 @@ service:
     metrics:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging, kafka/exporter]
+      exporters: [kafka/exporter]
     metrics/2:
       receivers: [kafka/receiver]
-      exporters: [logging, awsemf]
+      exporters: [awsemf]
   extensions: [pprof]
   telemetry:
     logs:

--- a/terraform/testcases/kafka_otlp_mock_2_8_1/otconfig.tpl
+++ b/terraform/testcases/kafka_otlp_mock_2_8_1/otconfig.tpl
@@ -20,8 +20,6 @@ processors:
   batch:
 
 exporters:
-  logging:
-    verbosity: detailed
   awsxray:
     region: '${region}'
     local_mode: true
@@ -41,11 +39,11 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      exporters: [logging,kafka/exporter]
+      exporters: [kafka/exporter]
     traces/2:
       receivers: [kafka/receiver]
       processors: [batch]
-      exporters: [logging,awsxray]
+      exporters: [awsxray]
   extensions: [pprof]
   telemetry:
     logs:

--- a/terraform/testcases/kafka_otlp_mock_3_2_0/otconfig.tpl
+++ b/terraform/testcases/kafka_otlp_mock_3_2_0/otconfig.tpl
@@ -20,8 +20,6 @@ processors:
   batch:
 
 exporters:
-  logging:
-    verbosity: detailed
   awsxray:
     region: '${region}'
     local_mode: true
@@ -41,11 +39,11 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      exporters: [logging,kafka/exporter]
+      exporters: [kafka/exporter]
     traces/2:
       receivers: [kafka/receiver]
       processors: [batch]
-      exporters: [logging,awsxray]
+      exporters: [awsxray]
   extensions: [pprof]
   telemetry:
     logs:

--- a/terraform/testcases/kafka_otlp_trace_2_8_1/otconfig.tpl
+++ b/terraform/testcases/kafka_otlp_trace_2_8_1/otconfig.tpl
@@ -20,8 +20,6 @@ processors:
   batch:
 
 exporters:
-  logging:
-    verbosity: detailed
   awsxray:
     local_mode: true
     region: '${region}'
@@ -39,11 +37,11 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      exporters: [logging,kafka/exporter]
+      exporters: [kafka/exporter]
     traces/2:
       receivers: [kafka/receiver]
       processors: [batch]
-      exporters: [logging,awsxray]
+      exporters: [awsxray]
   extensions: [pprof]
   telemetry:
     logs:

--- a/terraform/testcases/kafka_otlp_trace_3_2_0/otconfig.tpl
+++ b/terraform/testcases/kafka_otlp_trace_3_2_0/otconfig.tpl
@@ -20,8 +20,6 @@ processors:
   batch:
 
 exporters:
-  logging:
-    verbosity: detailed
   awsxray:
     local_mode: true
     region: '${region}'
@@ -39,11 +37,11 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      exporters: [logging,kafka/exporter]
+      exporters: [kafka/exporter]
     traces/2:
       receivers: [kafka/receiver]
       processors: [batch]
-      exporters: [logging,awsxray]
+      exporters: [awsxray]
   extensions: [pprof]
   telemetry:
     logs:

--- a/terraform/testcases/logzio_exporter_trace_mock/otconfig.tpl
+++ b/terraform/testcases/logzio_exporter_trace_mock/otconfig.tpl
@@ -11,8 +11,6 @@ processors:
   batch:
 
 exporters:
-  logging:
-    verbosity: detailed
   logzio/traces:
     account_token: testToken
     endpoint: "https://${mock_endpoint}"

--- a/terraform/testcases/newrelic_exporter_metric_mock/otconfig.tpl
+++ b/terraform/testcases/newrelic_exporter_metric_mock/otconfig.tpl
@@ -11,8 +11,6 @@ processors:
   batch:
 
 exporters:
-  logging:
-    verbosity: detailed
   newrelic:
     apikey: super-secret-api-key
     traces:
@@ -25,7 +23,7 @@ service:
     metrics:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging, newrelic]
+      exporters: [newrelic]
   extensions: [pprof]
   telemetry:
     logs:

--- a/terraform/testcases/newrelic_exporter_trace_mock/otconfig.tpl
+++ b/terraform/testcases/newrelic_exporter_trace_mock/otconfig.tpl
@@ -11,8 +11,6 @@ processors:
   batch:
 
 exporters:
-  logging:
-    verbosity: detailed
   newrelic:
     apikey: super-secret-api-key
     traces:

--- a/terraform/testcases/otlp_groupbytrace_tailsampling_mock/otconfig.tpl
+++ b/terraform/testcases/otlp_groupbytrace_tailsampling_mock/otconfig.tpl
@@ -20,8 +20,6 @@ processors:
           threshold_ms: 200
 
 exporters:
-  logging:
-    verbosity: detailed
   awsxray:
     region: ${region}
     local_mode: true

--- a/terraform/testcases/otlp_grpc_exporter_cw_amp_xray_ecs/otconfig.tpl
+++ b/terraform/testcases/otlp_grpc_exporter_cw_amp_xray_ecs/otconfig.tpl
@@ -124,27 +124,25 @@ exporters:
   awsxray:
     local_mode: true
     region: '${region}'
-  logging:
-    verbosity: detailed
 
 service:
   pipelines:
     metrics/container/cw:
       receivers: [awsecscontainermetrics]
       processors: [ filter, metricstransform, resource, batch]
-      exporters: [awsemf,logging]
+      exporters: [awsemf]
     metrics/container/amp:
       receivers: [ awsecscontainermetrics ]
       processors: [ filter, metricstransform, resource, batch ]
-      exporters: [ prometheusremotewrite, logging ]
+      exporters: [ prometheusremotewrite]
     metrics/application/cw:
       receivers: [ otlp ]
       processors: [ resourcedetection, batch ]
-      exporters: [ awsemf,logging ]
+      exporters: [ awsemf]
     metrics/application/amp:
       receivers: [ otlp ]
       processors: [ resourcedetection, batch ]
-      exporters: [ prometheusremotewrite, logging ]
+      exporters: [ prometheusremotewrite]
     traces/application/xray:
       receivers: [ otlp ]
       processors: [ resourcedetection, batch ]

--- a/terraform/testcases/otlp_grpc_exporter_metric_mock/otconfig.tpl
+++ b/terraform/testcases/otlp_grpc_exporter_metric_mock/otconfig.tpl
@@ -11,8 +11,6 @@ processors:
   batch:
 
 exporters:
-  logging:
-    verbosity: detailed
   otlp:
     endpoint: ${mock_endpoint}
     tls:

--- a/terraform/testcases/otlp_grpc_exporter_trace_mock/otconfig.tpl
+++ b/terraform/testcases/otlp_grpc_exporter_trace_mock/otconfig.tpl
@@ -11,8 +11,6 @@ processors:
   batch:
 
 exporters:
-  logging:
-    verbosity: detailed
   otlp:
     endpoint: ${mock_endpoint}
     tls:

--- a/terraform/testcases/otlp_http_exporter_metric_mock/otconfig.tpl
+++ b/terraform/testcases/otlp_http_exporter_metric_mock/otconfig.tpl
@@ -11,8 +11,6 @@ processors:
   batch:
 
 exporters:
-  logging:
-    verbosity: detailed
   otlphttp:
     metrics_endpoint: "https://${mock_endpoint}"
     tls:

--- a/terraform/testcases/otlp_http_exporter_trace_mock/otconfig.tpl
+++ b/terraform/testcases/otlp_http_exporter_trace_mock/otconfig.tpl
@@ -11,8 +11,6 @@ processors:
   batch:
 
 exporters:
-  logging:
-    verbosity: detailed
   otlphttp:
     traces_endpoint: "https://${mock_endpoint}"
     tls:

--- a/terraform/testcases/otlp_logs/otconfig.tpl
+++ b/terraform/testcases/otlp_logs/otconfig.tpl
@@ -11,8 +11,6 @@ processors:
   batch:
 
 exporters:
-  logging:
-    verbosity: detailed
   awscloudwatchlogs:
     log_group_name: "/aws/ecs/otlp/${testing_id}/logs"
     log_stream_name: "otlp-logs"
@@ -23,7 +21,7 @@ service:
     logs:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging, awscloudwatchlogs]
+      exporters: [awscloudwatchlogs]
   extensions: [pprof]
   telemetry:
     logs:

--- a/terraform/testcases/otlp_metric/otconfig.tpl
+++ b/terraform/testcases/otlp_metric/otconfig.tpl
@@ -11,8 +11,6 @@ processors:
   batch:
 
 exporters:
-  logging:
-    verbosity: detailed
   awsemf:
     region: '${region}'
 
@@ -21,7 +19,7 @@ service:
     metrics:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging, awsemf]
+      exporters: [awsemf]
   extensions: [pprof]
   telemetry:
     logs:

--- a/terraform/testcases/otlp_metric_adot_operator/otconfig.tpl
+++ b/terraform/testcases/otlp_metric_adot_operator/otconfig.tpl
@@ -11,8 +11,6 @@ extensions:
       batch:
 
     exporters:
-      logging:
-        verbosity: detailed
       awsemf:
         region: '${region}'
 
@@ -21,7 +19,7 @@ extensions:
         metrics:
           receivers: [otlp]
           processors: [batch]
-          exporters: [logging,awsemf]
+          exporters: [awsemf]
       extensions: [pprof]
       telemetry:
         logs:

--- a/terraform/testcases/otlp_metric_amp/otconfig.tpl
+++ b/terraform/testcases/otlp_metric_amp/otconfig.tpl
@@ -14,8 +14,6 @@ processors:
   batch:
 
 exporters:
-  logging:
-    verbosity: detailed
   prometheusremotewrite:
     endpoint: ${cortex_instance_endpoint}/api/v1/remote_write
     timeout: 10s
@@ -27,7 +25,7 @@ service:
     metrics:
       receivers: [otlp]
       processors: [batch]
-      exporters: [prometheusremotewrite,logging]
+      exporters: [prometheusremotewrite]
   extensions: [pprof, sigv4auth]
   telemetry:
     logs:

--- a/terraform/testcases/otlp_metric_auto_instrumentation_adot_operator/otconfig.tpl
+++ b/terraform/testcases/otlp_metric_auto_instrumentation_adot_operator/otconfig.tpl
@@ -8,8 +8,6 @@ receivers:
       batch:
 
     exporters:
-      logging:
-        verbosity: detailed
       awsemf:
         region: '${region}'
 
@@ -18,7 +16,7 @@ receivers:
         metrics:
           receivers: [otlp]
           processors: [batch]
-          exporters: [logging,awsemf]
+          exporters: [awsemf]
       telemetry:
         logs:
           level: ${log_level}

--- a/terraform/testcases/otlp_metric_mock/otconfig.tpl
+++ b/terraform/testcases/otlp_metric_mock/otconfig.tpl
@@ -11,8 +11,6 @@ processors:
   batch:
 
 exporters:
-  logging:
-    verbosity: detailed
   awsemf:
     region: ${region}
     endpoint: "https://${mock_endpoint}"
@@ -22,7 +20,7 @@ service:
     metrics:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging, awsemf]
+      exporters: [awsemf]
   extensions: [pprof]
   telemetry:
     logs:

--- a/terraform/testcases/otlp_mock/otconfig.tpl
+++ b/terraform/testcases/otlp_mock/otconfig.tpl
@@ -11,8 +11,6 @@ processors:
   batch:
 
 exporters:
-  logging:
-    verbosity: detailed
   awsxray:
     region: ${region}
     local_mode: true

--- a/terraform/testcases/otlp_trace/otconfig.tpl
+++ b/terraform/testcases/otlp_trace/otconfig.tpl
@@ -11,8 +11,6 @@ processors:
   batch:
 
 exporters:
-  logging:
-    verbosity: detailed
   awsxray:
     local_mode: true
     region: '${region}'
@@ -22,7 +20,7 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging,awsxray]
+      exporters: [awsxray]
   extensions: [pprof]
   telemetry:
     logs:

--- a/terraform/testcases/otlp_trace_adot_operator/otconfig.tpl
+++ b/terraform/testcases/otlp_trace_adot_operator/otconfig.tpl
@@ -11,8 +11,6 @@ extensions:
       batch:
 
     exporters:
-      logging:
-        verbosity: detailed
       awsxray:
         local_mode: true
         region: '${region}'
@@ -22,7 +20,7 @@ extensions:
         traces:
           receivers: [otlp]
           processors: [batch]
-          exporters: [logging,awsxray]
+          exporters: [awsxray]
       extensions: [pprof]
       telemetry:
         logs:

--- a/terraform/testcases/otlp_trace_auto_instrumentation_adot_operator/otconfig.tpl
+++ b/terraform/testcases/otlp_trace_auto_instrumentation_adot_operator/otconfig.tpl
@@ -8,8 +8,6 @@ receivers:
       batch:
 
     exporters:
-      logging:
-        verbosity: detailed
       awsxray:
         local_mode: true
         region: '${region}'
@@ -19,7 +17,7 @@ receivers:
         traces:
           receivers: [otlp]
           processors: [batch]
-          exporters: [logging,awsxray]
+          exporters: [awsxray]
       telemetry:
         logs:
           level: ${log_level}

--- a/terraform/testcases/otlp_trace_resourcedetection_ec2/otconfig.tpl
+++ b/terraform/testcases/otlp_trace_resourcedetection_ec2/otconfig.tpl
@@ -19,8 +19,6 @@ processors:
           - ^tag2$
 
 exporters:
-  logging:
-    verbosity: detailed
   awsxray:
     local_mode: true
     region: '${region}'

--- a/terraform/testcases/otlp_trace_resourcedetection_ecs/otconfig.tpl
+++ b/terraform/testcases/otlp_trace_resourcedetection_ecs/otconfig.tpl
@@ -15,8 +15,6 @@ processors:
       override: false
 
 exporters:
-  logging:
-    verbosity: detailed
   awsxray:
     local_mode: true
     region: '${region}'

--- a/terraform/testcases/otlp_trace_resourcedetection_eks/otconfig.tpl
+++ b/terraform/testcases/otlp_trace_resourcedetection_eks/otconfig.tpl
@@ -15,8 +15,6 @@ processors:
       override: true
 
 exporters:
-  logging:
-    verbosity: detailed
   awsxray:
     local_mode: true
     region: '${region}'

--- a/terraform/testcases/prometheus_sd/otconfig.tpl
+++ b/terraform/testcases/prometheus_sd/otconfig.tpl
@@ -22,13 +22,11 @@ exporters:
     timeout: 10s
     auth:
       authenticator: sigv4auth
-  logging:
-    verbosity: detailed
 service:
   pipelines:
     metrics:
      receivers: [prometheus]
-     exporters: [prometheusremotewrite, logging]
+     exporters: [prometheusremotewrite]
   extensions: [sigv4auth]
   telemetry:
     logs:

--- a/terraform/testcases/prometheus_sd_adot_operator/otconfig.tpl
+++ b/terraform/testcases/prometheus_sd_adot_operator/otconfig.tpl
@@ -22,13 +22,11 @@ extensions:
         timeout: 10s
         auth:
           authenticator: sigv4auth
-      logging:
-        verbosity: detailed
     service:
       pipelines:
         metrics:
           receivers: [prometheus]
-          exporters: [prometheusremotewrite, logging]
+          exporters: [prometheusremotewrite]
       extensions: [sigv4auth]
       telemetry:
         logs:

--- a/terraform/testcases/sapm_exporter_trace_mock/otconfig.tpl
+++ b/terraform/testcases/sapm_exporter_trace_mock/otconfig.tpl
@@ -11,8 +11,6 @@ processors:
   batch:
 
 exporters:
-  logging:
-    verbosity: detailed
   sapm:
     endpoint: "https://${mock_endpoint}"
 

--- a/terraform/testcases/signalfx_exporter_metric_mock/otconfig.tpl
+++ b/terraform/testcases/signalfx_exporter_metric_mock/otconfig.tpl
@@ -11,8 +11,6 @@ processors:
   batch:
 
 exporters:
-  logging:
-    verbosity: detailed
   signalfx:
     access_token: dummytoken
     ingest_url: "https://${mock_endpoint}"

--- a/terraform/testcases/signalfxcorrelation_exporter_trace_mock/otconfig.tpl
+++ b/terraform/testcases/signalfxcorrelation_exporter_trace_mock/otconfig.tpl
@@ -11,8 +11,6 @@ processors:
   batch:
 
 exporters:
-  logging:
-    verbosity: detailed
   signalfx_correlation:
     endpoint: "https://${mock_endpoint}"
 

--- a/terraform/testcases/splunkhec_exporter_trace_mock/otconfig.tpl
+++ b/terraform/testcases/splunkhec_exporter_trace_mock/otconfig.tpl
@@ -11,8 +11,6 @@ processors:
   batch:
 
 exporters:
-  logging:
-    verbosity: detailed
   splunk_hec:
     endpoint: "https://${mock_endpoint}"
     token: dummytoken

--- a/terraform/testcases/standard_otlp_metric_trace/otconfig.tpl
+++ b/terraform/testcases/standard_otlp_metric_trace/otconfig.tpl
@@ -11,8 +11,6 @@ processors:
   batch:
 
 exporters:
-  logging:
-    verbosity: detailed
   awsemf:
     region: ${region}
     no_verify_ssl: false
@@ -26,11 +24,11 @@ service:
     metrics:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging, awsemf]
+      exporters: [awsemf]
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging, awsxray]
+      exporters: [awsxray]
   extensions: [pprof]
   telemetry:
     logs:

--- a/terraform/testcases/statsd/otconfig.tpl
+++ b/terraform/testcases/statsd/otconfig.tpl
@@ -6,13 +6,11 @@ exporters:
   awsemf:
     namespace: '${otel_service_namespace}/${otel_service_name}'
     region: '${region}'
-  logging:
-    verbosity: detailed
 service:
   pipelines:
     metrics:
       receivers: [statsd]
-      exporters: [awsemf, logging]
+      exporters: [awsemf]
   telemetry:
     logs:
       level: ${log_level}

--- a/terraform/testcases/statsd_instscopedisabled/otconfig.tpl
+++ b/terraform/testcases/statsd_instscopedisabled/otconfig.tpl
@@ -6,13 +6,11 @@ exporters:
   awsemf:
     namespace: '${otel_service_namespace}/${otel_service_name}'
     region: '${region}'
-  logging:
-    verbosity: detailed
 service:
   pipelines:
     metrics:
       receivers: [statsd]
-      exporters: [awsemf, logging]
+      exporters: [awsemf]
   telemetry:
     logs:
       level: ${log_level}

--- a/terraform/testcases/statsd_mock/otconfig.tpl
+++ b/terraform/testcases/statsd_mock/otconfig.tpl
@@ -3,8 +3,6 @@ receivers:
     endpoint: 0.0.0.0:${udp_port}
     aggregation_interval: 20s
 exporters:
-  logging:
-    verbosity: detailed
   otlphttp:
     metrics_endpoint: "https://${mock_endpoint}"
     tls:

--- a/terraform/testcases/statsd_nootellib_instScopeEnabled/otconfig.tpl
+++ b/terraform/testcases/statsd_nootellib_instScopeEnabled/otconfig.tpl
@@ -15,13 +15,11 @@ exporters:
           - "statsdTestMetric1h_*"
           - "statsdTestMetric1c_*"
 
-  logging:
-    verbosity: detailed
 service:
   pipelines:
     metrics:
       receivers: [statsd]
-      exporters: [awsemf, logging]
+      exporters: [awsemf]
   telemetry:
     logs:
       level: ${log_level}

--- a/terraform/testcases/statsd_otellib_instScopeEnabled/otconfig.tpl
+++ b/terraform/testcases/statsd_otellib_instScopeEnabled/otconfig.tpl
@@ -6,13 +6,11 @@ exporters:
   awsemf:
     namespace: '${otel_service_namespace}/${otel_service_name}'
     region: '${region}'
-  logging:
-    verbosity: detailed
 service:
   pipelines:
     metrics:
       receivers: [statsd]
-      exporters: [awsemf, logging]
+      exporters: [awsemf]
   telemetry:
     logs:
       level: ${log_level}

--- a/terraform/testcases/xrayreceiver/otconfig.tpl
+++ b/terraform/testcases/xrayreceiver/otconfig.tpl
@@ -10,8 +10,6 @@ processors:
   batch:
 
 exporters:
-  logging:
-    verbosity: detailed
   awsxray:
     local_mode: true
     region: '${region}'

--- a/terraform/testcases/xrayreceiver_mock/otconfig.tpl
+++ b/terraform/testcases/xrayreceiver_mock/otconfig.tpl
@@ -10,8 +10,6 @@ processors:
   batch:
 
 exporters:
-  logging:
-    verbosity: detailed
   awsxray:
     region: ${region}
     local_mode: true

--- a/terraform/testcases/zipkin_mock/otconfig.tpl
+++ b/terraform/testcases/zipkin_mock/otconfig.tpl
@@ -9,8 +9,6 @@ processors:
   batch:
 
 exporters:
-  logging:
-    verbosity: detailed
   otlphttp:
     traces_endpoint: "https://${mock_endpoint}"
     tls:
@@ -22,7 +20,7 @@ service:
     traces:
       receivers: [zipkin]
       processors: [batch]
-      exporters: [otlphttp,logging]
+      exporters: [otlphttp]
   extensions: [pprof]
   telemetry:
     logs:


### PR DESCRIPTION
**Description:** 
Remove otlp_logging environment variable from ecs terraform task definition. Had it added in sample app.

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

