### PR TITLE
Pin Spark image to commit-id tag instead of latest

### DIFF
--- a/terraform/eks/container-insights-agent/config_map_fargate.yml
+++ b/terraform/eks/container-insights-agent/config_map_fargate.yml
@@ -331,7 +331,7 @@ data:
           - new_container_memory_hierarchical_pgfault
           - new_container_memory_hierarchical_pgmajfault
 
-      metricsgeneration/1:
+      experimental_metricsgeneration/1:
         rules:
           - name: pod_network_total_bytes
             unit: Bytes/Second
@@ -360,7 +360,7 @@ data:
             operation: divide
             scale_by: 100
 
-      metricsgeneration/2:
+      experimental_metricsgeneration/2:
         rules:
           - name: pod_cpu_utilization_over_pod_limit_${TestingId}
             type: calculate
@@ -439,6 +439,6 @@ data:
       pipelines:
         metrics:
           receivers: [prometheus]
-          processors: [metricstransform/label_1, resourcedetection, metricstransform/rename, filter, cumulativetodelta, deltatorate, metricsgeneration/1, metricsgeneration/2, metricstransform/label_2, batch]
+          processors: [metricstransform/label_1, resourcedetection, metricstransform/rename, filter, cumulativetodelta, deltatorate, experimental_metricsgeneration/1, experimental_metricsgeneration/2, metricstransform/label_2, batch]
           exporters: [debug, awsemf]
       extensions: [health_check]

--- a/terraform/eks/container-insights-agent/config_map_fargate.yml
+++ b/terraform/eks/container-insights-agent/config_map_fargate.yml
@@ -331,7 +331,7 @@ data:
           - new_container_memory_hierarchical_pgfault
           - new_container_memory_hierarchical_pgmajfault
 
-      experimental_metricsgeneration/1:
+      metricsgeneration/1:
         rules:
           - name: pod_network_total_bytes
             unit: Bytes/Second
@@ -360,7 +360,7 @@ data:
             operation: divide
             scale_by: 100
 
-      experimental_metricsgeneration/2:
+      metricsgeneration/2:
         rules:
           - name: pod_cpu_utilization_over_pod_limit_${TestingId}
             type: calculate
@@ -439,6 +439,6 @@ data:
       pipelines:
         metrics:
           receivers: [prometheus]
-          processors: [metricstransform/label_1, resourcedetection, metricstransform/rename, filter, cumulativetodelta, deltatorate, experimental_metricsgeneration/1, experimental_metricsgeneration/2, metricstransform/label_2, batch]
+          processors: [metricstransform/label_1, resourcedetection, metricstransform/rename, filter, cumulativetodelta, deltatorate, metricsgeneration/1, metricsgeneration/2, metricstransform/label_2, batch]
           exporters: [debug, awsemf]
       extensions: [health_check]

--- a/terraform/testcases/configmap_provider_http/parameters.tfvars
+++ b/terraform/testcases/configmap_provider_http/parameters.tfvars
@@ -2,7 +2,7 @@ validation_config = "spark-otel-metric-validation-testing-id.yml"
 
 sample_app = "spark"
 
-sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:f3c87ee4c0e3fc7cd8bf6d0eb7d8e570f75ae6dc"
 
 configuration_source = "http"
 

--- a/terraform/testcases/configmap_provider_https/parameters.tfvars
+++ b/terraform/testcases/configmap_provider_https/parameters.tfvars
@@ -2,7 +2,7 @@ validation_config = "spark-otel-metric-validation-testing-id.yml"
 
 sample_app = "spark"
 
-sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:f3c87ee4c0e3fc7cd8bf6d0eb7d8e570f75ae6dc"
 
 configuration_source  = "https"
 ecs_taskdef_directory = "configmap-providers"

--- a/terraform/testcases/configmap_provider_s3/parameters.tfvars
+++ b/terraform/testcases/configmap_provider_s3/parameters.tfvars
@@ -2,7 +2,7 @@ validation_config = "spark-otel-metric-validation-testing-id.yml"
 
 sample_app = "spark"
 
-sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:f3c87ee4c0e3fc7cd8bf6d0eb7d8e570f75ae6dc"
 
 configuration_source = "s3"
 

--- a/terraform/testcases/datadog_exporter_metric_mock/parameters.tfvars
+++ b/terraform/testcases/datadog_exporter_metric_mock/parameters.tfvars
@@ -3,6 +3,6 @@ soaking_data_mode = "metric"
 
 sample_app = "spark"
 
-sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:f3c87ee4c0e3fc7cd8bf6d0eb7d8e570f75ae6dc"
 
 otconfig_args = ["--feature-gates=-adot.exporter.datadogexporter.deprecation"]

--- a/terraform/testcases/datadog_exporter_trace_mock/parameters.tfvars
+++ b/terraform/testcases/datadog_exporter_trace_mock/parameters.tfvars
@@ -3,6 +3,6 @@ soaking_data_mode = "trace"
 
 sample_app = "spark"
 
-sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:f3c87ee4c0e3fc7cd8bf6d0eb7d8e570f75ae6dc"
 
 otconfig_args = ["--feature-gates=-adot.exporter.datadogexporter.deprecation"]

--- a/terraform/testcases/kafka_otlp_metric_2_8_1/parameters.tfvars
+++ b/terraform/testcases/kafka_otlp_metric_2_8_1/parameters.tfvars
@@ -2,6 +2,6 @@ validation_config = "spark-otel-metric-validation.yml"
 
 sample_app = "spark"
 
-sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:f3c87ee4c0e3fc7cd8bf6d0eb7d8e570f75ae6dc"
 
 kafka_version = "2.8.1"

--- a/terraform/testcases/kafka_otlp_metric_3_2_0/parameters.tfvars
+++ b/terraform/testcases/kafka_otlp_metric_3_2_0/parameters.tfvars
@@ -2,6 +2,6 @@ validation_config = "spark-otel-metric-validation.yml"
 
 sample_app = "spark"
 
-sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:f3c87ee4c0e3fc7cd8bf6d0eb7d8e570f75ae6dc"
 
 kafka_version = "3.2.0"

--- a/terraform/testcases/kafka_otlp_metric_mock_2_8_1/parameters.tfvars
+++ b/terraform/testcases/kafka_otlp_metric_mock_2_8_1/parameters.tfvars
@@ -3,6 +3,6 @@ soaking_data_mode = "metric"
 
 sample_app = "spark"
 
-sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:f3c87ee4c0e3fc7cd8bf6d0eb7d8e570f75ae6dc"
 
 kafka_version = "2.8.1"

--- a/terraform/testcases/kafka_otlp_metric_mock_3_2_0/parameters.tfvars
+++ b/terraform/testcases/kafka_otlp_metric_mock_3_2_0/parameters.tfvars
@@ -3,6 +3,6 @@ soaking_data_mode = "metric"
 
 sample_app = "spark"
 
-sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:f3c87ee4c0e3fc7cd8bf6d0eb7d8e570f75ae6dc"
 
 kafka_version = "3.2.0"

--- a/terraform/testcases/kafka_otlp_mock_2_8_1/parameters.tfvars
+++ b/terraform/testcases/kafka_otlp_mock_2_8_1/parameters.tfvars
@@ -3,6 +3,6 @@ soaking_data_mode = "trace"
 
 sample_app = "spark"
 
-sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:f3c87ee4c0e3fc7cd8bf6d0eb7d8e570f75ae6dc"
 
 kafka_version = "2.8.1"

--- a/terraform/testcases/kafka_otlp_mock_3_2_0/parameters.tfvars
+++ b/terraform/testcases/kafka_otlp_mock_3_2_0/parameters.tfvars
@@ -3,6 +3,6 @@ soaking_data_mode = "trace"
 
 sample_app = "spark"
 
-sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:f3c87ee4c0e3fc7cd8bf6d0eb7d8e570f75ae6dc"
 
 kafka_version = "3.2.0"

--- a/terraform/testcases/kafka_otlp_trace_2_8_1/parameters.tfvars
+++ b/terraform/testcases/kafka_otlp_trace_2_8_1/parameters.tfvars
@@ -5,6 +5,6 @@ soaking_data_mode = "trace"
 
 sample_app = "spark"
 
-sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:f3c87ee4c0e3fc7cd8bf6d0eb7d8e570f75ae6dc"
 
 kafka_version = "2.8.1"

--- a/terraform/testcases/kafka_otlp_trace_3_2_0/parameters.tfvars
+++ b/terraform/testcases/kafka_otlp_trace_3_2_0/parameters.tfvars
@@ -5,6 +5,6 @@ soaking_data_mode = "trace"
 
 sample_app = "spark"
 
-sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:f3c87ee4c0e3fc7cd8bf6d0eb7d8e570f75ae6dc"
 
 kafka_version = "3.2.0"

--- a/terraform/testcases/logzio_exporter_trace_mock/parameters.tfvars
+++ b/terraform/testcases/logzio_exporter_trace_mock/parameters.tfvars
@@ -3,6 +3,6 @@ soaking_data_mode = "trace"
 
 sample_app = "spark"
 
-sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:f3c87ee4c0e3fc7cd8bf6d0eb7d8e570f75ae6dc"
 
 otconfig_args = ["--feature-gates=-adot.exporter.logzioexporter.deprecation"]

--- a/terraform/testcases/newrelic_exporter_metric_mock/parameters.tfvars
+++ b/terraform/testcases/newrelic_exporter_metric_mock/parameters.tfvars
@@ -4,4 +4,4 @@ mock_endpoint     = "mocked-server"
 
 sample_app = "spark"
 
-sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:f3c87ee4c0e3fc7cd8bf6d0eb7d8e570f75ae6dc"

--- a/terraform/testcases/newrelic_exporter_trace_mock/parameters.tfvars
+++ b/terraform/testcases/newrelic_exporter_trace_mock/parameters.tfvars
@@ -4,4 +4,4 @@ mock_endpoint     = "mocked-server"
 
 sample_app = "spark"
 
-sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:f3c87ee4c0e3fc7cd8bf6d0eb7d8e570f75ae6dc"

--- a/terraform/testcases/otlp_groupbytrace_tailsampling_mock/parameters.tfvars
+++ b/terraform/testcases/otlp_groupbytrace_tailsampling_mock/parameters.tfvars
@@ -3,4 +3,4 @@ soaking_data_mode = "trace"
 
 sample_app = "spark"
 
-sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:f3c87ee4c0e3fc7cd8bf6d0eb7d8e570f75ae6dc"

--- a/terraform/testcases/otlp_grpc_exporter_metric_mock/parameters.tfvars
+++ b/terraform/testcases/otlp_grpc_exporter_metric_mock/parameters.tfvars
@@ -5,4 +5,4 @@ soaking_data_mode = "metric"
 
 sample_app = "spark"
 
-sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:f3c87ee4c0e3fc7cd8bf6d0eb7d8e570f75ae6dc"

--- a/terraform/testcases/otlp_grpc_exporter_trace_mock/parameters.tfvars
+++ b/terraform/testcases/otlp_grpc_exporter_trace_mock/parameters.tfvars
@@ -5,4 +5,4 @@ soaking_data_mode = "trace"
 
 sample_app = "spark"
 
-sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:f3c87ee4c0e3fc7cd8bf6d0eb7d8e570f75ae6dc"

--- a/terraform/testcases/otlp_http_exporter_metric_mock/parameters.tfvars
+++ b/terraform/testcases/otlp_http_exporter_metric_mock/parameters.tfvars
@@ -3,4 +3,4 @@ soaking_data_mode = "metric"
 
 sample_app = "spark"
 
-sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:f3c87ee4c0e3fc7cd8bf6d0eb7d8e570f75ae6dc"

--- a/terraform/testcases/otlp_http_exporter_trace_mock/parameters.tfvars
+++ b/terraform/testcases/otlp_http_exporter_trace_mock/parameters.tfvars
@@ -3,4 +3,4 @@ soaking_data_mode = "trace"
 
 sample_app = "spark"
 
-sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:f3c87ee4c0e3fc7cd8bf6d0eb7d8e570f75ae6dc"

--- a/terraform/testcases/otlp_logs/parameters.tfvars
+++ b/terraform/testcases/otlp_logs/parameters.tfvars
@@ -2,4 +2,4 @@ validation_config = "spark-otel-log-validation.yml"
 
 sample_app = "spark"
 
-sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:f3c87ee4c0e3fc7cd8bf6d0eb7d8e570f75ae6dc"

--- a/terraform/testcases/otlp_metric/parameters.tfvars
+++ b/terraform/testcases/otlp_metric/parameters.tfvars
@@ -2,4 +2,4 @@ validation_config = "spark-otel-metric-validation.yml"
 
 sample_app = "spark"
 
-sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:f3c87ee4c0e3fc7cd8bf6d0eb7d8e570f75ae6dc"

--- a/terraform/testcases/otlp_metric_adot_operator/parameters.tfvars
+++ b/terraform/testcases/otlp_metric_adot_operator/parameters.tfvars
@@ -2,4 +2,4 @@ validation_config = "spark-otel-metric-validation.yml"
 
 sample_app = "spark"
 
-sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:f3c87ee4c0e3fc7cd8bf6d0eb7d8e570f75ae6dc"

--- a/terraform/testcases/otlp_metric_k8sattr/parameters.tfvars
+++ b/terraform/testcases/otlp_metric_k8sattr/parameters.tfvars
@@ -2,7 +2,7 @@ validation_config = "spark-otel-k8sattr-validation.yml"
 
 sample_app = "spark"
 
-sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:f3c87ee4c0e3fc7cd8bf6d0eb7d8e570f75ae6dc"
 
 rollup = false
 

--- a/terraform/testcases/otlp_metric_k8sattr_podassoc/parameters.tfvars
+++ b/terraform/testcases/otlp_metric_k8sattr_podassoc/parameters.tfvars
@@ -2,7 +2,7 @@ validation_config = "spark-otel-k8sattr-validation.yml"
 
 sample_app = "spark"
 
-sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:f3c87ee4c0e3fc7cd8bf6d0eb7d8e570f75ae6dc"
 
 rollup = false
 

--- a/terraform/testcases/otlp_metric_mock/parameters.tfvars
+++ b/terraform/testcases/otlp_metric_mock/parameters.tfvars
@@ -3,4 +3,4 @@ soaking_data_mode = "metric"
 
 sample_app = "spark"
 
-sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:f3c87ee4c0e3fc7cd8bf6d0eb7d8e570f75ae6dc"

--- a/terraform/testcases/otlp_mock/parameters.tfvars
+++ b/terraform/testcases/otlp_mock/parameters.tfvars
@@ -3,4 +3,4 @@ soaking_data_mode = "trace"
 
 sample_app = "spark"
 
-sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:f3c87ee4c0e3fc7cd8bf6d0eb7d8e570f75ae6dc"

--- a/terraform/testcases/otlp_trace/parameters.tfvars
+++ b/terraform/testcases/otlp_trace/parameters.tfvars
@@ -5,4 +5,4 @@ soaking_data_mode = "trace"
 
 sample_app = "spark"
 
-sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:f3c87ee4c0e3fc7cd8bf6d0eb7d8e570f75ae6dc"

--- a/terraform/testcases/otlp_trace_adot_operator/parameters.tfvars
+++ b/terraform/testcases/otlp_trace_adot_operator/parameters.tfvars
@@ -5,4 +5,4 @@ soaking_data_mode = "trace"
 
 sample_app = "spark"
 
-sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:f3c87ee4c0e3fc7cd8bf6d0eb7d8e570f75ae6dc"

--- a/terraform/testcases/otlp_trace_k8sattr/parameters.tfvars
+++ b/terraform/testcases/otlp_trace_k8sattr/parameters.tfvars
@@ -5,4 +5,4 @@ soaking_data_mode = "trace"
 
 sample_app = "spark"
 
-sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:f3c87ee4c0e3fc7cd8bf6d0eb7d8e570f75ae6dc"

--- a/terraform/testcases/otlp_trace_k8sattr_podassoc/parameters.tfvars
+++ b/terraform/testcases/otlp_trace_k8sattr_podassoc/parameters.tfvars
@@ -5,4 +5,4 @@ soaking_data_mode = "trace"
 
 sample_app = "spark"
 
-sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:f3c87ee4c0e3fc7cd8bf6d0eb7d8e570f75ae6dc"

--- a/terraform/testcases/otlp_trace_loadbalancing/parameters.tfvars
+++ b/terraform/testcases/otlp_trace_loadbalancing/parameters.tfvars
@@ -5,4 +5,4 @@ soaking_data_mode = "trace"
 
 sample_app = "spark"
 
-sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:f3c87ee4c0e3fc7cd8bf6d0eb7d8e570f75ae6dc"

--- a/terraform/testcases/otlp_trace_resourcedetection_eks/parameters.tfvars
+++ b/terraform/testcases/otlp_trace_resourcedetection_eks/parameters.tfvars
@@ -5,4 +5,4 @@ soaking_data_mode = "trace"
 
 sample_app = "spark"
 
-sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:f3c87ee4c0e3fc7cd8bf6d0eb7d8e570f75ae6dc"

--- a/terraform/testcases/sapm_exporter_trace_mock/parameters.tfvars
+++ b/terraform/testcases/sapm_exporter_trace_mock/parameters.tfvars
@@ -3,6 +3,6 @@ soaking_data_mode = "trace"
 
 sample_app = "spark"
 
-sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:f3c87ee4c0e3fc7cd8bf6d0eb7d8e570f75ae6dc"
 
 otconfig_args = ["--feature-gates=-adot.exporter.sapmexporter.deprecation"]

--- a/terraform/testcases/signalfx_exporter_metric_mock/parameters.tfvars
+++ b/terraform/testcases/signalfx_exporter_metric_mock/parameters.tfvars
@@ -3,6 +3,6 @@ soaking_data_mode = "metric"
 
 sample_app = "spark"
 
-sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:f3c87ee4c0e3fc7cd8bf6d0eb7d8e570f75ae6dc"
 
 otconfig_args = ["--feature-gates=-adot.exporter.signalfxexporter.deprecation"]

--- a/terraform/testcases/signalfxcorrelation_exporter_trace_mock/parameters.tfvars
+++ b/terraform/testcases/signalfxcorrelation_exporter_trace_mock/parameters.tfvars
@@ -3,4 +3,4 @@ soaking_data_mode = "trace"
 
 sample_app = "spark"
 
-sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
+sample_app_image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:f3c87ee4c0e3fc7cd8bf6d0eb7d8e570f75ae6dc"


### PR DESCRIPTION
**Description:**

https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/12287678809/job/34290134094 pushed an image that is not compatible with our test cases and is breaking Collector Canaries/PR-build. Pinning the image to working tag from a day ago - https://gallery.ecr.aws/aws-otel-test/aws-otel-java-spark

- Update metricsgeneration instead `experimental_metricsgeneration`

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

