### PR TITLE
Add missing fields to EKS containerd schemas

### DIFF
--- a/validator/src/main/resources/expected-data-template/container-insight/eks/containerd-infrastructure/Container.json
+++ b/validator/src/main/resources/expected-data-template/container-insight/eks/containerd-infrastructure/Container.json
@@ -14,27 +14,33 @@
     "NodeName":{},
     "PodName":{},
     "Namespace":{},
+    "container_cpu_limit":{},
+    "container_cpu_request":{},
+    "container_cpu_usage_system":{},
+    "container_cpu_usage_total":{},
+    "container_cpu_usage_user":{},
+    "container_cpu_utilization":{},
     "container_memory_cache":{},
     "container_memory_failcnt":{},
+    "container_memory_hierarchical_pgfault":{},
+    "container_memory_hierarchical_pgmajfault":{},
     "container_memory_mapped_file":{},
     "container_memory_max_usage":{},
+    "container_memory_pgfault":{},
+    "container_memory_pgmajfault":{},
     "container_memory_rss":{},
     "container_memory_swap":{},
     "container_memory_usage":{},
     "container_memory_working_set":{},
     "container_memory_utilization":{},
     "container_status":{},
+    "number_of_container_restarts":{},
     "kubernetes":{
       "type": "object",
       "properties": {
         "host": {},
         "labels": {
-          "type": "object",
-          "properties": {
-            "controller-revision-hash": {},
-            "k8s-app": {},
-            "pod-template-generation": {}
-          }
+          "type": "object"
         },
         "namespace_name":{},
         "pod_id":{},
@@ -60,7 +66,7 @@
           "additionalProperties": false
         }
       },
-      "required": ["host", "namespace_name", "pod_id", "pod_name", "container_name", "containerd", "pod_owners", "labels"],
+      "required": ["host", "namespace_name", "pod_id", "pod_name", "container_name", "containerd", "pod_owners"],
       "additionalProperties": false
     }
   },

--- a/validator/src/main/resources/expected-data-template/container-insight/eks/containerd-infrastructure/Pod.json
+++ b/validator/src/main/resources/expected-data-template/container-insight/eks/containerd-infrastructure/Pod.json
@@ -15,18 +15,42 @@
     "NodeName":{},
     "PodName":{},
     "Namespace":{},
+    "Service":{},
+    "pod_cpu_limit":{},
+    "pod_cpu_request":{},
+    "pod_cpu_reserved_capacity":{},
+    "pod_cpu_usage_system":{},
+    "pod_cpu_usage_total":{},
+    "pod_cpu_usage_user":{},
+    "pod_cpu_utilization":{},
+    "pod_cpu_utilization_over_pod_limit":{},
     "pod_memory_cache":{},
     "pod_memory_failcnt":{},
+    "pod_memory_hierarchical_pgfault":{},
+    "pod_memory_hierarchical_pgmajfault":{},
+    "pod_memory_limit": {},
     "pod_memory_mapped_file":{},
     "pod_memory_max_usage":{},
+    "pod_memory_pgfault":{},
+    "pod_memory_pgmajfault":{},
+    "pod_memory_request":{},
+    "pod_memory_reserved_capacity":{},
     "pod_memory_rss":{},
     "pod_memory_swap":{},
     "pod_memory_usage":{},
-    "pod_memory_working_set":{},
     "pod_memory_utilization":{},
-    "pod_memory_limit": {},
-    "pod_memory_request":{},
     "pod_memory_utilization_over_pod_limit":{},
+    "pod_memory_working_set":{},
+    "pod_network_rx_bytes":{},
+    "pod_network_rx_dropped":{},
+    "pod_network_rx_errors":{},
+    "pod_network_rx_packets":{},
+    "pod_network_total_bytes":{},
+    "pod_network_tx_bytes":{},
+    "pod_network_tx_dropped":{},
+    "pod_network_tx_errors":{},
+    "pod_network_tx_packets":{},
+    "pod_number_of_container_restarts":{},
     "pod_number_of_containers":{},
     "pod_number_of_running_containers":{},
     "pod_status":{},
@@ -35,12 +59,7 @@
       "properties": {
         "host": {},
         "labels": {
-          "type": "object",
-          "properties": {
-            "controller-revision-hash": {},
-            "name": {},
-            "pod-template-generation": {}
-          }
+          "type": "object"
         },
         "namespace_name":{},
         "pod_id":{},
@@ -55,9 +74,10 @@
             },
             "required": ["owner_kind", "owner_name"]
           }
-        }
+        },
+        "service_name":{}
       },
-      "required": ["host", "namespace_name", "pod_id", "pod_name", "labels", "pod_owners"],
+      "required": ["host", "namespace_name", "pod_id", "pod_name", "pod_owners"],
       "additionalProperties": false
     },
     "_aws": {
@@ -120,9 +140,6 @@
     "pod_memory_usage",
     "pod_memory_working_set",
     "pod_memory_utilization",
-    "pod_memory_limit",
-    "pod_memory_request",
-    "pod_memory_utilization_over_pod_limit",
     "pod_number_of_containers",
     "pod_number_of_running_containers",
     "pod_status",


### PR DESCRIPTION
**Description:** Add missing CPU, network, and pgfault fields to Pod.json and Container.json schemas for EKS containerd tests. These fields are emitted by the collector after OTel dependency bump but were missing from the validation schemas.

**Link to tracking Issue:** N/A

**Testing:** Compared CloudWatch log output against schemas to verify all emitted fields are now included.

**Documentation:** Here is the upstream list for all the metrics collected by the awscontainerinsightsreciever [https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/awscontainerinsightreceiver/README.md#available-m[…]-attributes](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/awscontainerinsightreceiver/README.md#available-metrics-and-resource-attributes)

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.