### PR TITLE
Update validator to cover ADOT v2 version.

### DIFF
--- a/validator/src/main/resources/expected-data-template/spark/sparkAppExpectedHTTPTrace.mustache
+++ b/validator/src/main/resources/expected-data-template/spark/sparkAppExpectedHTTPTrace.mustache
@@ -11,7 +11,7 @@
   },
   "subsegments": [
     {
-      "name": "aws.amazon.com",
+      "name": "aws.amazon.com|GET",
       "http": {
         "request": {
           "url": "https://aws\\.amazon\\.com/",

--- a/validator/src/main/resources/expected-data-template/springboot/springbootAppExpectedHTTPTrace.mustache
+++ b/validator/src/main/resources/expected-data-template/springboot/springbootAppExpectedHTTPTrace.mustache
@@ -13,7 +13,7 @@
     {
       "subsegments": [
         {
-          "name": "aws\\.amazon\\.com",
+          "name": "aws\\.amazon\\.com|GET",
           "http": {
             "request": {
               "url": "https://aws\\.amazon\\.com/",


### PR DESCRIPTION
**Description:** <Describe what has changed.>
ADOT Java right now support V2.x version which utilize otel upstream latest v2.10.0 ([PR](https://github.com/aws-observability/aws-application-signals-test-framework/pull/336)). The e2e test failed because the trace template is not updated to match with v2.x versions: https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/12486110016/job/34846031564

This PR update the trace validator template to match the emitted trace for both v1.x and v2.x versions.

**Testing:** <Describe what testing was performed and which tests were added.>
Local generate a new image using the updated code, and confirmed the tests passed successfully:
```
validator-1  | 22:34:49.547 [main] INFO  com.amazon.aoc.validators.TraceValidator - validation is passed for path /aws-sdk-call
validator-1  | 22:34:49.547 [main] INFO  com.amazon.aoc.App - Validation has completed in 1 minutes.
app-1        | [otel.javaagent 2024-12-24 22:34:49:578 +0000] [qtp1006917610-65] DEBUG io.opentelemetry.javaagent.tooling.AgentInstaller$TransformLoggingListener - Transformed org.eclipse.jetty.io.ManagedSelector$DestroyEndPoint -- jdk.internal.loader.ClassLoaders$AppClassLoader@1dbd16a6
validator-1 exited with code 0
Aborting on container exit...
[+] Stopping 3/3
 ✔ Container collector-validator-1  Stop...                                   0.0s
 ✔ Container collector-otel-1       Stopped                                   0.6s
 ✔ Container collector-app-1        Stopped                                   5.9s
```

**Documentation:** <Describe the documentation added.>

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

