### PR TITLE
Allow test cases to specify arguments for the collector

### DIFF
--- a/terraform/mock/main.tf
+++ b/terraform/mock/main.tf
@@ -23,6 +23,7 @@ locals {
   otconfig_template_path = fileexists("${var.testcase}/otconfig.tpl") ? "${var.testcase}/otconfig.tpl" : module.common.default_otconfig_path
   otconfig_file_path     = "./otconfig.yml"
   docker_compose_path    = "./docker_compose.yml"
+  collector_args         = concat(["--config=/tmp/otconfig.yaml"], var.otconfig_args)
 
   mock_endpoint             = var.mock_endpoint
   sample_app_listen_address = "${module.common.sample_app_listen_address_ip}:${module.common.sample_app_listen_address_port}"
@@ -59,7 +60,7 @@ data "template_file" "docker_compose" {
 
   vars = {
     collector_repo_path            = var.collector_repo_path
-    otconfig_path                  = local.otconfig_file_path
+    collector_args                 = jsonencode(local.collector_args)
     grpc_port                      = module.common.grpc_port
     udp_port                       = module.common.udp_port
     http_port                      = module.common.http_port

--- a/terraform/mock/variables.tf
+++ b/terraform/mock/variables.tf
@@ -21,5 +21,6 @@ variable "mock_endpoint" {
   default = "mocked-server/put-data"
 }
 
-
-
+variable "otconfig_args" {
+  default = []
+}

--- a/terraform/templates/local/docker_compose.tpl
+++ b/terraform/templates/local/docker_compose.tpl
@@ -15,7 +15,7 @@ services:
       args:
         BUILDMODE: copy
 
-    command: ["--config=/tmp/otconfig.yaml"]
+    command: ${collector_args}
     volumes:
       - ./otconfig.yml:/tmp/otconfig.yaml
       - "../../mocked_servers/https/certificates/ssl/certificate.crt:/etc/ssl/certs/ca-certificates.crt"

--- a/terraform/testcases/datadog_exporter_metric_mock/parameters.tfvars
+++ b/terraform/testcases/datadog_exporter_metric_mock/parameters.tfvars
@@ -4,3 +4,5 @@ soaking_data_mode = "metric"
 sample_app = "spark"
 
 sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
+
+otconfig_args = ["--feature-gates=-adot.exporter.datadogexporter.deprecation"]

--- a/terraform/testcases/datadog_exporter_trace_mock/parameters.tfvars
+++ b/terraform/testcases/datadog_exporter_trace_mock/parameters.tfvars
@@ -4,3 +4,5 @@ soaking_data_mode = "trace"
 sample_app = "spark"
 
 sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
+
+otconfig_args = ["--feature-gates=-adot.exporter.datadogexporter.deprecation"]

--- a/terraform/testcases/logzio_exporter_trace_mock/parameters.tfvars
+++ b/terraform/testcases/logzio_exporter_trace_mock/parameters.tfvars
@@ -4,3 +4,5 @@ soaking_data_mode = "trace"
 sample_app = "spark"
 
 sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
+
+otconfig_args = ["--feature-gates=-adot.exporter.logzioexporter.deprecation"]

--- a/terraform/testcases/sapm_exporter_trace_mock/parameters.tfvars
+++ b/terraform/testcases/sapm_exporter_trace_mock/parameters.tfvars
@@ -4,3 +4,5 @@ soaking_data_mode = "trace"
 sample_app = "spark"
 
 sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
+
+otconfig_args = ["--feature-gates=-adot.exporter.sapmexporter.deprecation"]

--- a/terraform/testcases/signalfx_exporter_metric_mock/parameters.tfvars
+++ b/terraform/testcases/signalfx_exporter_metric_mock/parameters.tfvars
@@ -4,3 +4,5 @@ soaking_data_mode = "metric"
 sample_app = "spark"
 
 sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
+
+otconfig_args = ["--feature-gates=-adot.exporter.signalfxexporter.deprecation"]


### PR DESCRIPTION
This is used to disable feature gates that effect the removal of deprecated components, allowing them to continue to be tested until they are fully removed.

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

