### PR TITLE
fix: use ecs detector instead of eks for Fargate resourcedetection

### DIFF
--- a/terraform/eks/container-insights-agent/config_map_fargate.yml
+++ b/terraform/eks/container-insights-agent/config_map_fargate.yml
@@ -402,9 +402,11 @@ data:
             action: update
             new_name: container_$$1
 
-      # add cluster name from env variable and EKS metadata
+      # add cluster name from env variable (OTEL_RESOURCE_ATTRIBUTES)
+      # Note: the eks detector fatally fails on Fargate because IMDS
+      # is unavailable and K8S_NODE_NAME is not set.
       resourcedetection:
-        detectors: [env, eks]
+        detectors: [env]
 
       batch:
         timeout: 15s

--- a/validator/src/main/resources/expected-data-template/container-insight/eks/fargate/Pod.json
+++ b/validator/src/main/resources/expected-data-template/container-insight/eks/fargate/Pod.json
@@ -4,62 +4,37 @@
   "description": "json schema for the cloudwatch agent k8s structured log",
   "type": "object",
   "properties": {
-    "ClusterName": {},
-    "LaunchType": {},
+    "ClusterName":{},
+    "LaunchType":{},
     "Namespace": {},
-    "PodName": {},
-    "Type": {},
-    "Timestamp": {},
-    "pod_cpu_usage_total": {},
-    "pod_cpu_limit": {},
-    "pod_cpu_request": {},
-    "pod_cpu_utilization_over_pod_limit": {},
-    "pod_memory_cache": {},
-    "pod_memory_failcnt": {},
-    "pod_memory_hierarchical_pgfault": {},
-    "pod_memory_hierarchical_pgmajfault": {},
-    "pod_memory_limit": {},
-    "pod_memory_max_usage": {},
-    "pod_memory_pgfault": {},
-    "pod_memory_pgmajfault": {},
-    "pod_memory_rss": {},
-    "pod_memory_swap": {},
-    "pod_memory_usage": {},
-    "pod_memory_utilization_over_pod_limit": {},
-    "pod_memory_working_set": {},
-    "pod_network_rx_bytes": {},
-    "pod_network_rx_dropped": {},
-    "pod_network_rx_errors": {},
-    "pod_network_rx_packets": {},
-    "pod_network_total_bytes": {},
-    "pod_network_tx_bytes": {},
-    "pod_network_tx_dropped": {},
-    "pod_network_tx_errors": {},
-    "pod_network_tx_packets": {},
-    "kubernetes": {
+    "PodName":{},
+    "Timestamp":{},
+    "kubernetes":{
       "type": "object",
       "properties": {
         "host": {},
-        "namespace_name": {},
-        "pod_name": {},
-        "pod_id": {},
-        "pod_owners": {
-          "type": "array"
-        },
-        "labels": {
-          "type": "object"
-        },
-        "service_name": {}
-      },
-      "required": ["namespace_name", "pod_name"]
+        "namespace_name":{},
+        "pod_name":{}
+      }
     },
     "_aws": {
-      "type": "object",
       "properties": {
         "CloudWatchMetrics": {},
         "Timestamp": {}
       },
-      "required": ["CloudWatchMetrics", "Timestamp"]
+      "required": [
+        "CloudWatchMetrics",
+        "Timestamp"
+      ]},
+      "kubernetes": {
+        "type": "object",
+        "properties": {
+          "host": {},
+          "namespace_name":{},
+          "pod_name":{}
+        },
+        "required": ["namespace_name"],
+        "additionalProperties": false
     }
   },
   "required": [
@@ -67,7 +42,6 @@
     "LaunchType",
     "Namespace",
     "PodName",
-    "kubernetes",
-    "_aws"
+    "kubernetes"
   ]
-}
+ }


### PR DESCRIPTION
The `eks` detector in the `resourcedetection` processor fatally crashes on EKS Fargate in OTel Collector Contrib v0.143.0+ because IMDS is unavailable and `K8S_NODE_NAME` is not set. The collector never starts, producing zero metrics and zero logs — causing both `eks_containerinsights_fargate_docker` and `eks_containerinsights_fargate_docker_metric` tests to fail.

The only resource attribute needed by this pipeline is `ClusterName`, which is already provided by the `env` detector via `OTEL_RESOURCE_ATTRIBUTES` set in the StatefulSet.

Fix: `detectors: [env, eks]` → `detectors: [env]`

Also reverts incorrect Pod.json schema and stateful_set feature gate changes from PR #1827.

Ref: https://github.com/aws-observability/aws-otel-collector/issues/3161

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.