### PR TITLE
Fix Fargate Container Insights: disable RemoveStartTimeAdjustment

### DIFF
--- a/terraform/eks/container-insights-agent/stateful_set_fargate.yml
+++ b/terraform/eks/container-insights-agent/stateful_set_fargate.yml
@@ -28,7 +28,7 @@ spec:
           command:
             - "/awscollector"
             - "--config=/conf/adot-collector-config.yaml"
-            - "--feature-gates=-processor.resourcedetection.propagateerrors"
+            - "--feature-gates=-processor.resourcedetection.propagateerrors,-receiver.prometheusreceiver.RemoveStartTimeAdjustment"
           env:
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: "ClusterName=${ClusterName}"


### PR DESCRIPTION
The prometheus receiver's `RemoveStartTimeAdjustment` feature gate was promoted to beta (enabled by default) in OTel Collector Contrib v0.140.1. This breaks the `cumulativetodelta` processor's delta computation for Fargate metrics, causing `pod_cpu_utilization_over_pod_limit` and other computed metrics to not be emitted.

Disables the feature gate to restore the previous behavior.

Long-term fix: add `metricstarttime` processor to the ADOT collector and Fargate pipeline config.

Ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/43916