### PR TITLE
fix: reduce Fargate scrape/batch intervals for test validation

### DIFF
--- a/terraform/eks/container-insights-agent/config_map_fargate.yml
+++ b/terraform/eks/container-insights-agent/config_map_fargate.yml
@@ -12,8 +12,8 @@ data:
       prometheus:
         config:
           global:
-            scrape_interval: 1m
-            scrape_timeout: 50s
+            scrape_interval: 15s
+            scrape_timeout: 10s
 
           scrape_configs:
           - job_name: 'kubelets-cadvisor-metrics'
@@ -287,6 +287,7 @@ data:
 
       # converts cumulative sum to delta
       cumulativetodelta:
+        initial_value: keep
         include:
             metrics:
                 - new_container_cpu_usage_seconds_total
@@ -406,7 +407,7 @@ data:
         detectors: [env, eks]
 
       batch:
-        timeout: 60s
+        timeout: 15s
 
     exporters:
       awsemf:


### PR DESCRIPTION
The cumulativetodelta processor needs 2+ scrape cycles before producing output. With 1m scrape + 60s batch, data takes too long to appear and the validator times out.

Reduce scrape_interval to 15s and batch timeout to 15s.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.