### PR TITLE
Add depends_on for the validator to wait

### DIFF
--- a/terraform/eks/main.tf
+++ b/terraform/eks/main.tf
@@ -235,7 +235,7 @@ module "validator" {
     module.adot_operator,
     kubectl_manifest.logs_sample_fargate_deploy,
     null_resource.prom_base_ready_check,
+    null_resource.aoc_deployment_adot_operator,
     kubernetes_deployment.aoc_deployment,
   ]
 }
-


### PR DESCRIPTION
**Description:**
Add depends_on for the validator to wait till the operator is deployed.

Testing:

```
s.xray.auto_instrumentation=true, [2].aws.xray.sdk_version=1.32.0, [2].aws.xray.sdk=opentelemetry for java, [2].aws.operation=ListBuckets, [2].aws.request_id=X4JVR2R7B78G83R4}
module.validator.null_resource.validator (local-exec): eks-validator-1  | 14:22:24.802 [main] INFO  com.amazon.aoc.validators.TraceValidator - validation is passed for path /aws-sdk-call
module.validator.null_resource.validator (local-exec): eks-validator-1  | 14:22:24.805 [main] INFO  com.amazon.aoc.App - Validation has completed in 1 minutes.
module.validator.null_resource.validator (local-exec): eks-validator-1 exited with code 0

```

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

