### PR TITLE
fix: make Fargate Pod.json schema minimally permissive

### DIFF
--- a/validator/src/main/resources/expected-data-template/container-insight/eks/fargate/Pod.json
+++ b/validator/src/main/resources/expected-data-template/container-insight/eks/fargate/Pod.json
@@ -1,57 +1,31 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "structured log schema",
-  "description": "json schema for the cloudwatch agent k8s structured log",
+  "description": "json schema for the cloudwatch agent k8s structured log - Fargate Pod type",
   "type": "object",
   "properties": {
     "ClusterName": {},
     "LaunchType": {},
     "Namespace": {},
     "PodName": {},
+    "NodeName": {},
     "Type": {},
-    "Timestamp": {},
-    "pod_cpu_usage_total": {},
-    "pod_cpu_limit": {},
-    "pod_cpu_request": {},
-    "pod_cpu_utilization_over_pod_limit": {},
+    "Version": {},
+    "OTelLib": {},
+    "pod_memory_working_set": {},
     "pod_memory_cache": {},
-    "pod_memory_failcnt": {},
-    "pod_memory_hierarchical_pgfault": {},
-    "pod_memory_hierarchical_pgmajfault": {},
-    "pod_memory_limit": {},
     "pod_memory_max_usage": {},
-    "pod_memory_pgfault": {},
-    "pod_memory_pgmajfault": {},
     "pod_memory_rss": {},
     "pod_memory_swap": {},
     "pod_memory_usage": {},
-    "pod_memory_utilization_over_pod_limit": {},
-    "pod_memory_working_set": {},
-    "pod_network_rx_bytes": {},
-    "pod_network_rx_dropped": {},
-    "pod_network_rx_errors": {},
-    "pod_network_rx_packets": {},
-    "pod_network_total_bytes": {},
-    "pod_network_tx_bytes": {},
-    "pod_network_tx_dropped": {},
-    "pod_network_tx_errors": {},
-    "pod_network_tx_packets": {},
     "kubernetes": {
       "type": "object",
       "properties": {
         "host": {},
         "namespace_name": {},
-        "pod_name": {},
-        "pod_id": {},
-        "pod_owners": {
-          "type": "array"
-        },
-        "labels": {
-          "type": "object"
-        },
-        "service_name": {}
+        "pod_name": {}
       },
-      "required": ["namespace_name", "pod_name"]
+      "required": ["host", "namespace_name", "pod_name"]
     },
     "_aws": {
       "type": "object",


### PR DESCRIPTION
## Problem

The `eks_containerinsights_fargate_docker` CI test fails with:
```
[StructuredLogValidator] log structure validation failed for [Pod]
```

## Root Cause

The Fargate `Pod.json` schema was written without knowledge of the actual log structure emitted by the collector v0.151.0. The previous fix (PR #1827) added fields like `pod_id`, `pod_owners`, `labels` to the `kubernetes` object — but the actual Fargate pipeline does not emit those (they come from `awscontainerinsightreceiver`, not used in Fargate).

The Fargate pipeline uses `prometheus receiver` → `metricstransform` → `awsemf exporter`, NOT `awscontainerinsightreceiver`. So the `kubernetes` object only contains `{host, namespace_name, pod_name}`.

## Evidence

Actual Pod-type log event pulled from `/aws/containerinsights/collector-ci-fargate-1-33/performance`:
- Top-level: ClusterName, LaunchType, Namespace, PodName, NodeName, Type, Version, OTelLib, pod_memory_*, plus dynamic prometheus labels
- kubernetes: `{host, namespace_name, pod_name}` only
- _aws: `{CloudWatchMetrics, Timestamp}`

## Fix

Schema derived from the actual CloudWatch log event. Validates:
- Required top-level fields: `ClusterName`, `LaunchType`, `Namespace`, `PodName`, `kubernetes`, `_aws`
- `kubernetes` object requires: `host`, `namespace_name`, `pod_name`
- `_aws` object requires: `CloudWatchMetrics`, `Timestamp`
- No `additionalProperties: false` anywhere (prometheus labels are dynamic)

Validated locally against the real log event using jsonschema.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.