### PR TITLE
Use renamed metric generation processor name

### DIFF
--- a/terraform/eks/container-insights-agent/config_map_fargate.yml
+++ b/terraform/eks/container-insights-agent/config_map_fargate.yml
@@ -331,7 +331,7 @@ data:
           - new_container_memory_hierarchical_pgfault
           - new_container_memory_hierarchical_pgmajfault
 
-      experimental_metricsgeneration/1:
+      metricsgeneration/1:
         rules:
           - name: pod_network_total_bytes
             unit: Bytes/Second
@@ -360,7 +360,7 @@ data:
             operation: divide
             scale_by: 100
 
-      experimental_metricsgeneration/2:
+      metricsgeneration/2:
         rules:
           - name: pod_cpu_utilization_over_pod_limit_${TestingId}
             type: calculate
@@ -439,6 +439,6 @@ data:
       pipelines:
         metrics:
           receivers: [prometheus]
-          processors: [metricstransform/label_1, resourcedetection, metricstransform/rename, filter, cumulativetodelta, deltatorate, experimental_metricsgeneration/1, experimental_metricsgeneration/2, metricstransform/label_2, batch]
+          processors: [metricstransform/label_1, resourcedetection, metricstransform/rename, filter, cumulativetodelta, deltatorate, metricsgeneration/1, metricsgeneration/2, metricstransform/label_2, batch]
           exporters: [debug, awsemf]
       extensions: [health_check]


### PR DESCRIPTION
**Description:** Use renamed metric generation processor name

- Renamed experimental_metricsgeneration to metricsgeneration, ref - https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/35821

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

