### PR TITLE
Add additional EKS clusters versions 1.28, 1.29

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -27,6 +27,10 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v2
+      with:
+        terraform_version: '1.10.3'
     - name: Format Terraform
       run: cd terraform && make check-fmt
 

--- a/cdk_infra/lib/config/cluster-config/clusters.yml
+++ b/cdk_infra/lib/config/cluster-config/clusters.yml
@@ -45,6 +45,28 @@ clusters:
   - name: collector-ci-fargate-1-27
     version: "1.27"
     launch_type: fargate
+  - name: collector-ci-arm64-1-28
+    version: "1.28"
+    launch_type: ec2
+    instance_type: m6g.large
+  - name: collector-ci-amd64-1-28
+    version: "1.28"
+    launch_type: ec2
+    instance_type: "m5.large"
+  - name: collector-ci-fargate-1-28
+    version: "1.28"
+    launch_type: fargate
+  - name: collector-ci-arm64-1-29
+    version: "1.29"
+    launch_type: ec2
+    instance_type: m6g.large
+  - name: collector-ci-amd64-1-29
+    version: "1.29"
+    launch_type: ec2
+    instance_type: "m5.large"
+  - name: collector-ci-fargate-1-29
+    version: "1.29"
+    launch_type: fargate
   - name: collector-ci-arm64-1-30
     version: "1.30"
     launch_type: ec2
@@ -136,6 +158,26 @@ clusters:
     cert_manager: true
   - name: operator-ci-arm64-1-27
     version: "1.27"
+    launch_type: ec2
+    instance_type: m6g.large
+    cert_manager: true
+  - name: operator-ci-amd64-1-28
+    version: "1.28"
+    launch_type: ec2
+    instance_type: m5.large
+    cert_manager: true
+  - name: operator-ci-arm64-1-28
+    version: "1.28"
+    launch_type: ec2
+    instance_type: m6g.large
+    cert_manager: true
+  - name: operator-ci-amd64-1-29
+    version: "1.29"
+    launch_type: ec2
+    instance_type: m5.large
+    cert_manager: true
+  - name: operator-ci-arm64-1-29
+    version: "1.29"
     launch_type: ec2
     instance_type: m6g.large
     cert_manager: true

--- a/cdk_infra/lib/utils/eks/kubectlLayer.ts
+++ b/cdk_infra/lib/utils/eks/kubectlLayer.ts
@@ -5,6 +5,8 @@ import { KubectlV24Layer } from '@aws-cdk/lambda-layer-kubectl-v24';
 import { KubectlV25Layer } from '@aws-cdk/lambda-layer-kubectl-v25';
 import { KubectlV26Layer } from '@aws-cdk/lambda-layer-kubectl-v26';
 import { KubectlV27Layer } from '@aws-cdk/lambda-layer-kubectl-v27';
+import { KubectlV28Layer } from '@aws-cdk/lambda-layer-kubectl-v28';
+import { KubectlV29Layer } from '@aws-cdk/lambda-layer-kubectl-v29';
 import { KubectlV30Layer } from '@aws-cdk/lambda-layer-kubectl-v30';
 import { KubectlV31Layer } from '@aws-cdk/lambda-layer-kubectl-v31';
 
@@ -21,6 +23,10 @@ export function GetLayer(
       return new KubectlV26Layer(scope, 'v26Layer');
     case '1.27':
       return new KubectlV27Layer(scope, 'v27Layer');
+    case '1.28':
+      return new KubectlV28Layer(scope, 'v28Layer');
+    case '1.29':
+      return new KubectlV29Layer(scope, 'v29Layer');
     case '1.30':
       return new KubectlV30Layer(scope, 'v30Layer');
     case '1.31':

--- a/cdk_infra/lib/utils/eks/validate-interface-schema.ts
+++ b/cdk_infra/lib/utils/eks/validate-interface-schema.ts
@@ -4,7 +4,16 @@ import { ec2ClusterInterface } from '../../interfaces/eks/ec2cluster-interface';
 const validateSchema = require('yaml-schema-validator');
 
 const supportedLaunchTypes = new Set(['fargate', 'ec2']);
-const supportedVersions = new Set(['1.24', '1.25', '1.26', '1.27', '1.30', '1.31']);
+const supportedVersions = new Set([
+  '1.24',
+  '1.25',
+  '1.26',
+  '1.27',
+  '1.28',
+  '1.29',
+  '1.30',
+  '1.31'
+]);
 const supportedCPUArchitectures = new Set(['m5', 'm6g', 't4g']);
 const supportedNodeSizes = new Set([
   'medium',

--- a/cdk_infra/package-lock.json
+++ b/cdk_infra/package-lock.json
@@ -20,6 +20,8 @@
         "@aws-cdk/lambda-layer-kubectl-v25": "^2.0.4",
         "@aws-cdk/lambda-layer-kubectl-v26": "^2.1.0",
         "@aws-cdk/lambda-layer-kubectl-v27": "^2.1.0",
+        "@aws-cdk/lambda-layer-kubectl-v28": "^2.1.0",
+        "@aws-cdk/lambda-layer-kubectl-v29": "^2.1.0",
         "@aws-cdk/lambda-layer-kubectl-v30": "^2.0.0",
         "@aws-cdk/lambda-layer-kubectl-v31": "^2.0.0",
         "aws-cdk-lib": "^2.174.0",
@@ -1442,6 +1444,26 @@
       "integrity": "sha512-2gXadkJSw1gDWO3ep0JhmFP99Ul5uUCJAEcROt/hnDTc0TMeUDa8qLrCwhmgOAM9xCXMwRcWomEGmK0fmr2vQg==",
       "peerDependencies": {
         "aws-cdk-lib": "^2.28.0",
+        "constructs": "^10.0.5"
+      }
+    },
+    "node_modules/@aws-cdk/lambda-layer-kubectl-v28": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/lambda-layer-kubectl-v28/-/lambda-layer-kubectl-v28-2.2.0.tgz",
+      "integrity": "sha512-m7nMDn/Ff9S+gJ5Sok5NuYHBzgsj3Xz3dOo0BxXYJJNPl9UtD1HnPcKV56lHn9+BACJff/h8aPUMln0xCUPuIw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.28.0",
+        "constructs": "^10.0.5"
+      }
+    },
+    "node_modules/@aws-cdk/lambda-layer-kubectl-v29": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/lambda-layer-kubectl-v29/-/lambda-layer-kubectl-v29-2.1.0.tgz",
+      "integrity": "sha512-YwSyM3eNK5DiEY+5HWzVmkLzEMFSyTpsBSqki/kNePwH+UXP//Nmee2vMEIYxNFW6tpN3dx+B4gYNiJhBwGhKQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.94.0",
         "constructs": "^10.0.5"
       }
     },
@@ -7980,6 +8002,18 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/lambda-layer-kubectl-v27/-/lambda-layer-kubectl-v27-2.1.0.tgz",
       "integrity": "sha512-2gXadkJSw1gDWO3ep0JhmFP99Ul5uUCJAEcROt/hnDTc0TMeUDa8qLrCwhmgOAM9xCXMwRcWomEGmK0fmr2vQg==",
+      "requires": {}
+    },
+    "@aws-cdk/lambda-layer-kubectl-v28": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/lambda-layer-kubectl-v28/-/lambda-layer-kubectl-v28-2.2.0.tgz",
+      "integrity": "sha512-m7nMDn/Ff9S+gJ5Sok5NuYHBzgsj3Xz3dOo0BxXYJJNPl9UtD1HnPcKV56lHn9+BACJff/h8aPUMln0xCUPuIw==",
+      "requires": {}
+    },
+    "@aws-cdk/lambda-layer-kubectl-v29": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/lambda-layer-kubectl-v29/-/lambda-layer-kubectl-v29-2.1.0.tgz",
+      "integrity": "sha512-YwSyM3eNK5DiEY+5HWzVmkLzEMFSyTpsBSqki/kNePwH+UXP//Nmee2vMEIYxNFW6tpN3dx+B4gYNiJhBwGhKQ==",
       "requires": {}
     },
     "@aws-cdk/lambda-layer-kubectl-v30": {

--- a/cdk_infra/package.json
+++ b/cdk_infra/package.json
@@ -40,6 +40,8 @@
     "@aws-cdk/lambda-layer-kubectl-v25": "^2.0.4",
     "@aws-cdk/lambda-layer-kubectl-v26": "^2.1.0",
     "@aws-cdk/lambda-layer-kubectl-v27": "^2.1.0",
+    "@aws-cdk/lambda-layer-kubectl-v28": "^2.1.0",
+    "@aws-cdk/lambda-layer-kubectl-v29": "^2.1.0",
     "@aws-cdk/lambda-layer-kubectl-v30": "^2.0.0",
     "@aws-cdk/lambda-layer-kubectl-v31": "^2.0.0",
     "aws-cdk-lib": "^2.174.0",

--- a/cdk_infra/test/test_config/test_clusters.yml
+++ b/cdk_infra/test/test_config/test_clusters.yml
@@ -19,6 +19,14 @@ clusters:
     launch_type: ec2
     instance_type: m6g.large
     version: "1.27"
+  - name: m6g-arm64-Cluster-1-28
+    launch_type: ec2
+    instance_type: m6g.large
+    version: "1.28"
+  - name: m6g-arm64-Cluster-1-29
+    launch_type: ec2
+    instance_type: m6g.large
+    version: "1.29"
   - name: m6g-arm64-Cluster-1-30
     launch_type: ec2
     instance_type: m6g.large


### PR DESCRIPTION
**Description:** 

Add additional EKS clusters versions 1.28, 1.29



**Testing**
```
✨  Deployment time: 897.88s

Stack ARN:
arn:aws:cloudformation:us-west-2:629274716306:stack/collector-ci-arm64-1-28EKSCluster/296033f0-d83d-11ef-b329-06ed73ba35e3

✨  Total time: 913.66s

```

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

