### PR TITLE
Fix ARM64 build failures by updating CA certificates

### DIFF
--- a/mocked_servers/grpc_metrics/Dockerfile
+++ b/mocked_servers/grpc_metrics/Dockerfile
@@ -1,4 +1,8 @@
 FROM golang:1.23 AS build
+
+# Update CA certificates to fix TLS handshake issues on ARM64
+RUN apt-get update && apt-get install -y ca-certificates && update-ca-certificates && rm -rf /var/lib/apt/lists/*
+
 WORKDIR $GOPATH/main
 COPY . .
 RUN go env -w GOPROXY=direct

--- a/mocked_servers/grpc_trace/Dockerfile
+++ b/mocked_servers/grpc_trace/Dockerfile
@@ -1,4 +1,8 @@
 FROM golang:1.23 AS build
+
+# Update CA certificates to fix TLS handshake issues on ARM64
+RUN apt-get update && apt-get install -y ca-certificates && update-ca-certificates && rm -rf /var/lib/apt/lists/*
+
 WORKDIR $GOPATH/main
 COPY . .
 RUN go env -w GOPROXY=direct

--- a/sample-apps/jmx/Dockerfile
+++ b/sample-apps/jmx/Dockerfile
@@ -1,6 +1,9 @@
 # Build the war file
 FROM maven:3-openjdk-8 as build
 
+# Update CA certificates to fix TLS handshake issues on ARM64
+RUN apt-get update && apt-get install -y ca-certificates && update-ca-certificates && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 COPY . .
 RUN mvn package

--- a/sample-apps/prometheus/Dockerfile
+++ b/sample-apps/prometheus/Dockerfile
@@ -1,4 +1,8 @@
 FROM golang:1.23 as build
+
+# Update CA certificates to fix TLS handshake issues on ARM64
+RUN apt-get update && apt-get install -y ca-certificates && update-ca-certificates && rm -rf /var/lib/apt/lists/*
+
 WORKDIR $GOPATH/main
 COPY . .
 RUN go env -w GOPROXY=direct


### PR DESCRIPTION
**Description:** 

Fixes ARM64 Docker build failures caused by TLS handshake errors when downloading Maven and Go dependencies. Updates CA certificates in base images before dependency downloads to resolve g`nutls_handshake()` failed and `Broken pipe` errors.

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

