### PR TITLE
Signalfx config change to drop dimensions

### DIFF
--- a/terraform/testcases/signalfx_exporter_metric_mock/otconfig.tpl
+++ b/terraform/testcases/signalfx_exporter_metric_mock/otconfig.tpl
@@ -15,6 +15,31 @@ exporters:
     access_token: dummytoken
     ingest_url: "https://${mock_endpoint}"
     api_url: "http://localhost/dummy_url"
+    translation_rules:
+    - action: drop_dimensions
+      metric_names:
+        http.server.duration_count: true
+        http.server.duration_sum: true
+        http.server.duration_min: true
+        http.server.duration_max: true
+        http.server.duration_bucket: true
+        process.runtime.jvm.memory.usage: true
+      dimension_pairs:
+        "aws.ecs.container.arn":
+        "aws.ecs.container.image.id":
+        "aws.ecs.launchtype":
+        "aws.ecs.task.arn":
+        "aws.ecs.task.family":
+        "aws.ecs.task.revision":
+        "aws.log.group.arns":
+        "aws.log.group.names":
+        "aws.log.stream.arns":
+        "aws.log.stream.names":
+        "cloud.account.id":
+        "cloud.availability_zone":
+        "cloud.platform":
+        "cloud.provider":
+        "cloud.region":
 
 service:
   pipelines:


### PR DESCRIPTION
**Description:** 

During mock test the signalfx exporter is dropping metrics due to long list of dimensions, dropping dimensions to let the export continue.

Tested locally

```
module.validator[0].null_resource.validator (local-exec): validator-1  | 19:42:16.260 [main] INFO  com.amazon.aoc.validators.MockedServerValidator - mocked server validation passed
module.validator[0].null_resource.validator (local-exec): validator-1  | 19:42:16.260 [main] INFO  com.amazon.aoc.App - Validation has completed in 5 minutes.
module.validator[0].null_resource.validator (local-exec): validator-1 exited with code 0

```

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

