### PR TITLE
fix regression - Remove featuregate flag and run as container as root

### DIFF
--- a/adot-testbed/app/src/test/java/software/amazon/adot/testbed/CollectorSetup.java
+++ b/adot-testbed/app/src/test/java/software/amazon/adot/testbed/CollectorSetup.java
@@ -55,8 +55,9 @@ abstract class CollectorSetup {
             .withLogConsumer(new Slf4jLogConsumer(collectorLogger))
             .waitingFor(Wait.forLogMessage(".*Everything is ready. Begin running and processing data.*", 1))
             .withEnv(createCollectorEnvVars(logStreamName))
+            .withCreateContainerCmdModifier(cmd -> cmd.withUser("root"))
             .withClasspathResourceMapping("/logs", "/logs", BindMode.READ_WRITE)
-            .withCommand("--config", "/etc/collector/config.yaml", "--feature-gates=+adot.receiver.filelog,+adot.exporter.awscloudwatchlogs,+adot.extension.file_storage");
+            .withCommand("--config", "/etc/collector/config.yaml");
 
         //Mount the Temp directory
         collector.withFileSystemBind(logDirectory.toString(),"/tempLogs", BindMode.READ_WRITE);


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

https://github.com/aws-observability/aws-otel-test-framework/pull/1474 undid the changes in commits https://github.com/aws-observability/aws-otel-test-framework/pull/1468 and https://github.com/aws-observability/aws-otel-test-framework/pull/1500
This [failed the testbed job](https://github.com/aws-observability/aws-otel-collector/actions/runs/7253011430/job/19759715304) using the latest test image - `public.ecr.aws/aws-otel-test/adot-collector-integration-test:v0.36.0-4cb5808a.`

This fix brings back the previous undone changes.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>
[Reproduced testbed error](https://github.com/jj22ee/aws-otel-collector/actions/runs/7253548583/job/19760368067) in forked modified workflow using latest test image
After implementing this fix, the [workflow job now succeeds](https://github.com/jj22ee/aws-otel-collector/actions/runs/7253651081/job/19760701994)

**Documentation:** <Describe the documentation added.>

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

