### PR TITLE
fix: update Fargate Pod.json schema to match collector v0.151.0 output

### DIFF
--- a/terraform/eks/container-insights-agent/stateful_set_fargate.yml
+++ b/terraform/eks/container-insights-agent/stateful_set_fargate.yml
@@ -28,7 +28,6 @@ spec:
           command:
             - "/awscollector"
             - "--config=/conf/adot-collector-config.yaml"
-            - "--feature-gates=-receiver.prometheusreceiver.RemoveStartTimeAdjustment"
           env:
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: "ClusterName=${ClusterName}"

--- a/validator/src/main/resources/expected-data-template/container-insight/eks/fargate/Pod.json
+++ b/validator/src/main/resources/expected-data-template/container-insight/eks/fargate/Pod.json
@@ -1,40 +1,39 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "structured log schema",
-  "description": "json schema for the cloudwatch agent k8s structured log",
+  "description": "json schema for the cloudwatch agent k8s structured log - Fargate Pod type",
   "type": "object",
   "properties": {
-    "ClusterName":{},
-    "LaunchType":{},
+    "ClusterName": {},
+    "LaunchType": {},
     "Namespace": {},
-    "PodName":{},
-    "Timestamp":{},
-    "kubernetes":{
+    "PodName": {},
+    "NodeName": {},
+    "Type": {},
+    "Version": {},
+    "OTelLib": {},
+    "pod_memory_working_set": {},
+    "pod_memory_cache": {},
+    "pod_memory_max_usage": {},
+    "pod_memory_rss": {},
+    "pod_memory_swap": {},
+    "pod_memory_usage": {},
+    "kubernetes": {
       "type": "object",
       "properties": {
         "host": {},
-        "namespace_name":{},
-        "pod_name":{}
-      }
+        "namespace_name": {},
+        "pod_name": {}
+      },
+      "required": ["host", "namespace_name", "pod_name"]
     },
     "_aws": {
+      "type": "object",
       "properties": {
         "CloudWatchMetrics": {},
         "Timestamp": {}
       },
-      "required": [
-        "CloudWatchMetrics",
-        "Timestamp"
-      ]},
-      "kubernetes": {
-        "type": "object",
-        "properties": {
-          "host": {},
-          "namespace_name":{},
-          "pod_name":{}
-        },
-        "required": ["namespace_name"],
-        "additionalProperties": false
+      "required": ["CloudWatchMetrics", "Timestamp"]
     }
   },
   "required": [
@@ -42,6 +41,7 @@
     "LaunchType",
     "Namespace",
     "PodName",
-    "kubernetes"
+    "kubernetes",
+    "_aws"
   ]
- }
+}


### PR DESCRIPTION
Follow-up to PR #1829 (detector fix). The collector now starts and produces Pod-type logs, but the old Pod.json schema rejects them due to a duplicate kubernetes key bug and additionalProperties:false.

This schema was validated against an actual Pod-type log event pulled from /aws/containerinsights/collector-ci-fargate-1-33/performance.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.