### PR TITLE
Update E2E Collector tests to use different collector names for each concurrent test

### DIFF
--- a/terraform/eks/adot-operator/adot_collector_deployment.tpl
+++ b/terraform/eks/adot-operator/adot_collector_deployment.tpl
@@ -1,7 +1,7 @@
 apiVersion: opentelemetry.io/v1alpha1
 kind: OpenTelemetryCollector
 metadata:
-  name: aoc
+  name: ${AOC_NAME}
   namespace: ${AOC_NAMESPACE}
 spec:
   image: ${AOC_IMAGE}

--- a/terraform/eks/otlp.tf
+++ b/terraform/eks/otlp.tf
@@ -273,6 +273,7 @@ data "template_file" "adot_collector_config_file" {
   template = file("./adot-operator/adot_collector_deployment.tpl")
 
   vars = {
+    AOC_NAME           = var.deployment_type == "fargate" ? "aoc-fargate" : "aoc"
     AOC_NAMESPACE      = var.deployment_type == "fargate" ? kubernetes_namespace.aoc_fargate_ns.metadata[0].name : kubernetes_namespace.aoc_ns.metadata[0].name
     AOC_IMAGE          = module.common.aoc_image
     AOC_DEPLOY_MODE    = var.aoc_deploy_mode


### PR DESCRIPTION
**Description:** 
We suspect that between this commit https://github.com/open-telemetry/opentelemetry-operator/pull/2787/files - `When two Collectors are created with the same name but different namespaces, the ClusterRoleBinding created by the first will be overriden by the second one` and this commit https://github.com/open-telemetry/opentelemetry-operator/pull/2938/files - `Cleanup ClusterRoles and ClusterRoleBindings created by the operator ... The operator uses finalizer on the collector to run the cleanup`, having multiple collectors with the same name is causing test failures like https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/9879456604/job/27295225403

In this commit, we are changing the E2E collector tests for fargate/non-fargate (which run concurrently) to use different collector names to ameliorate the test failures.

Note: `AOC_NAMESPACE` is not used anywhere else: 
* https://github.com/search?q=repo%3Aaws-observability%2Faws-otel-test-framework%20AOC_NAMESPACE&type=code
* https://github.com/search?q=repo%3Aaws-observability%2Faws-otel-java-instrumentation%20AOC_NAMESPACE&type=code

**Link to tracking Issue:** N/A

**Testing:** N/A

**Documentation:** N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

