### PR TITLE
Update adot operator to 0.70.0

### DIFF
--- a/terraform/eks/adot-operator/adot_operator.tf
+++ b/terraform/eks/adot-operator/adot_operator.tf
@@ -46,7 +46,7 @@ resource "helm_release" "adot-operator" {
 
   repository = "https://open-telemetry.github.io/opentelemetry-helm-charts"
   chart      = "opentelemetry-operator"
-  version    = "0.63.2"
+  version    = "0.70.0"
   namespace  = "adot-operator-${var.testing_id}-ns"
   wait       = true
   timeout    = 600


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Updates to 0.70.0 which includes operator version 0.109.0 
https://github.com/open-telemetry/opentelemetry-helm-charts/compare/opentelemetry-kube-stack-0.2.3...opentelemetry-operator-0.70.0


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

