### PR TITLE
Update Helm chart to 0.100.0 for operator 0.141.x support

### DIFF
--- a/terraform/eks/adot-operator/adot-operator-values.yaml
+++ b/terraform/eks/adot-operator/adot-operator-values.yaml
@@ -1,4 +1,4 @@
 kubeRBACProxy:
   image:
     repository: public.ecr.aws/aws-observability/mirror-kube-rbac-proxy
-    tag: "v0.19.1"
+    tag: "v0.20.1"

--- a/terraform/eks/adot-operator/adot_operator.tf
+++ b/terraform/eks/adot-operator/adot_operator.tf
@@ -46,7 +46,7 @@ resource "helm_release" "adot-operator" {
 
   repository = "https://open-telemetry.github.io/opentelemetry-helm-charts"
   chart      = "opentelemetry-operator"
-  version    = "0.93.1"
+  version    = "0.100.0"
   namespace  = "adot-operator-${var.testing_id}-ns"
   wait       = true
   timeout    = 600

--- a/terraform/eks/variables.tf
+++ b/terraform/eks/variables.tf
@@ -63,7 +63,7 @@ variable "operator_repository" {
 
 variable "operator_tag" {
   type    = string
-  default = "v0.131.0"
+  default = "v0.139.0"
 }
 
 // This will only fetch data from the MSK cluster in case this value is set


### PR DESCRIPTION
**Description:** Update OpenTelemetry Operator Helm chart version from 0.93.1 to 0.100.0 to support operator versions 0.139.0-0.141.x. Also updates kube-rbac-proxy to v0.20.1.

Changes:
- Helm chart: 0.93.1 → 0.100.0 (appVersion 0.131.0 → 0.139.0)
- kube-rbac-proxy: v0.19.1 → v0.20.1
- Default operator_tag: v0.131.0 → v0.139.0

**Link to tracking Issue:** N/A

**Testing:** Pending - will be validated by aws-otel-operator e2e tests after merge.

**Documentation:** N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.