### PR TITLE
Terraform increase wait ecs

### DIFF
--- a/terraform/ecs/efs.tf
+++ b/terraform/ecs/efs.tf
@@ -93,6 +93,11 @@ resource "aws_instance" "collector_efs_ec2" {
   depends_on = [aws_efs_mount_target.collector_efs_mount, aws_key_pair.aws_ssh_key]
 }
 
+resource "time_sleep" "wait_90_seconds" {
+  depends_on = [aws_efs_mount_target.collector_efs_mount]
+  create_duration = "90s"
+}
+
 resource "null_resource" "mount_efs" {
   provisioner "remote-exec" {
     inline = [
@@ -109,7 +114,7 @@ resource "null_resource" "mount_efs" {
     }
   }
 
-  depends_on = [aws_instance.collector_efs_ec2]
+  depends_on = [aws_instance.collector_efs_ec2, time_sleep.wait_90_seconds]
 }
 resource "null_resource" "scp_cert" {
   provisioner "file" {
@@ -146,4 +151,3 @@ output "private_key" {
 output "efs_ip" {
   value = aws_instance.collector_efs_ec2.public_ip
 }
-


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Added wait timer (90s) to allow EFS to finish creating before mounting. 
https://docs.aws.amazon.com/efs/latest/ug/mounting-fs-mount-cmd-dns-name.html
>Note
We recommend that you wait 90 seconds after creating a mount target before you mount your file system. This wait lets the DNS records propagate fully in the AWS Region where the file system is.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>
Ran the changes locally and efs issue no longer persisted

**Documentation:** <Describe the documentation added.>

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

