### PR TITLE
Update Ec2 Cluster stack to fetch NodeGroup releaseVersion

### DIFF
--- a/cdk_infra/lib/stacks/eks/ec2-cluster-stack.ts
+++ b/cdk_infra/lib/stacks/eks/ec2-cluster-stack.ts
@@ -8,6 +8,25 @@ import {
 } from 'aws-cdk-lib/aws-eks';
 import { ManagedPolicy } from 'aws-cdk-lib/aws-iam';
 import { GetLayer } from '../../utils/eks/kubectlLayer';
+import { StringParameter } from 'aws-cdk-lib/aws-ssm';
+
+function getReleaseVersion(amiType: string, clusterVersion: string, scope: Construct): string {
+  let parameterName: string;
+
+  // https://docs.aws.amazon.com/eks/latest/userguide/retrieve-ami-id.html
+  if (amiType === NodegroupAmiType.AL2_X86_64) {
+    parameterName = `/aws/service/eks/optimized-ami/${clusterVersion}/amazon-linux-2/recommended/release_version`;
+  } else if (amiType === NodegroupAmiType.AL2_ARM_64) {
+    parameterName = `/aws/service/eks/optimized-ami/${clusterVersion}/amazon-linux-2-arm64/recommended/release_version`;
+  } else {
+    throw new Error(`Unsupported amiType: ${amiType}`);
+  }
+
+  // Fetch and return the release version from the SSM parameter
+  return StringParameter.fromStringParameterAttributes(scope, `NodeGroupReleaseVersion-${clusterVersion}-${amiType}`, {
+    parameterName,
+  }).stringValue;
+}
 
 export class EC2Stack extends Stack {
   cluster: eks.Cluster;
@@ -22,6 +41,7 @@ export class EC2Stack extends Stack {
       eks.ClusterLoggingTypes.CONTROLLER_MANAGER,
       eks.ClusterLoggingTypes.SCHEDULER
     ];
+
     this.cluster = new eks.Cluster(this, props.name, {
       clusterName: props.name,
       vpc: props.vpc,
@@ -31,14 +51,17 @@ export class EC2Stack extends Stack {
       clusterLogging: logging,
       kubectlLayer: GetLayer(this, props.version)
     });
+
     const lt = new ec2.LaunchTemplate(this, `${props.name}-launch-template`, {
       requireImdsv2: true,
       httpEndpoint: true,
       httpPutResponseHopLimit: 2,
       httpTokens: ec2.LaunchTemplateHttpTokens.REQUIRED
     });
+
     const clusterNodeGroup = new Nodegroup(this, `${props.name}-managed-ng`, {
       amiType: props.amiType,
+      releaseVersion: getReleaseVersion(props.amiType, props.version.version, this),
       instanceTypes: props.instanceTypes,
       cluster: this.cluster,
       minSize: 2,
@@ -48,6 +71,7 @@ export class EC2Stack extends Stack {
         version: lt.latestVersionNumber
       }
     });
+
     clusterNodeGroup.role.addManagedPolicy(
       ManagedPolicy.fromAwsManagedPolicyName('AmazonSSMManagedInstanceCore')
     );


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Update Ec2 Cluster stack to fetch NodeGroup releaseVersion

This change should make the NodeGroup always grab the releaseVersion, making sure the stack gets updated and therefore the newest AMI is always used in these nodegroups. Deployed to dev account and NodeGroups use the newest AMIs

![image](https://github.com/user-attachments/assets/09841f48-c2d8-4665-888d-936817f75784)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

