### PR TITLE
update AMI search pattern for SUSE15

### DIFF
--- a/terraform/ec2/amis.tf
+++ b/terraform/ec2/amis.tf
@@ -328,7 +328,7 @@ EOF
     # Suse Distribution
     suse15 = {
       os_family          = "suse"
-      ami_search_pattern = "suse-sles-15*"
+      ami_search_pattern = "suse-sles-15-sp5-v????????-hvm-ssd-x86_64"
       ami_owner          = "amazon"
       ami_product_code   = []
       family             = "linux"
@@ -345,7 +345,7 @@ EOF
     }
     arm_suse15 = {
       os_family          = "suse"
-      ami_search_pattern = "suse-sles-15*"
+      ami_search_pattern = "suse-sles-15-sp5-v????????-hvm-ssd-arm64"
       ami_owner          = "amazon"
       ami_product_code   = []
       family             = "linux"


### PR DESCRIPTION
**Description:** 
Update AMI search pattern for SUSE15. Seems like the original search pattern is too permissive.


**Link to tracking Issue:** <Issue number if applicable>

**Testing:** 
I see `suse-sles-15-sp5-v20240822-hvm-ssd-x86_64` and `suse-sles-15-sp5-v20240822-hvm-ssd-arm64`

**Documentation:** <Describe the documentation added.>

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

