### PR TITLE
Update otel operator to 0.70.0 in release branch

### DIFF
--- a/terraform/eks/adot-operator/adot_operator.tf
+++ b/terraform/eks/adot-operator/adot_operator.tf
@@ -46,7 +46,7 @@ resource "helm_release" "adot-operator" {
 
   repository = "https://open-telemetry.github.io/opentelemetry-helm-charts"
   chart      = "opentelemetry-operator"
-  version    = "0.63.2"
+  version    = "0.70.0"
   namespace  = "adot-operator-${var.testing_id}-ns"
   wait       = true
   timeout    = 600


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Setting this to 0.70.0  in release branch 0.41.x since its used in test


Uses: aws-observability/aws-otel-operator/.github/workflows/operator-eks-test.yaml@refs/heads/release/v0.109.x (1975d81c78e1c2fada6dddb43900f63193be91f3)
 Inputs
 ADOTCollectorVersion: v0.41.1

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

