### PR TITLE
Remove EOL EC2 AMIs from CI test matrix nad fix flaky image builds

### DIFF
--- a/.github/workflows/update-test-images.yml
+++ b/.github/workflows/update-test-images.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   run-image-build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_TYPE || 'ubuntu-latest' }}
     steps:
       - name: Remove cache
         run: rm -rf /opt/hostedtoolcache

--- a/mocked_servers/grpc_metrics/Dockerfile
+++ b/mocked_servers/grpc_metrics/Dockerfile
@@ -1,9 +1,9 @@
-FROM golang:1.23 AS build
+FROM --platform=$BUILDPLATFORM golang:1.23 AS build
+ARG TARGETARCH
 WORKDIR $GOPATH/main
 COPY . .
-RUN go env -w GOPROXY=direct
 
-RUN GO111MODULE=on CGO_ENABLED=0 GOOS=linux go build -o=/bin/main .
+RUN GO111MODULE=on CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -o=/bin/main .
 
 FROM scratch
 COPY --from=build /bin/main /bin/main

--- a/mocked_servers/grpc_trace/Dockerfile
+++ b/mocked_servers/grpc_trace/Dockerfile
@@ -1,9 +1,9 @@
-FROM golang:1.23 AS build
+FROM --platform=$BUILDPLATFORM golang:1.23 AS build
+ARG TARGETARCH
 WORKDIR $GOPATH/main
 COPY . .
-RUN go env -w GOPROXY=direct
 
-RUN GO111MODULE=on CGO_ENABLED=0 GOOS=linux go build -o=/bin/main .
+RUN GO111MODULE=on CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -o=/bin/main .
 
 FROM scratch
 COPY --from=build /bin/main /bin/main

--- a/mocked_servers/https/Dockerfile
+++ b/mocked_servers/https/Dockerfile
@@ -1,13 +1,13 @@
-FROM golang:1.23 AS build
+FROM --platform=$BUILDPLATFORM golang:1.23 AS build
+ARG TARGETARCH
 
 # Update CA certificates to fix TLS handshake issues on ARM64
 RUN apt-get update && apt-get install -y ca-certificates && update-ca-certificates && rm -rf /var/lib/apt/lists/*
 
 WORKDIR $GOPATH/main
 COPY . .
-RUN go env -w GOPROXY=direct
 
-RUN GO111MODULE=on CGO_ENABLED=0 GOOS=linux go build -o=/bin/main .
+RUN GO111MODULE=on CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -o=/bin/main .
 
 FROM scratch
 COPY --from=build /bin/main /bin/main

--- a/sample-apps/jaeger-zipkin-sample-app/Dockerfile
+++ b/sample-apps/jaeger-zipkin-sample-app/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:8.1.1-jdk17 as builder
+FROM --platform=$BUILDPLATFORM gradle:8.1.1-jdk17 AS builder
 
 WORKDIR /app
 COPY ./build.gradle ./build.gradle

--- a/sample-apps/jmx/Dockerfile
+++ b/sample-apps/jmx/Dockerfile
@@ -1,5 +1,5 @@
 # Build the war file
-FROM maven:3-openjdk-8 as build
+FROM --platform=$BUILDPLATFORM maven:3.9-eclipse-temurin-8 AS build
 
 WORKDIR /app
 COPY . .

--- a/sample-apps/prometheus/Dockerfile
+++ b/sample-apps/prometheus/Dockerfile
@@ -1,10 +1,9 @@
-FROM golang:1.23 as build
+FROM --platform=$BUILDPLATFORM golang:1.23 AS build
+ARG TARGETARCH
 WORKDIR $GOPATH/main
 COPY . .
-RUN go env -w GOPROXY=direct
-# Retry logic for go mod download to handle transient network issues
-RUN for i in 1 2 3; do GO111MODULE=on go mod download && break || sleep 5; done
-RUN GO111MODULE=on CGO_ENABLED=0 GOOS=linux go build -o=/bin/main .
+
+RUN GO111MODULE=on CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -o=/bin/main .
 
 FROM scratch
 COPY --from=build /bin/main /bin/main

--- a/tools/batchTestGenerator/internal/testCaseBuilder.go
+++ b/tools/batchTestGenerator/internal/testCaseBuilder.go
@@ -6,14 +6,10 @@ import (
 )
 
 var ec2AMIs = []string{
-	"ubuntu20",
-	"arm_ubuntu20",
 	"ubuntu22",
 	"arm_ubuntu22",
 	"debian11",
 	"arm_debian11",
-	"debian10",
-	"arm_debian10",
 	"amazonlinux2",
 	"arm_amazonlinux2",
 	"amazonlinux3",
@@ -21,7 +17,6 @@ var ec2AMIs = []string{
 	"windows2022",
 	"windows2019",
 	"suse15",
-	"suse12",
 	"redhat8",
 	"arm_redhat8",
 }


### PR DESCRIPTION
**Description:** 

Remove end-of-life AMIs (debian10, suse12, ubuntu20) from EC2 test matrix  and fix flaky image builds


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

