### PR TITLE
Changed line to prevent IndexOutOfBoundsException

### DIFF
--- a/load-generator/src/main/java/com/amazon/opentelemetry/load/generator/emitter/OtlpMetricEmitter.java
+++ b/load-generator/src/main/java/com/amazon/opentelemetry/load/generator/emitter/OtlpMetricEmitter.java
@@ -119,7 +119,7 @@ public class OtlpMetricEmitter extends MetricEmitter {
     if(meter!= null) {
       log.info("Registering counter metrics...");
       counters = new LongCounter[param.getDatapointCount()];
-      for(int id=0 ; id < param.getMetricCount(); id++) {
+      for(int id=0 ; id < param.getDatapointCount(); id++) {
         counters[id] = meter.counterBuilder(API_COUNTER_METRIC + id)
                 .setDescription("API request load sent in bytes")
                 .setUnit("one")


### PR DESCRIPTION
**Description:**

I was getting an IndexOutOfBoundsException in LoadGenerator when I tried running .`/gradlew :load-generator:run --args="metric --metricCount=100 --datapointCount=10 --observationInterval=1000 --flushInterval=1000 --metricType=counter -u=localhost:4317 -d=otlp"`



<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

