### PR TITLE
Set collector image and tag in helm chart (#1627)

### DIFF
--- a/terraform/eks/adot-operator/adot_operator.tf
+++ b/terraform/eks/adot-operator/adot_operator.tf
@@ -29,6 +29,12 @@ variable "operator_repository" {
 variable "operator_tag" {
 }
 
+variable "aoc_image_repo" {
+}
+
+variable "aoc_version" {
+}
+
 resource "helm_release" "adot-operator" {
   name = "adot-operator-${var.testing_id}"
 
@@ -47,6 +53,16 @@ resource "helm_release" "adot-operator" {
   set {
     name  = "manager.image.tag"
     value = var.operator_tag
+  }
+
+  set {
+    name  = "manager.collectorImage.tag"
+    value = var.aoc_version
+  }
+
+  set {
+    name  = "manager.collectorImage.repository"
+    value = var.aoc_image_repo
   }
 
   provisioner "local-exec" {

--- a/terraform/eks/main.tf
+++ b/terraform/eks/main.tf
@@ -180,6 +180,8 @@ module "adot_operator" {
   kubeconfig          = local_file.kubeconfig.filename
   operator_repository = var.operator_repository
   operator_tag        = var.operator_tag
+  aoc_image_repo      = var.aoc_image_repo
+  aoc_version         = var.aoc_version
 }
 
 


### PR DESCRIPTION
Backport https://github.com/aws-observability/aws-otel-test-framework/pull/1627 to 1.32.x release branch to unblock 1.32.2 patch.

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

