### PR TITLE
Update to use docker compose

### DIFF
--- a/terraform/ecs/Makefile
+++ b/terraform/ecs/Makefile
@@ -6,7 +6,7 @@ validate:
 # You can modify this to whatever temp credential helper you have if your ~/.aws is using credential_process
 # The docker compose file mount ~/.aws into the container for getting AWS credential
 #	awsl isengard get > creds.env
-	docker-compose -f validator_docker_compose.yml up
+	docker compose -f validator_docker_compose.yml up
 
 build:
-	docker-compose -f validator_docker_compose.yml build
+	docker compose -f validator_docker_compose.yml build

--- a/terraform/mock/main.tf
+++ b/terraform/mock/main.tf
@@ -84,9 +84,9 @@ resource "local_file" "write_docker_compose_file" {
 resource "null_resource" "run_docker_compose" {
   provisioner "local-exec" {
     command = <<-EOT
-      docker-compose -f ${local.docker_compose_path} down
-      docker-compose -f ${local.docker_compose_path} build
-      docker-compose -f ${local.docker_compose_path} up -d
+      docker compose -f ${local.docker_compose_path} down
+      docker compose -f ${local.docker_compose_path} build
+      docker compose -f ${local.docker_compose_path} up -d
     EOT
   }
 }

--- a/terraform/validation/main.tf
+++ b/terraform/validation/main.tf
@@ -64,9 +64,9 @@ resource "local_file" "docker_compose_file" {
 resource "null_resource" "validator" {
   provisioner "local-exec" {
     command = <<-EOT
-      docker-compose -f ${local.docker_compose_path} down
-      docker-compose -f ${local.docker_compose_path} build
-      docker-compose -f ${local.docker_compose_path} up --abort-on-container-exit
+      docker compose -f ${local.docker_compose_path} down
+      docker compose -f ${local.docker_compose_path} build
+      docker compose -f ${local.docker_compose_path} up --abort-on-container-exit
     EOT
   }
 


### PR DESCRIPTION
**Description:** Updating docker-compose to docker compose, see https://github.com/orgs/community/discussions/116610

**Testing:**
ran ``terraform apply -var="testcase=../testcases/otlp_mock" -var-file="../testcases/otlp_mock/parameters.tfvars"``

Before change 
```
│ Error: local-exec provisioner error
│ 
│   with null_resource.run_docker_compose,
│   on main.tf line 85, in resource "null_resource" "run_docker_compose":
│   85:   provisioner "local-exec" {
│ 
│ Error running command 'docker-compose -f ./docker_compose.yml down
│ docker-compose -f ./docker_compose.yml build
│ docker-compose -f ./docker_compose.yml up -d
│ ': exit status 127. Output: /bin/sh: docker-compose: command not found
│ /bin/sh: line 1: docker-compose: command not found
│ /bin/sh: line 2: docker-compose: command not found
```

After change
```
Apply complete! Resources: 3 added, 0 changed, 1 destroyed.
```


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

