### PR TITLE
Adding aws_sdk_2 trace prefix

### DIFF
--- a/validator/src/main/java/com/amazon/aoc/fileconfigs/PredefinedExpectedTemplate.java
+++ b/validator/src/main/java/com/amazon/aoc/fileconfigs/PredefinedExpectedTemplate.java
@@ -60,6 +60,8 @@ public enum PredefinedExpectedTemplate implements FileConfig {
       "/expected-data-template/springboot/springbootAppExpectedHTTPTrace.mustache"),
   SPRINGBOOT_SDK_AWSSDK_EXPECTED_TRACE(
       "/expected-data-template/springboot/springbootAppExpectedAWSSDKTrace.mustache"),
+  SPRINGBOOT_SDK_AWSSDK_2_EXPECTED_TRACE(
+      "/expected-data-template/springboot/springbootAppExpectedAWSSDK2Trace.mustache"),
   GO_SDK_HTTP_EXPECTED_TRACE("/expected-data-template/go/goAppExpectedHTTPTrace.mustache"),
   GO_SDK_AWSSDK_EXPECTED_TRACE("/expected-data-template/go/goAppExpectedAWSSDKTrace.mustache"),
   JS_SDK_HTTP_EXPECTED_TRACE("/expected-data-template/js/jsAppExpectedHTTPTrace.mustache"),

--- a/validator/src/main/resources/expected-data-template/springboot/springbootAppExpectedAWSSDK2Trace.mustache
+++ b/validator/src/main/resources/expected-data-template/springboot/springbootAppExpectedAWSSDK2Trace.mustache
@@ -1,0 +1,31 @@
+[{
+  "name": "aws-otel-integ-test",
+  "http": {
+    "request": {
+      "url": "{{endpoint}}/aws-sdk-call",
+      "method": "GET"
+    },
+    "response": {
+      "status": 200
+    }
+  },
+  "subsegments": [
+    {
+      "subsegments": [
+        {
+          "name": "AWS.SDK.S3",
+          "http": {
+            "request": {
+              "url": "https://s3\\.{{region}}\\.amazonaws\\.com/",
+              "method": "GET"
+            },
+            "response": {
+              "status": 200
+            }
+          },
+          "namespace": "aws"
+        }
+      ]
+    }
+  ]
+}]

--- a/validator/src/main/resources/validations/springboot-otel-trace-metric-validation.yml
+++ b/validator/src/main/resources/validations/springboot-otel-trace-metric-validation.yml
@@ -15,5 +15,5 @@
   httpPath: "/aws-sdk-call"
   httpMethod: "get"
   callingType: "http"
-  expectedTraceTemplate: "SPRINGBOOT_SDK_AWSSDK_EXPECTED_TRACE"
+  expectedTraceTemplate: "SPRINGBOOT_SDK_AWSSDK_2_EXPECTED_TRACE"
   


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
ADOT Java Agent now prefixes like [this](https://github.com/aws-observability/aws-apm-java-instrumentation/blob/2f4cfd531449a59cd256028b7d5bb5dcec1ae93a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGenerator.java#L197) for aws-sdk-2 scoped traces.
which is causing [this](https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/6873043238/job/18692875229) failure.
springboot-otel-trace-metric-validation.yml is not used anywhere else other than for testing springboot app from java agent repo, which is using aws_sdk_2. Made changes accordingly.


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

