### PR TITLE
Updating 3p actions from VID to CSHA

### DIFF
--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -18,21 +18,21 @@ jobs:
   run-cdk-deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
         with:
           role-to-assume: ${{ secrets.TEST_FW_ASSUMABLE_ROLE_ARN }}
           aws-region: us-west-2
           role-duration-seconds: 21600
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 #v5.0.0
         with:
           node-version: 16
       - name: Get npm cache directory
         id: npm-cache-dir
         run: |
           echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v4
+      - uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 #v4.2.4
         id: npm-cache
         with:
           path: ${{ steps.npm-cache-dir.outputs.dir }}

--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
+        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 #v5.0.0
         with:
           role-to-assume: ${{ secrets.TEST_FW_ASSUMABLE_ROLE_ARN }}
           aws-region: us-west-2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -64,7 +64,7 @@ jobs:
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
       if: matrix.language != 'java'
-      uses: github/codeql-action/autobuild@16df4fbc19aea13d921737861d6c622bf3cefe23 #v3.30.3
+      uses: github/codeql-action/autobuild@16df4fbc19aea13d921737861d6c622bf3cefe23 #v2.30.3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
     - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v2
+      uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd #v3.1.2
       with:
         terraform_version: '1.10.3'
     - name: Format Terraform
@@ -48,11 +48,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@16df4fbc19aea13d921737861d6c622bf3cefe23 #v3.30.3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -64,7 +64,7 @@ jobs:
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
       if: matrix.language != 'java'
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@16df4fbc19aea13d921737861d6c622bf3cefe23 #v3.30.3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -78,4 +78,4 @@ jobs:
       if: matrix.language == 'java'
       
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@16df4fbc19aea13d921737861d6c622bf3cefe23 #v2.23.0

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -13,22 +13,22 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-java@v4
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
+    - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 #v5.0.0
       with:
         distribution: 'zulu'
         java-version: 17
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 #v5.0.0
       with:
         role-to-assume: ${{ secrets.INTEG_TEST_TFW_ROLE_ARN }}
         role-duration-seconds: 1200
         aws-region: us-east-1
     - name: Login to ECR
-      uses: docker/login-action@v3
+      uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 #v3.5.0
       with:
         registry: public.ecr.aws
     - name: Push validator docker image
-      uses: burrunan/gradle-cache-action@v2
+      uses: burrunan/gradle-cache-action@4a07779efc8120348ea6dfd35314bc30a586eb0f #v3.0.1
       with:
         arguments: :validator:jib --stacktrace

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -13,9 +13,9 @@ jobs:
   validator-build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
     - name: Set up JDK 1.8
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 #v5.0.0
       with:
         distribution: 'zulu'
         java-version: 17
@@ -26,11 +26,11 @@ jobs:
   validator-image-build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 #v3.11.1
     - name: Build validator image
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 #v6.18.0
       with:
         context: ./validator
         push: false
@@ -42,26 +42,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go 1.x
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 #6.0.0
       with:
         go-version: '~1.21.1'
     - name: Checkout repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
     - name: Unit test
       run: make go-test
   cdk-test:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
+    - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 #v5.0.0
       with:
         node-version: 16
     - name: Get npm cache directory
       id: npm-cache-dir
       run: |
         echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
-    - uses: actions/cache@v4
+    - uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 #v4.2.4
       id: npm-cache # use this to check for `cache-hit` ==> if: steps.npm-cache.outputs.cache-hit != 'true'
       with:
         path: ${{ steps.npm-cache-dir.outputs.dir }}
@@ -77,14 +77,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 #v5.0.0
         with:
           distribution: 'zulu'
           java-version: '17'
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a #4.4.3
       - name: adot-testbed build
         working-directory: adot-testbed/
         run: gradle build -x test

--- a/.github/workflows/update-load-generator-image.yml
+++ b/.github/workflows/update-load-generator-image.yml
@@ -24,27 +24,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 #v5.0.0
         with:
           role-to-assume: ${{ secrets.TEST_FW_ASSUMABLE_ROLE_ARN }}
           aws-region: us-east-1
           role-duration-seconds: 7200
       - name: Login to Amazon ECR Public
         id: login-ecr-public
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 #v2.0.1
         with:
           registry-type: public
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 #v5.0.0
         with:
           distribution: 'zulu'
           java-version: 17
-      - name: Build image with jib
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: :load-generator:jib
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a #4.4.3
+
+        name: Build image with jib
+        run: ./gradlew :load-generator:jib
         env:
           COMMIT_HASH: ${{ github.sha }}
 

--- a/.github/workflows/update-test-images.yml
+++ b/.github/workflows/update-test-images.yml
@@ -23,24 +23,26 @@ jobs:
     steps:
       - name: Remove cache
         run: rm -rf /opt/hostedtoolcache
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 #v5.0.0
         with:
           role-to-assume: ${{ secrets.TEST_FW_ASSUMABLE_ROLE_ARN }}
           aws-region: us-west-2
           role-duration-seconds: 7200
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 #v5.0.0
         with:
           distribution: 'zulu'
           java-version: 17
-      - uses: gradle/wrapper-validation-action@v3
-      - name: Build locally with gradle
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: build
+      - uses: gradle/actions/wrapper-validation@ed408507eac070d1f99cc633dbcf757c94c7933a #4.4.3
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a #4.4.3
+
+        name: Build locally with gradle
+        run: ./gradlew build
+
       - name: Set up terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd #v3.1.2
         with:
           terraform_version: "1.5.7"
       - name: run imagebuild


### PR DESCRIPTION
This pr updates all files with 3p actions using a Version tag to Commit SHA.

Refernces:
https://github.com/actions/checkout
https://github.com/aws-actions/configure-aws-credentials  
https://github.com/actions/setup-node
https://github.com/hashicorp/setup-terraform
https://github.com/actions/cache
https://github.com/github/codeql-action
https://github.com/docker/login-action
https://github.com/actions/setup-java
https://github.com/docker/login-action
https://github.com/docker/setup-buildx-action
https://github.com/docker/build-push-action
https://github.com/burrunan/gradle-cache-action
https://github.com/actions/setup-go
https://github.com/gradle/actions/blob/f8140229023a7015c7ce4df6f7c390a3cace8f83/docs/deprecation-upgrade-guide.md#using-the-action-to-execute-gradle-via-the-arguments-parameter-is-deprecated
https://github.com/aws-actions/amazon-ecr-login

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

