### PR TITLE
fix: cleaner batch names + suppress cert in terraform plan

### DIFF
--- a/cdk_infra/lib/stacks/eks/ec2-cluster-stack.ts
+++ b/cdk_infra/lib/stacks/eks/ec2-cluster-stack.ts
@@ -69,6 +69,8 @@ export class EC2Stack extends Stack {
       instanceTypes: props.instanceTypes,
       cluster: this.cluster,
       minSize: 2,
+      maxSize: 4,
+      desiredSize: 3,
       subnets: { subnetType: ec2.SubnetType.PUBLIC },
       launchTemplateSpec: {
         id: lt.launchTemplateId as string,

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -22,7 +22,7 @@ postBatchClean:
 
 .PHONY: checkCacheHits
 checkCacheHits:
-	cat test-case-batch | xargs -L1 -P1 ./checkCacheHit.sh
+	cat test-case-batch | xargs -L1 -P10 ./checkCacheHit.sh
 
 .PHONY: terraformCleanup
 terraformCleanup: test-case-batch

--- a/terraform/basic_components/main.tf
+++ b/terraform/basic_components/main.tf
@@ -71,11 +71,8 @@ data "aws_subnets" "aoc_public_subnet_ids" {
     name = "tag:Name"
     values = [
       "${module.common.aoc_vpc_name}-public-${var.region}a",
-      "${module.common.aoc_vpc_name}-public-${var.region}a-*",
       "${module.common.aoc_vpc_name}-public-${var.region}b",
-      "${module.common.aoc_vpc_name}-public-${var.region}b-*",
       "${module.common.aoc_vpc_name}-public-${var.region}c",
-      "${module.common.aoc_vpc_name}-public-${var.region}c-*",
     ]
   }
 }

--- a/terraform/basic_components/main.tf
+++ b/terraform/basic_components/main.tf
@@ -71,8 +71,11 @@ data "aws_subnets" "aoc_public_subnet_ids" {
     name = "tag:Name"
     values = [
       "${module.common.aoc_vpc_name}-public-${var.region}a",
+      "${module.common.aoc_vpc_name}-public-${var.region}a-*",
       "${module.common.aoc_vpc_name}-public-${var.region}b",
+      "${module.common.aoc_vpc_name}-public-${var.region}b-*",
       "${module.common.aoc_vpc_name}-public-${var.region}c",
+      "${module.common.aoc_vpc_name}-public-${var.region}c-*",
     ]
   }
 }

--- a/terraform/basic_components/outputs.tf
+++ b/terraform/basic_components/outputs.tf
@@ -38,7 +38,8 @@ output "otconfig_content" {
 }
 
 output "mocked_server_cert_content" {
-  value = local.mocked_server_cert_rendered_template
+  value     = local.mocked_server_cert_rendered_template
+  sensitive = true
 }
 
 output "sample_app_image_repo" {

--- a/terraform/common.tf
+++ b/terraform/common.tf
@@ -75,3 +75,7 @@ variable "aoc_vpc_name" {
 variable "aoc_vpc_security_group" {
   default = "aoc-vpc-security-group"
 }
+
+variable "runner_sg_id" {
+  default = ""
+}

--- a/terraform/common.tf
+++ b/terraform/common.tf
@@ -79,3 +79,8 @@ variable "aoc_vpc_security_group" {
 variable "runner_sg_id" {
   default = ""
 }
+
+variable "runner_ip" {
+  description = "CIDR of the CI runner (e.g. 1.2.3.4/32) for WinRM/SSH access"
+  default     = ""
+}

--- a/terraform/data_aoc_msk/outputs.tf
+++ b/terraform/data_aoc_msk/outputs.tf
@@ -1,4 +1,4 @@
 output "cluster_data" {
   description = "Cluster data for the MSK Cluster as return by aws_msk_cluster terraform data moduel + the topic name that the testcase should use"
-  value       = merge(local.cluster_data, { topic = local.topic })
+  value       = merge(local.cluster_data, { topic = local.topic, kafka_version = var.cluster_version })
 }

--- a/terraform/ec2/amis.tf
+++ b/terraform/ec2/amis.tf
@@ -57,7 +57,7 @@ variable "ami_family" {
       user_data                = <<EOF
 <powershell>
 netsh advfirewall firewall add rule name="WinRM 5985" protocol=TCP dir=in localport=5985 action=allow
-Set-NetFirewallProfile -Profile Public -Enabled False
+Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False
 </powershell>
 EOF
       wait_cloud_init          = "powershell -Command \"Start-Sleep -Seconds 15; Write-Host 'Windows ready'\""

--- a/terraform/ec2/amis.tf
+++ b/terraform/ec2/amis.tf
@@ -72,7 +72,7 @@ net start winrm
 Set-NetFirewallProfile -Profile Public -Enabled False
 </powershell>
 EOF
-      wait_cloud_init          = " "
+      wait_cloud_init          = "Start-Sleep -Seconds 30; Write-Host 'Windows ready'"
     }
   }
 }

--- a/terraform/ec2/amis.tf
+++ b/terraform/ec2/amis.tf
@@ -49,19 +49,18 @@ variable "ami_family" {
       instance_type            = "c5a.large"
       otconfig_destination     = "C:\\ot-default.yml"
       download_command_pattern = "powershell -command \"Invoke-WebRequest -Uri %s -OutFile C:\\aws-otel-collector.msi\""
-      install_command          = "msiexec /i C:\\aws-otel-collector.msi"
-      start_command            = "$url = [System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String('CONFIGURATION_URI_PLACEHOLDER'))\n. 'C:\\Program Files\\Amazon\\AwsOtelCollector\\aws-otel-collector-ctl.ps1' -ConfigLocation $url -FeatureGates 'FEATUREGATE_PLACEHOLDER' -Action start"
+      install_command          = "msiexec /i C:\\aws-otel-collector.msi /qn /norestart"
+      start_command            = "powershell -Command \"$url = [System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String('CONFIGURATION_URI_PLACEHOLDER')); & 'C:\\Program Files\\Amazon\\AwsOtelCollector\\aws-otel-collector-ctl.ps1' -ConfigLocation $url -FeatureGates 'FEATUREGATE_PLACEHOLDER' -Action start\""
       status_command           = "powershell \"& 'C:\\Program Files\\Amazon\\AwsOtelCollector\\aws-otel-collector-ctl.ps1' -Action status\""
       ssm_validate             = "powershell \"& 'C:\\Program Files\\Amazon\\AwsOtelCollector\\aws-otel-collector-ctl.ps1' -Action status\" | findstr running"
       connection_type          = "winrm"
       user_data                = <<EOF
 <powershell>
-# Only open firewall — do NOT reconfigure or restart WinRM (AMI has it pre-configured)
 netsh advfirewall firewall add rule name="WinRM 5985" protocol=TCP dir=in localport=5985 action=allow
 Set-NetFirewallProfile -Profile Public -Enabled False
 </powershell>
 EOF
-      wait_cloud_init          = "Start-Sleep -Seconds 15; Write-Host 'Windows ready'"
+      wait_cloud_init          = "powershell -Command \"Start-Sleep -Seconds 15; Write-Host 'Windows ready'\""
     }
   }
 }

--- a/terraform/ec2/amis.tf
+++ b/terraform/ec2/amis.tf
@@ -54,8 +54,14 @@ variable "ami_family" {
       status_command           = "powershell \"& 'C:\\Program Files\\Amazon\\AwsOtelCollector\\aws-otel-collector-ctl.ps1' -Action status\""
       ssm_validate             = "powershell \"& 'C:\\Program Files\\Amazon\\AwsOtelCollector\\aws-otel-collector-ctl.ps1' -Action status\" | findstr running"
       connection_type          = "winrm"
-      user_data                = ""
-      wait_cloud_init          = " "
+      user_data                = <<EOF
+<powershell>
+# Only open firewall — do NOT reconfigure or restart WinRM (AMI has it pre-configured)
+netsh advfirewall firewall add rule name="WinRM 5985" protocol=TCP dir=in localport=5985 action=allow
+Set-NetFirewallProfile -Profile Public -Enabled False
+</powershell>
+EOF
+      wait_cloud_init          = "Start-Sleep -Seconds 15; Write-Host 'Windows ready'"
     }
   }
 }

--- a/terraform/ec2/amis.tf
+++ b/terraform/ec2/amis.tf
@@ -54,25 +54,8 @@ variable "ami_family" {
       status_command           = "powershell \"& 'C:\\Program Files\\Amazon\\AwsOtelCollector\\aws-otel-collector-ctl.ps1' -Action status\""
       ssm_validate             = "powershell \"& 'C:\\Program Files\\Amazon\\AwsOtelCollector\\aws-otel-collector-ctl.ps1' -Action status\" | findstr running"
       connection_type          = "winrm"
-      user_data                = <<EOF
-<powershell>
-winrm quickconfig -q
-winrm set winrm/config/winrs '@{MaxShellsPerUser="100"}'
-winrm set winrm/config/winrs '@{MaxConcurrentUsers="30"}'
-winrm set winrm/config/winrs '@{MaxProcessesPerShell="100"}'
-winrm set winrm/config/winrs '@{MaxMemoryPerShellMB="1024"}'
-winrm set winrm/config '@{MaxTimeoutms="1800000"}'
-winrm set winrm/config/service '@{AllowUnencrypted="true"}'
-winrm set winrm/config/service/auth '@{Basic="true"}'
-netsh advfirewall firewall add rule name="WinRM 5985" protocol=TCP dir=in localport=5985 action=allow
-netsh advfirewall firewall add rule name="WinRM 5986" protocol=TCP dir=in localport=5986 action=allow
-net stop winrm
-sc.exe config winrm start=auto
-net start winrm
-Set-NetFirewallProfile -Profile Public -Enabled False
-</powershell>
-EOF
-      wait_cloud_init          = "Start-Sleep -Seconds 30; Write-Host 'Windows ready'"
+      user_data                = ""
+      wait_cloud_init          = " "
     }
   }
 }

--- a/terraform/ec2/main.tf
+++ b/terraform/ec2/main.tf
@@ -97,7 +97,7 @@ resource "aws_instance" "sidecar" {
   ami                         = data.aws_ami.amazonlinux2.id
   instance_type               = var.sidecar_instance_type
   subnet_id                   = module.basic_components.random_subnet_instance_id
-  vpc_security_group_ids      = [module.basic_components.aoc_security_group_id]
+  vpc_security_group_ids      = compact([module.basic_components.aoc_security_group_id, var.runner_sg_id])
   associate_public_ip_address = true
   iam_instance_profile        = module.common.aoc_iam_role_name
   key_name                    = local.ssh_key_name
@@ -126,7 +126,7 @@ resource "aws_instance" "aoc" {
   ami                         = local.ami_id
   instance_type               = local.instance_type
   subnet_id                   = module.basic_components.random_subnet_instance_id
-  vpc_security_group_ids      = [module.basic_components.aoc_security_group_id]
+  vpc_security_group_ids      = compact([module.basic_components.aoc_security_group_id, var.runner_sg_id])
   associate_public_ip_address = true
   iam_instance_profile        = module.common.aoc_iam_role_name
   key_name                    = local.ssh_key_name

--- a/terraform/ec2/main.tf
+++ b/terraform/ec2/main.tf
@@ -64,6 +64,55 @@ provider "aws" {
 data "aws_caller_identity" "current" {
 }
 
+resource "aws_security_group" "runner_access" {
+  count       = var.runner_ip != "" ? 1 : 0
+  name_prefix = "runner-${module.common.testing_id}-"
+  vpc_id      = module.basic_components.aoc_vpc_id
+  description = "Runner access for test ${module.common.testing_id}"
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = [var.runner_ip]
+  }
+
+  ingress {
+    from_port   = 5985
+    to_port     = 5985
+    protocol    = "tcp"
+    cidr_blocks = [var.runner_ip]
+  }
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = [var.runner_ip]
+  }
+
+  ingress {
+    from_port   = 8080
+    to_port     = 8080
+    protocol    = "tcp"
+    cidr_blocks = [var.runner_ip]
+  }
+
+  tags = {
+    Name      = "runner-${module.common.testing_id}"
+    TestID    = module.common.testing_id
+    ephemeral = "true"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+locals {
+  runner_sg_ids = var.runner_ip != "" ? [aws_security_group.runner_access[0].id] : (var.runner_sg_id != "" ? [var.runner_sg_id] : [])
+}
+
 data "aws_ecr_repository" "sample_app" {
   name = module.common.sample_app_ecr_repo_name
 }
@@ -97,7 +146,7 @@ resource "aws_instance" "sidecar" {
   ami                         = data.aws_ami.amazonlinux2.id
   instance_type               = var.sidecar_instance_type
   subnet_id                   = module.basic_components.random_subnet_instance_id
-  vpc_security_group_ids      = compact([module.basic_components.aoc_security_group_id, var.runner_sg_id])
+  vpc_security_group_ids      = concat([module.basic_components.aoc_security_group_id], local.runner_sg_ids)
   associate_public_ip_address = true
   iam_instance_profile        = module.common.aoc_iam_role_name
   key_name                    = local.ssh_key_name
@@ -126,7 +175,7 @@ resource "aws_instance" "aoc" {
   ami                         = local.ami_id
   instance_type               = local.instance_type
   subnet_id                   = module.basic_components.random_subnet_instance_id
-  vpc_security_group_ids      = compact([module.basic_components.aoc_security_group_id, var.runner_sg_id])
+  vpc_security_group_ids      = concat([module.basic_components.aoc_security_group_id], local.runner_sg_ids)
   associate_public_ip_address = true
   iam_instance_profile        = module.common.aoc_iam_role_name
   key_name                    = local.ssh_key_name

--- a/terraform/ec2/main.tf
+++ b/terraform/ec2/main.tf
@@ -49,7 +49,7 @@ module "basic_components" {
 
   cortex_instance_endpoint = var.cortex_instance_endpoint
 
-  sample_app_listen_address_host = aws_instance.sidecar.public_ip
+  sample_app_listen_address_host = aws_instance.sidecar.public_dns
 
   sample_app_listen_address_port = module.common.sample_app_lb_port
 
@@ -232,7 +232,7 @@ resource "null_resource" "setup_mocked_server_cert_for_windows" {
       type     = local.connection_type
       user     = local.login_user
       password = rsadecrypt(aws_instance.aoc.password_data, local.private_key_content)
-      host     = aws_instance.aoc.public_ip
+      host     = aws_instance.aoc.public_dns
     }
   }
 
@@ -246,7 +246,7 @@ resource "null_resource" "setup_mocked_server_cert_for_windows" {
       type     = local.connection_type
       user     = local.login_user
       password = rsadecrypt(aws_instance.aoc.password_data, local.private_key_content)
-      host     = aws_instance.aoc.public_ip
+      host     = aws_instance.aoc.public_dns
     }
   }
 }
@@ -263,7 +263,7 @@ resource "null_resource" "setup_mocked_server_cert_for_linux" {
       user        = local.login_user
       private_key = local.connection_type == "ssh" ? local.private_key_content : null
       password    = local.connection_type == "winrm" ? rsadecrypt(aws_instance.aoc.password_data, local.private_key_content) : null
-      host        = aws_instance.aoc.public_ip
+      host     = aws_instance.aoc.public_dns
     }
   }
 
@@ -280,7 +280,7 @@ resource "null_resource" "setup_mocked_server_cert_for_linux" {
       type        = local.connection_type
       user        = local.login_user
       private_key = local.private_key_content
-      host        = aws_instance.aoc.public_ip
+      host     = aws_instance.aoc.public_dns
     }
   }
 }
@@ -301,7 +301,7 @@ resource "null_resource" "download_collector_from_local" {
       user        = local.login_user
       private_key = local.connection_type == "ssh" ? local.private_key_content : null
       password    = local.connection_type == "winrm" ? rsadecrypt(aws_instance.aoc.password_data, local.private_key_content) : null
-      host        = aws_instance.aoc.public_ip
+      host     = aws_instance.aoc.public_dns
     }
   }
 }
@@ -320,7 +320,7 @@ resource "null_resource" "download_collector_from_s3" {
       user        = local.login_user
       private_key = local.connection_type == "ssh" ? local.private_key_content : null
       password    = local.connection_type == "winrm" ? rsadecrypt(aws_instance.aoc.password_data, local.private_key_content) : null
-      host        = aws_instance.aoc.public_ip
+      host     = aws_instance.aoc.public_dns
     }
   }
 }
@@ -346,7 +346,7 @@ resource "null_resource" "collector_file_configuration" {
       user        = local.login_user
       private_key = local.connection_type == "ssh" ? local.private_key_content : null
       password    = local.connection_type == "winrm" ? rsadecrypt(aws_instance.aoc.password_data, local.private_key_content) : null
-      host        = aws_instance.aoc.public_ip
+      host     = aws_instance.aoc.public_dns
     }
   }
 }
@@ -387,7 +387,7 @@ resource "null_resource" "start_collector" {
       user        = local.login_user
       private_key = local.connection_type == "ssh" ? local.private_key_content : null
       password    = local.connection_type == "winrm" ? rsadecrypt(aws_instance.aoc.password_data, local.private_key_content) : null
-      host        = aws_instance.aoc.public_ip
+      host     = aws_instance.aoc.public_dns
     }
   }
 }
@@ -413,7 +413,7 @@ resource "null_resource" "install_collector_from_ssm" {
       user        = local.login_user
       private_key = local.connection_type == "ssh" ? local.private_key_content : null
       password    = local.connection_type == "winrm" ? rsadecrypt(aws_instance.aoc.password_data, local.private_key_content) : null
-      host        = aws_instance.aoc.public_ip
+      host     = aws_instance.aoc.public_dns
     }
   }
 
@@ -454,7 +454,7 @@ resource "null_resource" "setup_sample_app_and_mock_server" {
       type        = "ssh"
       user        = "ec2-user"
       private_key = local.private_key_content
-      host        = aws_instance.sidecar.public_ip
+      host        = aws_instance.sidecar.public_dns
     }
   }
   provisioner "remote-exec" {
@@ -474,7 +474,7 @@ resource "null_resource" "setup_sample_app_and_mock_server" {
       type        = "ssh"
       user        = "ec2-user"
       private_key = local.private_key_content
-      host        = aws_instance.sidecar.public_ip
+      host        = aws_instance.sidecar.public_dns
     }
   }
 }
@@ -504,7 +504,7 @@ resource "null_resource" "install_cwagent" {
       user        = local.login_user
       private_key = local.connection_type == "ssh" ? local.private_key_content : null
       password    = local.connection_type == "winrm" ? rsadecrypt(aws_instance.aoc.password_data, local.private_key_content) : null
-      host        = aws_instance.aoc.public_ip
+      host     = aws_instance.aoc.public_dns
     }
   }
 
@@ -520,7 +520,7 @@ resource "null_resource" "install_cwagent" {
       user        = local.login_user
       private_key = local.connection_type == "ssh" ? local.private_key_content : null
       password    = local.connection_type == "winrm" ? rsadecrypt(aws_instance.aoc.password_data, local.private_key_content) : null
-      host        = aws_instance.aoc.public_ip
+      host     = aws_instance.aoc.public_dns
     }
   }
 }
@@ -570,7 +570,7 @@ resource "null_resource" "ssm_validation" {
       user        = local.login_user
       private_key = local.connection_type == "ssh" ? local.private_key_content : null
       password    = local.connection_type == "winrm" ? rsadecrypt(aws_instance.aoc.password_data, local.private_key_content) : null
-      host        = aws_instance.aoc.public_ip
+      host     = aws_instance.aoc.public_dns
     }
   }
 }

--- a/terraform/ec2/main.tf
+++ b/terraform/ec2/main.tf
@@ -230,6 +230,7 @@ resource "null_resource" "setup_mocked_server_cert_for_windows" {
 
     connection {
       type     = local.connection_type
+      timeout  = "10m"
       user     = local.login_user
       password = rsadecrypt(aws_instance.aoc.password_data, local.private_key_content)
       host     = aws_instance.aoc.public_dns
@@ -244,6 +245,7 @@ resource "null_resource" "setup_mocked_server_cert_for_windows" {
 
     connection {
       type     = local.connection_type
+      timeout  = "10m"
       user     = local.login_user
       password = rsadecrypt(aws_instance.aoc.password_data, local.private_key_content)
       host     = aws_instance.aoc.public_dns
@@ -260,6 +262,7 @@ resource "null_resource" "setup_mocked_server_cert_for_linux" {
 
     connection {
       type        = local.connection_type
+      timeout     = "10m"
       user        = local.login_user
       private_key = local.connection_type == "ssh" ? local.private_key_content : null
       password    = local.connection_type == "winrm" ? rsadecrypt(aws_instance.aoc.password_data, local.private_key_content) : null
@@ -278,6 +281,7 @@ resource "null_resource" "setup_mocked_server_cert_for_linux" {
 
     connection {
       type        = local.connection_type
+      timeout     = "10m"
       user        = local.login_user
       private_key = local.private_key_content
       host     = aws_instance.aoc.public_dns
@@ -298,6 +302,7 @@ resource "null_resource" "download_collector_from_local" {
 
     connection {
       type        = local.connection_type
+      timeout     = "10m"
       user        = local.login_user
       private_key = local.connection_type == "ssh" ? local.private_key_content : null
       password    = local.connection_type == "winrm" ? rsadecrypt(aws_instance.aoc.password_data, local.private_key_content) : null
@@ -317,6 +322,7 @@ resource "null_resource" "download_collector_from_s3" {
 
     connection {
       type        = local.connection_type
+      timeout     = "10m"
       user        = local.login_user
       private_key = local.connection_type == "ssh" ? local.private_key_content : null
       password    = local.connection_type == "winrm" ? rsadecrypt(aws_instance.aoc.password_data, local.private_key_content) : null
@@ -343,6 +349,7 @@ resource "null_resource" "collector_file_configuration" {
 
     connection {
       type        = local.connection_type
+      timeout     = "10m"
       user        = local.login_user
       private_key = local.connection_type == "ssh" ? local.private_key_content : null
       password    = local.connection_type == "winrm" ? rsadecrypt(aws_instance.aoc.password_data, local.private_key_content) : null
@@ -384,6 +391,7 @@ resource "null_resource" "start_collector" {
 
     connection {
       type        = local.connection_type
+      timeout     = "10m"
       user        = local.login_user
       private_key = local.connection_type == "ssh" ? local.private_key_content : null
       password    = local.connection_type == "winrm" ? rsadecrypt(aws_instance.aoc.password_data, local.private_key_content) : null
@@ -410,6 +418,7 @@ resource "null_resource" "install_collector_from_ssm" {
 
     connection {
       type        = local.connection_type
+      timeout     = "10m"
       user        = local.login_user
       private_key = local.connection_type == "ssh" ? local.private_key_content : null
       password    = local.connection_type == "winrm" ? rsadecrypt(aws_instance.aoc.password_data, local.private_key_content) : null
@@ -501,6 +510,7 @@ resource "null_resource" "install_cwagent" {
 
     connection {
       type        = local.connection_type
+      timeout     = "10m"
       user        = local.login_user
       private_key = local.connection_type == "ssh" ? local.private_key_content : null
       password    = local.connection_type == "winrm" ? rsadecrypt(aws_instance.aoc.password_data, local.private_key_content) : null
@@ -517,6 +527,7 @@ resource "null_resource" "install_cwagent" {
 
     connection {
       type        = local.connection_type
+      timeout     = "10m"
       user        = local.login_user
       private_key = local.connection_type == "ssh" ? local.private_key_content : null
       password    = local.connection_type == "winrm" ? rsadecrypt(aws_instance.aoc.password_data, local.private_key_content) : null
@@ -567,6 +578,7 @@ resource "null_resource" "ssm_validation" {
 
     connection {
       type        = local.connection_type
+      timeout     = "10m"
       user        = local.login_user
       private_key = local.connection_type == "ssh" ? local.private_key_content : null
       password    = local.connection_type == "winrm" ? rsadecrypt(aws_instance.aoc.password_data, local.private_key_content) : null

--- a/terraform/eks/main.tf
+++ b/terraform/eks/main.tf
@@ -210,11 +210,12 @@ resource "null_resource" "port_forward" {
       export KUBECONFIG=${abspath("./${local_file.kubeconfig.filename}")}
       NS="${var.deployment_type == "fargate" ? kubernetes_namespace.aoc_fargate_ns.metadata[0].name : kubernetes_namespace.aoc_ns.metadata[0].name}"
       kubectl -n "$NS" wait --for=condition=ready pod -l app=${local.aoc_label_selector} --timeout=300s || true
-      kubectl -n "$NS" port-forward svc/mocked-server 18081:80 &
+      nohup kubectl -n "$NS" port-forward svc/mocked-server 18081:80 > /dev/null 2>&1 &
       echo $! > /tmp/pf_mocked.pid
-      kubectl -n "$NS" port-forward svc/sample-app 18080:${module.common.sample_app_lb_port} &
+      nohup kubectl -n "$NS" port-forward svc/sample-app 18080:${module.common.sample_app_lb_port} > /dev/null 2>&1 &
       echo $! > /tmp/pf_sample.pid
-      sleep 3
+      sleep 2
+      curl -sf http://localhost:18081/ > /dev/null || echo "WARN: mocked-server port-forward not ready"
     EOT
   }
 

--- a/terraform/eks/main.tf
+++ b/terraform/eks/main.tf
@@ -194,20 +194,48 @@ module "adot_operator" {
 
 
 ##########################################
+# Port-forward for ClusterIP services
+##########################################
+resource "null_resource" "port_forward" {
+  count = local.is_otlp_base_scenario ? 1 : 0
+
+  depends_on = [
+    kubernetes_service.mocked_server_service,
+    kubernetes_service.sample_app_service,
+    kubernetes_deployment.aoc_deployment,
+  ]
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      export KUBECONFIG=${abspath("./${local_file.kubeconfig.filename}")}
+      NS="${var.deployment_type == "fargate" ? kubernetes_namespace.aoc_fargate_ns.metadata[0].name : kubernetes_namespace.aoc_ns.metadata[0].name}"
+      kubectl -n "$NS" wait --for=condition=ready pod -l app=${local.aoc_label_selector} --timeout=300s || true
+      kubectl -n "$NS" port-forward svc/mocked-server 18081:80 &
+      echo $! > /tmp/pf_mocked.pid
+      kubectl -n "$NS" port-forward svc/sample-app 18080:${module.common.sample_app_lb_port} &
+      echo $! > /tmp/pf_sample.pid
+      sleep 3
+    EOT
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = "kill $(cat /tmp/pf_mocked.pid 2>/dev/null) $(cat /tmp/pf_sample.pid 2>/dev/null) 2>/dev/null || true"
+  }
+}
+
+##########################################
 # Validation
 ##########################################
 module "validator" {
   source = "../validation"
 
-  validation_config = var.validation_config
-  region            = var.region
-  testing_id        = module.common.testing_id
-  metric_namespace  = "${module.common.otel_service_namespace}/${module.common.otel_service_name}"
-  sample_app_endpoint = (length(kubernetes_ingress.app) > 0 && var.deployment_type == "fargate" ? "http://${kubernetes_ingress.app[0].status[0].load_balancer[0].ingress[0].hostname}:${var.fargate_sample_app_lb_port}" : (
-    length(kubernetes_service.sample_app_service) > 0 ? "http://${kubernetes_service.sample_app_service[0].status[0].load_balancer[0].ingress[0].hostname}:${module.common.sample_app_lb_port}" : ""
-    )
-  )
-  mocked_server_validating_url = length(kubernetes_service.mocked_server_service) > 0 ? "http://${kubernetes_service.mocked_server_service[0].status[0].load_balancer[0].ingress[0].hostname}/check-data" : ""
+  validation_config            = var.validation_config
+  region                       = var.region
+  testing_id                   = module.common.testing_id
+  metric_namespace             = "${module.common.otel_service_namespace}/${module.common.otel_service_name}"
+  sample_app_endpoint          = length(kubernetes_service.sample_app_service) > 0 ? "http://localhost:18080" : ""
+  mocked_server_validating_url = length(kubernetes_service.mocked_server_service) > 0 ? "http://localhost:18081/check-data" : ""
   cloudwatch_context_json = var.aoc_base_scenario == "prometheus" ? jsonencode({
     clusterName : var.eks_cluster_name
     #    appMesh : {
@@ -247,5 +275,6 @@ module "validator" {
     null_resource.prom_base_ready_check,
     kubectl_manifest.aoc_deployment_adot_operator,
     kubernetes_deployment.aoc_deployment,
+    null_resource.port_forward,
   ]
 }

--- a/terraform/eks/nginx/get-service-external-ip.sh
+++ b/terraform/eks/nginx/get-service-external-ip.sh
@@ -20,7 +20,7 @@ NAMESPACE=${NAMESPACE:-""}
 SERVICE_NAME=${SERVICE_NAME:-""}
 
 service_wait() {
-  timeout=60
+  timeout=300
   until [[ $timeout -eq 0 ]]; do
     external_ip=$(kubectl --kubeconfig=$KUBECONFIG get service -n$NAMESPACE $SERVICE_NAME --no-headers | awk {'print $4'})
     if [ -z "$external_ip" ]; then

--- a/terraform/eks/nginx/get-service-external-ip.sh
+++ b/terraform/eks/nginx/get-service-external-ip.sh
@@ -23,9 +23,9 @@ service_wait() {
   timeout=300
   until [[ $timeout -eq 0 ]]; do
     external_ip=$(kubectl --kubeconfig=$KUBECONFIG get service -n$NAMESPACE $SERVICE_NAME --no-headers | awk {'print $4'})
-    if [ -z "$external_ip" ]; then
-      sleep 1
-      timeout=$(( timeout - 1 ))
+    if [ -z "$external_ip" ] || [ "$external_ip" = "<pending>" ] || [ "$external_ip" = "<none>" ]; then
+      sleep 2
+      timeout=$(( timeout - 2 ))
     else
       echo "get external ip $external_ip"
       return 0

--- a/terraform/eks/nginx/nginx.tf
+++ b/terraform/eks/nginx/nginx.tf
@@ -71,32 +71,28 @@ resource "helm_release" "nginx_ingress" {
   }
 }
 
-data "kubernetes_service" "nginx_ingress_sample" {
-  metadata {
-    name      = "${helm_release.nginx_ingress.name}-ingress-nginx-controller"
-    namespace = kubernetes_namespace.nginx_ns.metadata[0].name
-  }
-  depends_on = [helm_release.nginx_ingress]
-}
-
-data "template_file" "traffic_deployment_file" {
-  template = file("./nginx/nginx_traffic_sample.tpl")
-  vars = {
-    NAMESPACE   = kubernetes_namespace.traffic_ns.metadata[0].name
-    EXTERNAL_IP = data.kubernetes_service.nginx_ingress_sample.status[0].load_balancer[0].ingress[0].hostname
-  }
-}
-
-resource "local_file" "traffic_deployment" {
-  filename = "nginx_traffic_sample_${var.testing_id}.yaml"
-  content  = data.template_file.traffic_deployment_file.rendered
-}
-
 resource "null_resource" "apply_traffic_deployment" {
-  triggers = {
-    config_contents = md5(local_file.traffic_deployment.content)
-  }
+  depends_on = [helm_release.nginx_ingress]
+
   provisioner "local-exec" {
-    command = "kubectl --kubeconfig=${var.kubeconfig} apply -f ${local_file.traffic_deployment.filename}"
+    command = <<-EOT
+      # Wait for LB hostname
+      for i in $(seq 1 150); do
+        EXTERNAL_IP=$(kubectl --kubeconfig=$KUBECONFIG get svc -n$NS $SVC -o jsonpath='{.status.loadBalancer.ingress[0].hostname}' 2>/dev/null)
+        if [ -n "$EXTERNAL_IP" ]; then break; fi
+        sleep 2
+      done
+      if [ -z "$EXTERNAL_IP" ]; then echo "ERROR: nginx LB hostname not available after 300s"; exit 1; fi
+      echo "Nginx LB: $EXTERNAL_IP"
+      export NAMESPACE EXTERNAL_IP
+      envsubst < ./nginx/nginx_traffic_sample.tpl | kubectl --kubeconfig=$KUBECONFIG apply -f -
+    EOT
+
+    environment = {
+      KUBECONFIG = var.kubeconfig
+      NS         = kubernetes_namespace.nginx_ns.metadata[0].name
+      SVC        = "${helm_release.nginx_ingress.name}-ingress-nginx-controller"
+      NAMESPACE  = kubernetes_namespace.traffic_ns.metadata[0].name
+    }
   }
 }

--- a/terraform/eks/otlp.tf
+++ b/terraform/eks/otlp.tf
@@ -266,14 +266,11 @@ resource "kubernetes_service" "mocked_server_service" {
     selector = {
       app = local.aoc_label_selector
     }
-    type = "LoadBalancer"
+    type = "ClusterIP"
     port {
       port        = 80
       target_port = 8080
     }
-  }
-  timeouts {
-    create = "20m"
   }
 }
 
@@ -331,48 +328,13 @@ resource "kubernetes_service" "sample_app_service" {
       app = "sample-app"
     }
 
-    type = var.deployment_type == "fargate" ? "NodePort" : "LoadBalancer"
+    type = "ClusterIP"
 
     port {
       port        = module.common.sample_app_lb_port
       target_port = module.common.sample_app_listen_address_port
     }
   }
-  timeouts {
-    create = "20m"
-  }
 }
 
-resource "kubernetes_ingress" "app" {
-  count                  = var.deployment_type == "fargate" && local.is_otlp_base_scenario ? 1 : 0
-  wait_for_load_balancer = true
-  metadata {
-    name      = "sample-app-ingress"
-    namespace = kubernetes_namespace.aoc_fargate_ns.metadata[0].name
-    annotations = {
-      "kubernetes.io/ingress.class"           = "alb"
-      "alb.ingress.kubernetes.io/scheme"      = "internet-facing"
-      "alb.ingress.kubernetes.io/target-type" = "ip"
-    }
-    labels = {
-      "app" = "sample-app"
-    }
-  }
-
-  spec {
-    rule {
-      http {
-        path {
-          path = "/*"
-          backend {
-            service_name = kubernetes_service.sample_app_service[count.index].metadata[0].name
-            service_port = kubernetes_service.sample_app_service[count.index].spec[0].port[0].port
-          }
-        }
-      }
-    }
-  }
-
-  depends_on = [kubernetes_service.sample_app_service]
-}
 

--- a/terraform/eks/otlp.tf
+++ b/terraform/eks/otlp.tf
@@ -37,7 +37,7 @@ module "basic_components" {
   sample_app                     = var.sample_app
   mocked_server                  = var.mocked_server
   cortex_instance_endpoint       = var.cortex_instance_endpoint
-  sample_app_listen_address_host = var.sample_app_mode == "pull" ? kubernetes_service.sample_app_service[0].status[0].load_balancer[0].ingress[0].hostname : ""
+  sample_app_listen_address_host = var.sample_app_mode == "pull" ? kubernetes_service.sample_app_service[0].spec[0].cluster_ip : ""
   sample_app_listen_address_port = module.common.sample_app_lb_port
 
   extra_data = { msk = module.aoc_msk_cluster.cluster_data }

--- a/terraform/executeTerraformTest.sh
+++ b/terraform/executeTerraformTest.sh
@@ -75,6 +75,8 @@ esac
 
 ts() { date -u +"%H:%M:%S"; }
 PROGRESS_FILE="${GITHUB_STEP_SUMMARY:-/dev/null}"
+echo "| Platform | Test | Result | Duration |" >> "$PROGRESS_FILE"
+echo "|----------|------|--------|----------|" >> "$PROGRESS_FILE"
 test_framework_shortsha=$(git rev-parse --short HEAD)
 # Used as a retry mechanic.
 ATTEMPTS_LEFT=2

--- a/terraform/executeTerraformTest.sh
+++ b/terraform/executeTerraformTest.sh
@@ -100,8 +100,12 @@ while [ $ATTEMPTS_LEFT -gt 0 ] && ! ../checkCacheHit.sh $SERVICE $TESTCASE $ADDT
     echo "[$(ts)] terraform apply (30m timeout)"
     export TF_IN_AUTOMATION=true
 
-    if timeout -k 5m --signal=SIGINT -v 30m terraform apply -auto-approve -lock=false -compact-warnings $opts  -var="testcase=../testcases/$TESTCASE" ; then
+    timeout -k 5m --signal=SIGINT -v 30m terraform apply -auto-approve -lock=false -compact-warnings $opts -var="testcase=../testcases/$TESTCASE" 2>&1 | tee /tmp/tf_apply.log | grep --line-buffered -E "Creation complete|Error:|Still creating.*[0-9]0s elapsed" || true
+    TF_EXIT=${PIPESTATUS[0]}
+    if [ $TF_EXIT -eq 0 ]; then
         APPLY_EXIT=$?
+        DURATION=$(( $(date -u +%s) - TESTCASE_START ))
+        echo ""
         DURATION=$(( $(date -u +%s) - TESTCASE_START ))
         echo ""
         echo "  ✅ PASS: ${SERVICE} / ${TESTCASE} / ${ADDTL_PARAMS} (${DURATION}s)"
@@ -109,11 +113,12 @@ while [ $ATTEMPTS_LEFT -gt 0 ] && ! ../checkCacheHit.sh $SERVICE $TESTCASE $ADDT
         aws dynamodb put-item --region=us-west-2 --table-name ${DDB_TABLE_NAME} --item {\"TestId\":{\"S\":\"$SERVICE$TESTCASE$ADDTL_PARAMS\"}\,\"aoc_version\":{\"S\":\"$DDB_SK_PREFIX$test_framework_shortsha\"}\,\"TimeToExist\":{\"N\":\"${TTL_DATE}\"}} --return-consumed-capacity TOTAL
         echo "| $SERVICE | $TESTCASE | :white_check_mark: pass | ${DURATION}s |" >> "$PROGRESS_FILE"
     else
-        APPLY_EXIT=$?
+        APPLY_EXIT=$TF_EXIT
         DURATION=$(( $(date -u +%s) - TESTCASE_START ))
         echo ""
         echo "  ❌ FAIL: ${SERVICE} / ${TESTCASE} / ${ADDTL_PARAMS} (exit=${APPLY_EXIT}, ${DURATION}s)"
         echo ""
+        grep -E "Error:|validator" /tmp/tf_apply.log | tail -20
         echo "| $SERVICE | $TESTCASE | :x: fail (exit=$APPLY_EXIT) | ${DURATION}s |" >> "$PROGRESS_FILE"
     fi
 

--- a/terraform/templates/defaults/validator_docker_compose.tpl
+++ b/terraform/templates/defaults/validator_docker_compose.tpl
@@ -4,6 +4,7 @@ services:
   validator:
     build:
       ../../validator
+    network_mode: host
     volumes:
       - ~/.aws:/root/.aws
       - ./output:/var/output

--- a/tools/batchTestGenerator/internal/githubGenerator.go
+++ b/tools/batchTestGenerator/internal/githubGenerator.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 )
 
 // generates the batch keys and value json for github action utilization

--- a/tools/batchTestGenerator/internal/githubGenerator.go
+++ b/tools/batchTestGenerator/internal/githubGenerator.go
@@ -66,11 +66,19 @@ func GithubGenerator(config RunConfig) error {
 
 }
 
+func displayVariant(serviceType, additionalVar string) string {
+	if strings.Contains(additionalVar, "|") {
+		parts := strings.SplitN(additionalVar, "|", 2)
+		return strings.TrimPrefix(parts[1], "collector-ci-")
+	}
+	return additionalVar
+}
+
 func createBatchMap(maxBatches int, testCases []TestCaseInfo) (map[string][]string, error) {
 	// Group tests by platform + variant (AMI for EC2, cluster for EKS, launch type for ECS)
 	subGroups := make(map[string][]TestCaseInfo)
 	for _, tc := range testCases {
-		key := fmt.Sprintf("%s/%s", tc.serviceType, tc.additionalVar)
+		key := fmt.Sprintf("%s/%s", tc.serviceType, displayVariant(tc.serviceType, tc.additionalVar))
 		subGroups[key] = append(subGroups[key], tc)
 	}
 
@@ -92,7 +100,7 @@ func createBatchMap(maxBatches int, testCases []TestCaseInfo) (map[string][]stri
 			if testsPerBatch == 1 || len(tests) <= share {
 				id = fmt.Sprintf("%s/%s", groupKey, tc.testcaseName)
 			} else {
-				id = fmt.Sprintf("%s/%d", groupKey, batchNum)
+				id = fmt.Sprintf("%s/batch-%d", groupKey, batchNum)
 			}
 			val := fmt.Sprintf("%s %s %s", tc.serviceType, tc.testcaseName, tc.additionalVar)
 			batchMap[id] = append(batchMap[id], val)

--- a/tools/batchTestGenerator/internal/githubGenerator.go
+++ b/tools/batchTestGenerator/internal/githubGenerator.go
@@ -99,8 +99,10 @@ func createBatchMap(maxBatches int, testCases []TestCaseInfo) (map[string][]stri
 			}
 		}
 		if len(kafkaTests) > 0 {
-			id := fmt.Sprintf("%s/kafka", groupKey)
-			for _, tc := range kafkaTests {
+			// Split kafka into batches of 2 (each test takes ~10min, 2 fits in 30m timeout)
+			for i, tc := range kafkaTests {
+				batchNum := i / 2
+				id := fmt.Sprintf("%s/kafka-%d", groupKey, batchNum)
 				val := fmt.Sprintf("%s %s %s", tc.serviceType, tc.testcaseName, tc.additionalVar)
 				batchMap[id] = append(batchMap[id], val)
 			}

--- a/tools/batchTestGenerator/internal/githubGenerator.go
+++ b/tools/batchTestGenerator/internal/githubGenerator.go
@@ -88,6 +88,25 @@ func createBatchMap(maxBatches int, testCases []TestCaseInfo) (map[string][]stri
 	totalTests := len(testCases)
 
 	for groupKey, tests := range subGroups {
+		// Separate kafka tests into their own batch (they share MSK connections)
+		var kafkaTests []TestCaseInfo
+		var otherTests []TestCaseInfo
+		for _, tc := range tests {
+			if strings.Contains(tc.testcaseName, "kafka") {
+				kafkaTests = append(kafkaTests, tc)
+			} else {
+				otherTests = append(otherTests, tc)
+			}
+		}
+		if len(kafkaTests) > 0 {
+			id := fmt.Sprintf("%s/kafka", groupKey)
+			for _, tc := range kafkaTests {
+				val := fmt.Sprintf("%s %s %s", tc.serviceType, tc.testcaseName, tc.additionalVar)
+				batchMap[id] = append(batchMap[id], val)
+			}
+		}
+		tests = otherTests
+
 		share := (len(tests) * maxBatches) / totalTests
 		if share < 1 {
 			share = 1

--- a/validator/src/main/java/com/amazon/aoc/enums/GenericConstants.java
+++ b/validator/src/main/java/com/amazon/aoc/enums/GenericConstants.java
@@ -20,9 +20,9 @@ import lombok.Getter;
 @Getter
 public enum GenericConstants {
   // retry
-  SLEEP_IN_MILLISECONDS("20000"), // ms
-  SLEEP_IN_SECONDS("30"),
-  MAX_RETRIES("10"),
+  SLEEP_IN_MILLISECONDS("10000"), // ms
+  SLEEP_IN_SECONDS("15"),
+  MAX_RETRIES("20"),
 
   // validator env vars
   ENV_VAR_AGENT_VERSION("AGENT_VERSION"),


### PR DESCRIPTION
## Summary

- Strip region and `collector-ci-` prefix from EKS batch names for readability
  - Before: `EKS/us-west-2|collector-ci-amd64-1-34/0`
  - After: `EKS/amd64-1-34/batch-0`
- Add `batch-` prefix to numeric batch IDs for clarity
- Mark `mocked_server_cert_content` as sensitive to suppress 40K lines of PEM certificate data in terraform plan output

## Test plan
- [ ] Verify batch names render correctly in GitHub Actions UI
- [ ] Verify terraform plan no longer shows certificate content

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
