### PR TITLE
Remove featuregate flag in logs test bed

### DIFF
--- a/adot-testbed/app/src/test/java/software/amazon/adot/testbed/LogsTests.java
+++ b/adot-testbed/app/src/test/java/software/amazon/adot/testbed/LogsTests.java
@@ -85,7 +85,7 @@ class LogsTests {
             .withEnv(envVariables)
             .withCreateContainerCmdModifier(cmd -> cmd.withUser("root"))
             .withClasspathResourceMapping("/logs", "/logs", BindMode.READ_WRITE)
-            .withCommand("--config", "/etc/collector/config.yaml", "--feature-gates=+adot.receiver.filelog,+adot.exporter.awscloudwatchlogs,+adot.extension.file_storage");
+            .withCommand("--config", "/etc/collector/config.yaml");
 
        //Mount the Temp directory
         collector.withFileSystemBind(logDirectory.toString(),"/tempLogs", BindMode.READ_WRITE);


### PR DESCRIPTION
Remove Feature gate flag for starting the collector, the log components are no longer behind the feature gate in adot collector - main branch.

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

