### PR TITLE
[Fix] CI test failures for OTel v0.142.0 upgrade

### DIFF
--- a/terraform/ec2/main.tf
+++ b/terraform/ec2/main.tf
@@ -113,9 +113,10 @@ resource "aws_instance" "sidecar" {
     http_endpoint = "enabled"
     http_tokens   = "required"
 
-    # Use 2 hops because some of the test services run inside docker in the instance.
-    # That counts as an extra hop to access the IMDS. The default value is 1.
-    http_put_response_hop_limit = 2
+    # Use 3 hops to ensure Docker containers can reliably refresh credentials from IMDS.
+    # Docker bridge networking adds hops, and AWS SDK credential refresh at ~30min
+    # can fail with lower hop limits. The default value is 1.
+    http_put_response_hop_limit = 3
   }
 
 }

--- a/terraform/eks/container-insights-agent/cluster_role.tpl
+++ b/terraform/eks/container-insights-agent/cluster_role.tpl
@@ -32,4 +32,7 @@ rules:
     resources: ["leases"]
     resourceNames: ["otel-container-insight-clusterleader"]
     verbs: ["get","update", "create"]
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["get", "list", "watch"]
 

--- a/terraform/eks/container-insights-agent/cluster_role_fargate.yml
+++ b/terraform/eks/container-insights-agent/cluster_role_fargate.yml
@@ -15,3 +15,6 @@ rules:
     verbs: ["get", "list", "watch"]
   - nonResourceURLs: [ "/metrics/cadvisor"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["get", "list", "watch"]

--- a/terraform/eks/container-insights-agent/stateful_set_fargate.yml
+++ b/terraform/eks/container-insights-agent/stateful_set_fargate.yml
@@ -28,6 +28,7 @@ spec:
           command:
             - "/awscollector"
             - "--config=/conf/adot-collector-config.yaml"
+            - "--feature-gates=-processor.resourcedetection.propagateerrors"
           env:
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: "ClusterName=${ClusterName}"

--- a/terraform/eks/main.tf
+++ b/terraform/eks/main.tf
@@ -130,6 +130,14 @@ module "iam_assumable_role_admin" {
 
   provider_url = trimprefix(data.aws_eks_cluster.testing_cluster.identity[0].oidc[0].issuer, "https://")
 
+  # Allow dynamically-named service accounts to assume this role
+  # Service accounts are created with unique testing IDs (e.g., aoc-agent-{testing_id})
+  # in dynamically-named namespaces (e.g., aoc-ns-{testing_id})
+  oidc_subjects_with_wildcards = [
+    "system:serviceaccount:aoc-ns-*:*",
+    "system:serviceaccount:aoc-fargate-ns-*:*",
+  ]
+
   role_policy_arns = [
     "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy",
     "arn:aws:iam::aws:policy/AWSXrayFullAccess",

--- a/terraform/templates/defaults/docker_compose.tpl
+++ b/terraform/templates/defaults/docker_compose.tpl
@@ -9,6 +9,7 @@ services:
   sample_app:
     privileged: true
     image: ${sample_app_image}
+    restart: on-failure
     ports:
       - "${sample_app_external_port}:${sample_app_listen_address_port}"
     environment:


### PR DESCRIPTION
**Description:** Fix CI test failures in aws-otel-collector after upgrading to OpenTelemetry v0.142.0.

This PR addresses CI container insights test failures:

**Changes:**
1. Add `--feature-gates=-processor.resourcedetection.propagateerrors` to Fargate StatefulSet
2. Add `discovery.k8s.io/endpointslices` RBAC permission to ClusterRoles
3. Add `oidc_subjects_with_wildcards` to IAM module for proper IRSA trust policy
4. Increase hop limit to improve stability of our canary tests

**Breaking Changes in OTel v0.142.0:**
- [PR #44609](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44609) - Promote `processor.resourcedetection.propagateerrors` feature gate to beta (enabled by default)
- [PR #44610](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44610) - Remove deprecated `attributes` config from resourcedetection processor
- k8s client-go v0.34.2 now watches EndpointSlices by default

**Link to tracking Issue:** N/A

**Testing:** These changes will be validated by the CI tests that were previously failing.

**Documentation:** N/A

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.