### PR TITLE
Fix OTEL Operator version for E2E Operator EKS tests and revert previous fix attempt

### DIFF
--- a/terraform/eks/adot-operator/adot_collector_deployment.tpl
+++ b/terraform/eks/adot-operator/adot_collector_deployment.tpl
@@ -1,7 +1,7 @@
 apiVersion: opentelemetry.io/v1alpha1
 kind: OpenTelemetryCollector
 metadata:
-  name: ${AOC_NAME}
+  name: aoc
   namespace: ${AOC_NAMESPACE}
 spec:
   image: ${AOC_IMAGE}

--- a/terraform/eks/otlp.tf
+++ b/terraform/eks/otlp.tf
@@ -273,7 +273,6 @@ data "template_file" "adot_collector_config_file" {
   template = file("./adot-operator/adot_collector_deployment.tpl")
 
   vars = {
-    AOC_NAME           = var.deployment_type == "fargate" ? "aoc-fargate" : "aoc"
     AOC_NAMESPACE      = var.deployment_type == "fargate" ? kubernetes_namespace.aoc_fargate_ns.metadata[0].name : kubernetes_namespace.aoc_ns.metadata[0].name
     AOC_IMAGE          = module.common.aoc_image
     AOC_DEPLOY_MODE    = var.aoc_deploy_mode

--- a/terraform/eks/variables.tf
+++ b/terraform/eks/variables.tf
@@ -63,7 +63,7 @@ variable "operator_repository" {
 
 variable "operator_tag" {
   type    = string
-  default = "latest"
+  default = "v0.99.0"
 }
 
 // This will only fetch data from the MSK cluster in case this value is set


### PR DESCRIPTION
**Description:** 
We recently observed that main build was failing in ADOT Java repo, and failures started after May 20th, when OTEL Operator v0.100.0 was released, adding finalizer logic that we believe to be incompatible with our test framework. As a short term measure, we are fixing the OTEL Operator version to v0.99.0, the last known healthy version (as the test was passing on May 17th, when v0.99.0 was latest).

Also in this PR, we are reverting a previous change that attempted to rename the Collector, as we thought there was some problem with a duplicate naming, though this only introduced new problems.

**Link to tracking Issue:** N/A

**Testing:** N/A

**Documentation:** N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.