### PR TITLE
use debug exporter in place of logging exporter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,8 +67,10 @@ tools/batchTestGenerator/batchTestGenerator
 # ignore any generated test-case-batch files
 test-case-batch
 
-# ignore java validator bin
+# ignore java project bin dirs
 validator/bin
+load-generator/bin
+trace-java-client/bin
 
 .vscode
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -58,7 +58,7 @@ an example:
 receivers:
   awsecscontainermetrics:
 exporters:
-  logging:
+  debug:
     verbosity: detailed
   awsemf:
     namespace: '${otel_service_namespace}/${otel_service_name}'
@@ -68,7 +68,7 @@ service:
   pipelines:
     metrics:
       receivers: [awsecscontainermetrics]
-      exporters: [logging, awsemf]
+      exporters: [debug, awsemf]
 ```
 
 #### 3.2 ecs task definition 

--- a/terraform/eks/container-insights-agent/config_map_fargate.yml
+++ b/terraform/eks/container-insights-agent/config_map_fargate.yml
@@ -429,7 +429,7 @@ data:
               - pod_network_rx_bytes
               - pod_network_tx_bytes
 
-      logging:
+      debug:
         verbosity: detailed
 
     extensions:
@@ -440,5 +440,5 @@ data:
         metrics:
           receivers: [prometheus]
           processors: [metricstransform/label_1, resourcedetection, metricstransform/rename, filter, cumulativetodelta, deltatorate, experimental_metricsgeneration/1, experimental_metricsgeneration/2, metricstransform/label_2, batch]
-          exporters: [logging, awsemf]
+          exporters: [debug, awsemf]
       extensions: [health_check]

--- a/terraform/templates/defaults/otconfig.tpl
+++ b/terraform/templates/defaults/otconfig.tpl
@@ -20,7 +20,7 @@ processors:
     timeout: 60s
 
 exporters:
-  logging:
+  debug:
     verbosity: detailed
   awsxray:
     local_mode: true
@@ -33,11 +33,11 @@ service:
     traces:
       receivers: [otlp, awsxray]
       processors: [batch/traces]
-      exporters: [logging, awsxray]
+      exporters: [debug, awsxray]
     metrics:
       receivers: [otlp]
       processors: [batch/metrics]
-      exporters: [logging, awsemf]
+      exporters: [debug, awsemf]
   telemetry:
     logs:
       level: debug

--- a/terraform/testcases/ecshealthcheck/otconfig.tpl
+++ b/terraform/testcases/ecshealthcheck/otconfig.tpl
@@ -10,12 +10,12 @@ receivers:
         static_configs:
         - targets: [ ${sample_app_listen_address_host}:${sample_app_listen_address_port} ]
 exporters:
-  logging:
+  debug:
 service:
   pipelines:
     metrics:
      receivers: [prometheus]
-     exporters: [logging]
+     exporters: [debug]
   extensions: [health_check]
   telemetry:
     logs:

--- a/terraform/testcases/otlp_trace_loadbalancing/otconfig.tpl
+++ b/terraform/testcases/otlp_trace_loadbalancing/otconfig.tpl
@@ -45,7 +45,7 @@ processors:
     
 
 exporters:
-  logging:
+  debug:
   loadbalancing:
     protocol:
       otlp:


### PR DESCRIPTION
**Description:** Changes use of deprecated `logging` exporter to `debug` exporter in collector configurations.

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

