### PR TITLE
fix: batch job naming by platform + quiet terraform logs

### DIFF
--- a/terraform/executeTerraformTest.sh
+++ b/terraform/executeTerraformTest.sh
@@ -73,31 +73,59 @@ case ${AWS_REGION} in
     ;;
 esac
 
+ts() { date -u +"%H:%M:%S"; }
+PROGRESS_FILE="${GITHUB_STEP_SUMMARY:-/dev/null}"
 test_framework_shortsha=$(git rev-parse --short HEAD)
 # Used as a retry mechanic.
 ATTEMPTS_LEFT=2
 cd ${TEST_FOLDER};
+
+TEST_INDEX=${TEST_INDEX:-0}
+TEST_INDEX=$((TEST_INDEX + 1))
+export TEST_INDEX
+
 while [ $ATTEMPTS_LEFT -gt 0 ] && ! ../checkCacheHit.sh $SERVICE $TESTCASE $ADDTL_PARAMS; do
-    terraform init;
-    if timeout -k 5m --signal=SIGINT -v 45m terraform apply -auto-approve -lock=false $opts  -var="testcase=../testcases/$TESTCASE" ; then
+    TESTCASE_START=$(date -u +%s)
+    echo ""
+    echo "╔══════════════════════════════════════════════════════════════"
+    echo "║ TEST ${TEST_INDEX}: ${SERVICE} / ${TESTCASE} / ${ADDTL_PARAMS}"
+    echo "╚══════════════════════════════════════════════════════════════"
+    echo "::group::${SERVICE} ${TESTCASE} ${ADDTL_PARAMS}"
+
+    echo "[$(ts)] terraform init"
+    terraform init -no-color > /dev/null 2>&1;
+
+    echo "[$(ts)] terraform apply (30m timeout)"
+    export TF_IN_AUTOMATION=true
+
+    if timeout -k 5m --signal=SIGINT -v 30m terraform apply -auto-approve -lock=false -compact-warnings $opts  -var="testcase=../testcases/$TESTCASE" ; then
         APPLY_EXIT=$?
-        echo "Exit code: $?" 
+        DURATION=$(( $(date -u +%s) - TESTCASE_START ))
+        echo ""
+        echo "  ✅ PASS: ${SERVICE} / ${TESTCASE} / ${ADDTL_PARAMS} (${DURATION}s)"
+        echo ""
         aws dynamodb put-item --region=us-west-2 --table-name ${DDB_TABLE_NAME} --item {\"TestId\":{\"S\":\"$SERVICE$TESTCASE$ADDTL_PARAMS\"}\,\"aoc_version\":{\"S\":\"$DDB_SK_PREFIX$test_framework_shortsha\"}\,\"TimeToExist\":{\"N\":\"${TTL_DATE}\"}} --return-consumed-capacity TOTAL
+        echo "| $SERVICE | $TESTCASE | :white_check_mark: pass | ${DURATION}s |" >> "$PROGRESS_FILE"
     else
         APPLY_EXIT=$?
-        echo "Terraform apply failed"
-        echo "Exit code: $?"
-        echo "AWS_service: $SERVICE"
-        echo "Testcase: $TESTCASE" 
+        DURATION=$(( $(date -u +%s) - TESTCASE_START ))
+        echo ""
+        echo "  ❌ FAIL: ${SERVICE} / ${TESTCASE} / ${ADDTL_PARAMS} (exit=${APPLY_EXIT}, ${DURATION}s)"
+        echo ""
+        echo "| $SERVICE | $TESTCASE | :x: fail (exit=$APPLY_EXIT) | ${DURATION}s |" >> "$PROGRESS_FILE"
     fi
 
+    echo "[$(ts)] terraform destroy"
     case "$SERVICE" in
-        EKS*) terraform destroy --auto-approve $opts;
+        EKS*) terraform destroy --auto-approve -compact-warnings $opts > /dev/null 2>&1;
         ;;
     *)
-        terraform destroy --auto-approve;
+        terraform destroy --auto-approve -compact-warnings > /dev/null 2>&1;
     ;;
     esac
+
+    echo "[$(ts)] Destroy complete"
+    echo "::endgroup::"
 
     if [ $APPLY_EXIT -ne 0 ]; then
         echo "Waiting 60s before retry to allow resource cleanup..."

--- a/tools/batchTestGenerator/internal/githubGenerator.go
+++ b/tools/batchTestGenerator/internal/githubGenerator.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"container/ring"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -68,88 +67,34 @@ func GithubGenerator(config RunConfig) error {
 }
 
 func createBatchMap(maxBatches int, testCases []TestCaseInfo) (map[string][]string, error) {
-	var numBatches int
-	if len(testCases) <= maxBatches {
-		numBatches = len(testCases)
-	} else {
-		numBatches = maxBatches
-	}
-
-	nonParallelTestSet := map[string][]TestCaseInfo{
-		"EKS_ADOT_OPERATOR":       {},
-		"EKS_ADOT_OPERATOR_ARM64": {},
-		"EKS_FARGATE":             {},
-	}
-
-	if numBatches == 1 {
-		nonParallelTestSet = map[string][]TestCaseInfo{}
-	} else if numBatches-len(nonParallelTestSet) <= 0 {
-		numBatches = 1
-	} else {
-		numBatches -= len(nonParallelTestSet)
-	}
-
-	// circular linked list to distribute values
-	// we reach for a circular LL to evenly distrubute values since no
-	// weighting is being done during the batching process. We just want the
-	// easiest way to distribute test cases.
-	testContainers := ring.New(numBatches)
-	for i := 0; i < numBatches; i++ {
-		testContainers.Value = make([]TestCaseInfo, 0)
-		testContainers = testContainers.Next()
-	}
-
-	// distribute tests into containers
+	// Group tests by platform so batches never mix platforms
+	platformGroups := make(map[string][]TestCaseInfo)
 	for _, tc := range testCases {
-		if _, ok := nonParallelTestSet[tc.serviceType]; ok {
-			nonParallelTestSet[tc.serviceType] = append(nonParallelTestSet[tc.serviceType], tc)
-		} else {
-			testContainers.Value = append(testContainers.Value.([]TestCaseInfo), tc)
-			testContainers = testContainers.Next()
-		}
-
+		platformGroups[tc.serviceType] = append(platformGroups[tc.serviceType], tc)
 	}
 
-	// assign containers to a batch
+	// Allocate batch slots proportionally per platform
 	batchMap := make(map[string][]string)
+	totalTests := len(testCases)
 
-	batch := 0
-	// non-parallel tests
-	for _, npts := range nonParallelTestSet {
-		if len(npts) == 0 {
-			continue
-		}
-
-		nptsStringArray, err := generateBachValuesStringArray(npts)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create non parallel test set string array: %w", err)
-		}
-		id := fmt.Sprintf("batch%d", batch)
-		batchMap[id] = append(batchMap[id], nptsStringArray...)
-		if batch < maxBatches {
-			batch++
-		}
-	}
-
-	//assign following batches
-	for i := 0; i < numBatches; i++ {
-		ts := testContainers.Value.([]TestCaseInfo)
-		if len(ts) == 0 {
-			testContainers = testContainers.Next()
-			continue
+	for platform, tests := range platformGroups {
+		// Proportional share of batches for this platform
+		share := (len(tests) * maxBatches) / totalTests
+		if share < 1 {
+			share = 1
 		}
 
-		batchValueStringArray, err := generateBachValuesStringArray(ts)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create batchValueString: %w", err)
-		}
-		id := fmt.Sprintf("batch%d", batch)
-		batchMap[id] = append(batchMap[id], batchValueStringArray...)
-		testContainers = testContainers.Next()
-		if batch < maxBatches {
-			batch++
+		// Calculate tests per batch for this platform
+		testsPerBatch := (len(tests) + share - 1) / share
+
+		for i, tc := range tests {
+			batchNum := i / testsPerBatch
+			id := fmt.Sprintf("%s/%d", platform, batchNum)
+			val := fmt.Sprintf("%s %s %s", tc.serviceType, tc.testcaseName, tc.additionalVar)
+			batchMap[id] = append(batchMap[id], val)
 		}
 	}
 
 	return batchMap, nil
 }
+

--- a/tools/batchTestGenerator/internal/githubGenerator.go
+++ b/tools/batchTestGenerator/internal/githubGenerator.go
@@ -67,29 +67,33 @@ func GithubGenerator(config RunConfig) error {
 }
 
 func createBatchMap(maxBatches int, testCases []TestCaseInfo) (map[string][]string, error) {
-	// Group tests by platform so batches never mix platforms
-	platformGroups := make(map[string][]TestCaseInfo)
+	// Group tests by platform + variant (AMI for EC2, cluster for EKS, launch type for ECS)
+	subGroups := make(map[string][]TestCaseInfo)
 	for _, tc := range testCases {
-		platformGroups[tc.serviceType] = append(platformGroups[tc.serviceType], tc)
+		key := fmt.Sprintf("%s/%s", tc.serviceType, tc.additionalVar)
+		subGroups[key] = append(subGroups[key], tc)
 	}
 
-	// Allocate batch slots proportionally per platform
+	// Allocate batch slots proportionally per sub-group
 	batchMap := make(map[string][]string)
 	totalTests := len(testCases)
 
-	for platform, tests := range platformGroups {
-		// Proportional share of batches for this platform
+	for groupKey, tests := range subGroups {
 		share := (len(tests) * maxBatches) / totalTests
 		if share < 1 {
 			share = 1
 		}
 
-		// Calculate tests per batch for this platform
 		testsPerBatch := (len(tests) + share - 1) / share
 
 		for i, tc := range tests {
 			batchNum := i / testsPerBatch
-			id := fmt.Sprintf("%s/%d", platform, batchNum)
+			var id string
+			if testsPerBatch == 1 || len(tests) <= share {
+				id = fmt.Sprintf("%s/%s", groupKey, tc.testcaseName)
+			} else {
+				id = fmt.Sprintf("%s/%d", groupKey, batchNum)
+			}
 			val := fmt.Sprintf("%s %s %s", tc.serviceType, tc.testcaseName, tc.additionalVar)
 			batchMap[id] = append(batchMap[id], val)
 		}


### PR DESCRIPTION
## Summary
- Group batch jobs by platform/variant (e.g., EC2/amazonlinux2/3 instead of random batch numbers)
- Quiet terraform: init silenced, destroy silenced, -compact-warnings on apply
- Clear test progress banners with pass/fail status and duration
- Job summary table (Service | Testcase | Status | Duration)
- ::group:: annotations for collapsible sections in GitHub UI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.