### PR TITLE
Fix Kafka test configs for OTel Collector v0.141.0 breaking changes

### DIFF
--- a/terraform/testcases/kafka_otlp_metric_2_8_1/otconfig.tpl
+++ b/terraform/testcases/kafka_otlp_metric_2_8_1/otconfig.tpl
@@ -7,7 +7,6 @@ receivers:
       grpc:
         endpoint: 0.0.0.0:${grpc_port}
   kafka/receiver:
-    topic: ${extra_data.msk.topic}
     protocol_version: "${extra_data.msk.kafka_version}"
     auth:
       tls:
@@ -15,6 +14,8 @@ receivers:
     brokers:
 %{ for broker in split(",", extra_data["msk"].bootstrap_brokers_tls) }      - ${broker}
 %{ endfor }
+    metrics:
+      topic: ${extra_data.msk.topic}
 
 processors:
   batch:
@@ -27,10 +28,11 @@ exporters:
     auth:
       tls:
         insecure: false
-    topic: ${extra_data.msk.topic}
     brokers:
 %{ for broker in split(",", extra_data["msk"].bootstrap_brokers_tls) }      - ${broker}
 %{ endfor }
+    metrics:
+      topic: ${extra_data.msk.topic}
 
 service:
   pipelines:

--- a/terraform/testcases/kafka_otlp_metric_3_2_0/otconfig.tpl
+++ b/terraform/testcases/kafka_otlp_metric_3_2_0/otconfig.tpl
@@ -7,7 +7,6 @@ receivers:
       grpc:
         endpoint: 0.0.0.0:${grpc_port}
   kafka/receiver:
-    topic: ${extra_data.msk.topic}
     protocol_version: "${extra_data.msk.kafka_version}"
     auth:
       tls:
@@ -15,6 +14,8 @@ receivers:
     brokers:
 %{ for broker in split(",", extra_data["msk"].bootstrap_brokers_tls) }      - ${broker}
 %{ endfor }
+    metrics:
+      topic: ${extra_data.msk.topic}
 
 processors:
   batch:
@@ -27,10 +28,11 @@ exporters:
     auth:
       tls:
         insecure: false
-    topic: ${extra_data.msk.topic}
     brokers:
 %{ for broker in split(",", extra_data["msk"].bootstrap_brokers_tls) }      - ${broker}
 %{ endfor }
+    metrics:
+      topic: ${extra_data.msk.topic}
 
 service:
   pipelines:

--- a/terraform/testcases/kafka_otlp_metric_mock_2_8_1/otconfig.tpl
+++ b/terraform/testcases/kafka_otlp_metric_mock_2_8_1/otconfig.tpl
@@ -7,7 +7,6 @@ receivers:
       grpc:
         endpoint: 0.0.0.0:${grpc_port}
   kafka/receiver:
-    topic: ${extra_data.msk.topic}
     protocol_version: "${extra_data.msk.kafka_version}"
     auth:
       tls:
@@ -15,6 +14,8 @@ receivers:
     brokers:
 %{ for broker in split(",", extra_data["msk"].bootstrap_brokers_tls) }      - ${broker}
 %{ endfor }
+    metrics:
+      topic: ${extra_data.msk.topic}
 
 processors:
   batch:
@@ -28,10 +29,11 @@ exporters:
     auth:
       tls:
         insecure: false
-    topic: ${extra_data.msk.topic}
     brokers:
 %{ for broker in split(",", extra_data["msk"].bootstrap_brokers_tls) }      - ${broker}
 %{ endfor }
+    metrics:
+      topic: ${extra_data.msk.topic}
 
 service:
   pipelines:

--- a/terraform/testcases/kafka_otlp_metric_mock_3_2_0/otconfig.tpl
+++ b/terraform/testcases/kafka_otlp_metric_mock_3_2_0/otconfig.tpl
@@ -7,7 +7,6 @@ receivers:
       grpc:
         endpoint: 0.0.0.0:${grpc_port}
   kafka/receiver:
-    topic: ${extra_data.msk.topic}
     protocol_version: "${extra_data.msk.kafka_version}"
     auth:
       tls:
@@ -15,6 +14,8 @@ receivers:
     brokers:
 %{ for broker in split(",", extra_data["msk"].bootstrap_brokers_tls) }      - ${broker}
 %{ endfor }
+    metrics:
+      topic: ${extra_data.msk.topic}
 
 processors:
   batch:
@@ -28,10 +29,11 @@ exporters:
     auth:
       tls:
         insecure: false
-    topic: ${extra_data.msk.topic}
     brokers:
 %{ for broker in split(",", extra_data["msk"].bootstrap_brokers_tls) }      - ${broker}
 %{ endfor }
+    metrics:
+      topic: ${extra_data.msk.topic}
 
 service:
   pipelines:

--- a/terraform/testcases/kafka_otlp_mock_2_8_1/otconfig.tpl
+++ b/terraform/testcases/kafka_otlp_mock_2_8_1/otconfig.tpl
@@ -7,7 +7,6 @@ receivers:
       grpc:
         endpoint: 0.0.0.0:${grpc_port}
   kafka/receiver:
-    topic: ${extra_data.msk.topic}
     protocol_version: "${extra_data.msk.kafka_version}"
     auth:
       tls:
@@ -15,6 +14,8 @@ receivers:
     brokers:
 %{ for broker in split(",", extra_data["msk"].bootstrap_brokers_tls) }      - ${broker}
 %{ endfor }
+    traces:
+      topic: ${extra_data.msk.topic}
 
 processors:
   batch:
@@ -30,10 +31,11 @@ exporters:
     auth:
       tls:
         insecure: false
-    topic: ${extra_data.msk.topic}
     brokers:
 %{ for broker in split(",", extra_data["msk"].bootstrap_brokers_tls) }      - ${broker}
 %{ endfor }
+    traces:
+      topic: ${extra_data.msk.topic}
 
 service:
   pipelines:

--- a/terraform/testcases/kafka_otlp_mock_3_2_0/otconfig.tpl
+++ b/terraform/testcases/kafka_otlp_mock_3_2_0/otconfig.tpl
@@ -7,7 +7,6 @@ receivers:
       grpc:
         endpoint: 0.0.0.0:${grpc_port}
   kafka/receiver:
-    topic: ${extra_data.msk.topic}
     protocol_version: "${extra_data.msk.kafka_version}"
     auth:
       tls:
@@ -15,6 +14,8 @@ receivers:
     brokers:
 %{ for broker in split(",", extra_data["msk"].bootstrap_brokers_tls) }      - ${broker}
 %{ endfor }
+    traces:
+      topic: ${extra_data.msk.topic}
 
 processors:
   batch:
@@ -30,10 +31,11 @@ exporters:
     auth:
       tls:
         insecure: false
-    topic: ${extra_data.msk.topic}
     brokers:
 %{ for broker in split(",", extra_data["msk"].bootstrap_brokers_tls) }      - ${broker}
 %{ endfor }
+    traces:
+      topic: ${extra_data.msk.topic}
 
 service:
   pipelines:

--- a/terraform/testcases/kafka_otlp_trace_2_8_1/otconfig.tpl
+++ b/terraform/testcases/kafka_otlp_trace_2_8_1/otconfig.tpl
@@ -7,7 +7,6 @@ receivers:
       grpc:
         endpoint: 0.0.0.0:${grpc_port}
   kafka/receiver:
-    topic: ${extra_data.msk.topic}
     protocol_version: "${extra_data.msk.kafka_version}"
     auth:
       tls:
@@ -15,6 +14,8 @@ receivers:
     brokers:
 %{ for broker in split(",", extra_data["msk"].bootstrap_brokers_tls) }      - ${broker}
 %{ endfor }
+    traces:
+      topic: ${extra_data.msk.topic}
 
 processors:
   batch:
@@ -28,10 +29,11 @@ exporters:
     auth:
       tls:
         insecure: false
-    topic: ${extra_data.msk.topic}
     brokers:
 %{ for broker in split(",", extra_data["msk"].bootstrap_brokers_tls) }      - ${broker}
 %{ endfor }
+    traces:
+      topic: ${extra_data.msk.topic}
 
 service:
   pipelines:

--- a/terraform/testcases/kafka_otlp_trace_3_2_0/otconfig.tpl
+++ b/terraform/testcases/kafka_otlp_trace_3_2_0/otconfig.tpl
@@ -7,7 +7,6 @@ receivers:
       grpc:
         endpoint: 0.0.0.0:${grpc_port}
   kafka/receiver:
-    topic: ${extra_data.msk.topic}
     protocol_version: "${extra_data.msk.kafka_version}"
     auth:
       tls:
@@ -15,6 +14,8 @@ receivers:
     brokers:
 %{ for broker in split(",", extra_data["msk"].bootstrap_brokers_tls) }      - ${broker}
 %{ endfor }
+    traces:
+      topic: ${extra_data.msk.topic}
 
 processors:
   batch:
@@ -28,10 +29,11 @@ exporters:
     auth:
       tls:
         insecure: false
-    topic: ${extra_data.msk.topic}
     brokers:
 %{ for broker in split(",", extra_data["msk"].bootstrap_brokers_tls) }      - ${broker}
 %{ endfor }
+    traces:
+      topic: ${extra_data.msk.topic}
 
 service:
   pipelines:


### PR DESCRIPTION
## Description
Kafka tests failing after upgrading to OTel Collector v0.141.0 due to breaking changes in Kafka receiver/exporter configuration.

Breaking change: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44568

## Fix
Updated all 8 Kafka test configurations to use the new format where `topic` is nested under signal-specific sections (`traces:` or `metrics:`).


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

