### PR TITLE
Removed otlp_logging env variables from ecs_taskdef

### DIFF
--- a/terraform/templates/defaults/ecs_taskdef.tpl
+++ b/terraform/templates/defaults/ecs_taskdef.tpl
@@ -48,14 +48,6 @@
         {
             "name": "ZIPKIN_RECEIVER_ENDPOINT",
             "value": "127.0.0.1:${http_port}"
-        },
-        {
-            "name": "OTEL_LOGS_EXPORTER",
-            "value": "otlp"
-        },
-        {
-            "name": "SAMPLE_APP_LOG_LEVEL",
-            "value": "INFO"
         }
       ],
       "dependsOn": [


### PR DESCRIPTION
**Description:** 
Removed otlp_logging variable from ecs_task definition as it was added in sample app. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

