### PR TITLE
ci: fix Windows, EKS, batch naming, and test reliability

### DIFF
--- a/cdk_infra/lib/stacks/eks/ec2-cluster-stack.ts
+++ b/cdk_infra/lib/stacks/eks/ec2-cluster-stack.ts
@@ -69,6 +69,8 @@ export class EC2Stack extends Stack {
       instanceTypes: props.instanceTypes,
       cluster: this.cluster,
       minSize: 2,
+      maxSize: 4,
+      desiredSize: 3,
       subnets: { subnetType: ec2.SubnetType.PUBLIC },
       launchTemplateSpec: {
         id: lt.launchTemplateId as string,

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -22,7 +22,7 @@ postBatchClean:
 
 .PHONY: checkCacheHits
 checkCacheHits:
-	cat test-case-batch | xargs -L1 -P1 ./checkCacheHit.sh
+	cat test-case-batch | xargs -L1 -P10 ./checkCacheHit.sh
 
 .PHONY: terraformCleanup
 terraformCleanup: test-case-batch

--- a/terraform/basic_components/main.tf
+++ b/terraform/basic_components/main.tf
@@ -23,7 +23,7 @@ module "common" {
 locals {
   otconfig_path = fileexists("${var.testcase}/otconfig.tpl") ? "${var.testcase}/otconfig.tpl" : module.common.default_otconfig_path
 
-  subnet_ids_list = tolist(data.aws_subnet_ids.aoc_public_subnet_ids.ids)
+  subnet_ids_list = data.aws_subnets.aoc_public_subnet_ids.ids
 
   subnet_ids_random_index = random_id.subnetSelector.dec % length(local.subnet_ids_list)
 
@@ -46,8 +46,11 @@ data "aws_vpc" "aoc_vpc" {
 }
 
 # return private subnets
-data "aws_subnet_ids" "aoc_private_subnet_ids" {
-  vpc_id = data.aws_vpc.aoc_vpc.id
+data "aws_subnets" "aoc_private_subnet_ids" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.aoc_vpc.id]
+  }
   filter {
     name = "tag:Name"
     values = [
@@ -59,8 +62,11 @@ data "aws_subnet_ids" "aoc_private_subnet_ids" {
 }
 
 # return public subnets
-data "aws_subnet_ids" "aoc_public_subnet_ids" {
-  vpc_id = data.aws_vpc.aoc_vpc.id
+data "aws_subnets" "aoc_public_subnet_ids" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.aoc_vpc.id]
+  }
   filter {
     name = "tag:Name"
     values = [

--- a/terraform/basic_components/outputs.tf
+++ b/terraform/basic_components/outputs.tf
@@ -18,11 +18,11 @@ output "aoc_vpc_id" {
 }
 
 output "aoc_private_subnet_ids" {
-  value = data.aws_subnet_ids.aoc_private_subnet_ids.ids
+  value = data.aws_subnets.aoc_private_subnet_ids.ids
 }
 
 output "aoc_public_subnet_ids" {
-  value = data.aws_subnet_ids.aoc_public_subnet_ids.ids
+  value = data.aws_subnets.aoc_public_subnet_ids.ids
 }
 
 output "aoc_security_group_id" {
@@ -38,7 +38,8 @@ output "otconfig_content" {
 }
 
 output "mocked_server_cert_content" {
-  value = local.mocked_server_cert_rendered_template
+  value     = local.mocked_server_cert_rendered_template
+  sensitive = true
 }
 
 output "sample_app_image_repo" {

--- a/terraform/common.tf
+++ b/terraform/common.tf
@@ -75,3 +75,12 @@ variable "aoc_vpc_name" {
 variable "aoc_vpc_security_group" {
   default = "aoc-vpc-security-group"
 }
+
+variable "runner_sg_id" {
+  default = ""
+}
+
+variable "runner_ip" {
+  description = "CIDR of the CI runner (e.g. 1.2.3.4/32) for WinRM/SSH access"
+  default     = ""
+}

--- a/terraform/data_aoc_msk/outputs.tf
+++ b/terraform/data_aoc_msk/outputs.tf
@@ -1,4 +1,4 @@
 output "cluster_data" {
   description = "Cluster data for the MSK Cluster as return by aws_msk_cluster terraform data moduel + the topic name that the testcase should use"
-  value       = merge(local.cluster_data, { topic = local.topic })
+  value       = merge(local.cluster_data, { topic = local.topic, kafka_version = var.cluster_version })
 }

--- a/terraform/ec2/amis.tf
+++ b/terraform/ec2/amis.tf
@@ -22,7 +22,7 @@ variable "ami_family" {
       otconfig_destination     = "/tmp/ot-default.yml"
       download_command_pattern = "wget %s"
       install_command          = "while sudo fuser /var/cache/apt/archives/lock /var/lib/apt/lists/lock /var/lib/dpkg/lock /var/lib/dpkg/lock-frontend; do echo 'Waiting for dpkg lock...' && sleep 1; done; echo 'No dpkg lock and install collector.' && sudo dpkg -i aws-otel-collector.deb"
-      start_command            = "sudo /opt/aws/aws-otel-collector/bin/aws-otel-collector-ctl -c \"$(echo -n 'CONFIGURATION_URI_PLACEHOLDER' | base64 -d)\" -f FEATUREGATE_PLACEHOLDER -a start"
+      start_command            = "ADOT_CONFIG_URI=$(echo -n 'CONFIGURATION_URI_PLACEHOLDER' | base64 -d)\nsudo /opt/aws/aws-otel-collector/bin/aws-otel-collector-ctl -c \"$ADOT_CONFIG_URI\" -f FEATUREGATE_PLACEHOLDER -a start"
       status_command           = "sudo /opt/aws/aws-otel-collector/bin/aws-otel-collector-ctl -a status"
       ssm_validate             = "sudo /opt/aws/aws-otel-collector/bin/aws-otel-collector-ctl -a status | grep running"
       connection_type          = "ssh"
@@ -36,7 +36,7 @@ variable "ami_family" {
       otconfig_destination     = "/tmp/ot-default.yml"
       download_command_pattern = "curl %s --output aws-otel-collector.rpm"
       install_command          = "sudo rpm -Uvh aws-otel-collector.rpm"
-      start_command            = "sudo /opt/aws/aws-otel-collector/bin/aws-otel-collector-ctl -c \"$(echo -n 'CONFIGURATION_URI_PLACEHOLDER' | base64 -d)\" -f FEATUREGATE_PLACEHOLDER -a start"
+      start_command            = "ADOT_CONFIG_URI=$(echo -n 'CONFIGURATION_URI_PLACEHOLDER' | base64 -d)\nsudo /opt/aws/aws-otel-collector/bin/aws-otel-collector-ctl -c \"$ADOT_CONFIG_URI\" -f FEATUREGATE_PLACEHOLDER -a start"
       status_command           = "sudo /opt/aws/aws-otel-collector/bin/aws-otel-collector-ctl -a status"
       ssm_validate             = "sudo /opt/aws/aws-otel-collector/bin/aws-otel-collector-ctl -a status | grep running"
       connection_type          = "ssh"
@@ -49,30 +49,18 @@ variable "ami_family" {
       instance_type            = "c5a.large"
       otconfig_destination     = "C:\\ot-default.yml"
       download_command_pattern = "powershell -command \"Invoke-WebRequest -Uri %s -OutFile C:\\aws-otel-collector.msi\""
-      install_command          = "msiexec /i C:\\aws-otel-collector.msi"
-      start_command            = "powershell -command \"&{ $url = \\\"$([System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String('CONFIGURATION_URI_PLACEHOLDER')))\\\"; . 'C:\\Program Files\\Amazon\\AwsOtelCollector\\aws-otel-collector-ctl.ps1' -ConfigLocation \\\"$url\\\" -FeatureGates \\\"FEATUREGATE_PLACEHOLDER\\\" -Action start}\""
+      install_command          = "msiexec /i C:\\aws-otel-collector.msi /qn /norestart"
+      start_command            = "powershell -Command \"$url = [System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String('CONFIGURATION_URI_PLACEHOLDER')); & 'C:\\Program Files\\Amazon\\AwsOtelCollector\\aws-otel-collector-ctl.ps1' -ConfigLocation $url -FeatureGates 'FEATUREGATE_PLACEHOLDER' -Action start\""
       status_command           = "powershell \"& 'C:\\Program Files\\Amazon\\AwsOtelCollector\\aws-otel-collector-ctl.ps1' -Action status\""
       ssm_validate             = "powershell \"& 'C:\\Program Files\\Amazon\\AwsOtelCollector\\aws-otel-collector-ctl.ps1' -Action status\" | findstr running"
       connection_type          = "winrm"
       user_data                = <<EOF
 <powershell>
-winrm quickconfig -q
-winrm set winrm/config/winrs '@{MaxShellsPerUser="100"}'
-winrm set winrm/config/winrs '@{MaxConcurrentUsers="30"}'
-winrm set winrm/config/winrs '@{MaxProcessesPerShell="100"}'
-winrm set winrm/config/winrs '@{MaxMemoryPerShellMB="1024"}'
-winrm set winrm/config '@{MaxTimeoutms="1800000"}'
-winrm set winrm/config/service '@{AllowUnencrypted="true"}'
-winrm set winrm/config/service/auth '@{Basic="true"}'
 netsh advfirewall firewall add rule name="WinRM 5985" protocol=TCP dir=in localport=5985 action=allow
-netsh advfirewall firewall add rule name="WinRM 5986" protocol=TCP dir=in localport=5986 action=allow
-net stop winrm
-sc.exe config winrm start=auto
-net start winrm
-Set-NetFirewallProfile -Profile Public -Enabled False
+Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False
 </powershell>
 EOF
-      wait_cloud_init          = " "
+      wait_cloud_init          = "powershell -Command \"Start-Sleep -Seconds 15; Write-Host 'Windows ready'\""
     }
   }
 }
@@ -118,30 +106,24 @@ EOF
     }
     ubuntu22 = {
       os_family          = "ubuntu"
-      ami_search_pattern = "ubuntu/images/hvm-ssd/ubuntu-jammy*"
-      ami_owner          = "amazon"
+      ami_search_pattern = "cloudwatch-agent-integration-test-ubuntu-LTS-22*"
+      ami_owner          = "506463145083"
       ami_product_code   = []
       family             = "debian"
       arch               = "amd64"
       login_user         = "ubuntu"
-      user_data          = <<EOF
-#! /bin/bash
-sudo snap refresh amazon-ssm-agent
-EOF
+      user_data          = ""
     }
     arm_ubuntu22 = {
       os_family          = "ubuntu"
-      ami_search_pattern = "ubuntu/images/hvm-ssd/ubuntu-jammy*"
-      ami_owner          = "amazon"
+      ami_search_pattern = "cloudwatch-agent-integration-test-ubuntu-LTS-22-arm64*"
+      ami_owner          = "506463145083"
       ami_product_code   = []
       family             = "debian"
       arch               = "arm64"
       login_user         = "ubuntu"
       instance_type      = "c6g.large"
-      user_data          = <<EOF
-#! /bin/bash
-sudo snap refresh amazon-ssm-agent
-EOF
+      user_data          = ""
     }
     # Debian Distribution
     debian11 = {
@@ -165,23 +147,14 @@ EOF
     }
     arm_debian11 = {
       os_family          = "debian"
-      ami_search_pattern = "debian-11-arm64*"
-      ami_owner          = "amazon"
+      ami_search_pattern = "cloudwatch-agent-integration-test-debian-11-arm64*"
+      ami_owner          = "506463145083"
       ami_product_code   = []
       family             = "debian"
       arch               = "arm64"
       login_user         = "admin"
       instance_type      = "c6g.large"
-      user_data          = <<EOF
-#! /bin/bash
-cd /tmp
-sudo wget https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/debian_arm64/amazon-ssm-agent.deb
-while sudo fuser {/var/{lib/{dpkg,apt/lists},cache/apt/archives}/lock,/var/lib/dpkg/lock-frontend}; do
-   echo 'Waiting for dpkg lock...' && sleep 1
-done
-sudo dpkg -i amazon-ssm-agent.deb
-sudo systemctl enable amazon-ssm-agent
-EOF
+      user_data          = ""
     }
     debian10 = {
       os_family          = "debian"
@@ -225,64 +198,52 @@ EOF
     #AL3
     amazonlinux3 = {
       os_family          = "amazon_linux"
-      ami_search_pattern = "al2023-ami-2023*"
-      ami_owner          = "amazon"
+      ami_search_pattern = "cloudwatch-agent-integration-test-x86-al2023*"
+      ami_owner          = "506463145083"
       ami_product_code   = []
       family             = "linux"
       arch               = "amd64"
       login_user         = "ec2-user"
-      user_data          = <<EOF
-#! /bin/bash
-sudo yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
-EOF
+      user_data          = ""
     }
     arm_amazonlinux3 = {
       os_family          = "amazon_linux"
-      ami_search_pattern = "al2023-ami-2023*"
-      ami_owner          = "amazon"
+      ami_search_pattern = "cloudwatch-agent-integration-test-aarch64-al2023*"
+      ami_owner          = "506463145083"
       ami_product_code   = []
       family             = "linux"
       arch               = "arm64"
       login_user         = "ec2-user"
       instance_type      = "c6g.large"
-      user_data          = <<EOF
-#! /bin/bash
-sudo yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_arm64/amazon-ssm-agent.rpm
-EOF
+      user_data          = ""
     }
     #AL2
     amazonlinux2 = {
       os_family          = "amazon_linux"
-      ami_search_pattern = "amzn2-ami-kernel-5*"
-      ami_owner          = "amazon"
+      ami_search_pattern = "cloudwatch-agent-integration-test-al2*"
+      ami_owner          = "506463145083"
       ami_product_code   = []
       family             = "linux"
       arch               = "amd64"
       login_user         = "ec2-user"
-      user_data          = <<EOF
-#! /bin/bash
-sudo yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
-EOF
+      user_data          = ""
     }
     arm_amazonlinux2 = {
       os_family          = "amazon_linux"
-      ami_search_pattern = "amzn2-ami-kernel-5*"
-      ami_owner          = "amazon"
+      ami_search_pattern = "cloudwatch-agent-integration-test-arm64-al2*"
+      ami_owner          = "506463145083"
       ami_product_code   = []
       family             = "linux"
       arch               = "arm64"
       login_user         = "ec2-user"
       instance_type      = "c6g.large"
-      user_data          = <<EOF
-#! /bin/bash
-sudo yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_arm64/amazon-ssm-agent.rpm
-EOF
+      user_data          = ""
     }
     # Windows Distribution
     windows2022 = {
       os_family          = "windows"
-      ami_search_pattern = "Windows_Server-2022-English-Full-Base*"
-      ami_owner          = "amazon"
+      ami_search_pattern = "cloudwatch-agent-integration-test-win-2022*"
+      ami_owner          = "506463145083"
       ami_product_code   = []
       family             = "windows"
       arch               = "amd64"
@@ -290,8 +251,8 @@ EOF
     }
     windows2019 = {
       os_family          = "windows"
-      ami_search_pattern = "Windows_Server-2019-English-Full-Base-*"
-      ami_owner          = "amazon"
+      ami_search_pattern = "cloudwatch-agent-integration-test-win-2019*"
+      ami_owner          = "506463145083"
       ami_product_code   = []
       family             = "windows"
       arch               = "amd64"
@@ -300,38 +261,24 @@ EOF
     # Suse Distribution
     suse15 = {
       os_family          = "suse"
-      ami_search_pattern = "suse-sles-15-sp5-v????????-hvm-ssd-x86_64"
-      ami_owner          = "amazon"
+      ami_search_pattern = "cloudwatch-agent-integration-test-sles-15*"
+      ami_owner          = "506463145083"
       ami_product_code   = []
       family             = "linux"
       login_user         = "ec2-user"
       arch               = "amd64"
-      user_data          = <<EOF
-#! /bin/bash
-cd /tmp
-sudo wget https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
-sudo rpm -Uvh amazon-ssm-agent.rpm
-sudo systemctl enable amazon-ssm-agent
-sudo systemctl start amazon-ssm-agent
-EOF
+      user_data          = ""
     }
     arm_suse15 = {
       os_family          = "suse"
-      ami_search_pattern = "suse-sles-15-sp5-v????????-hvm-ssd-arm64"
-      ami_owner          = "amazon"
+      ami_search_pattern = "cloudwatch-agent-integration-test-sles-15-arm64*"
+      ami_owner          = "506463145083"
       ami_product_code   = []
       family             = "linux"
       login_user         = "ec2-user"
       arch               = "arm64"
       instance_type      = "c6g.large"
-      user_data          = <<EOF
-#! /bin/bash
-cd /tmp
-sudo wget https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_arm64/amazon-ssm-agent.rpm
-sudo rpm -Uvh amazon-ssm-agent.rpm
-sudo systemctl enable amazon-ssm-agent
-sudo systemctl start amazon-ssm-agent
-EOF
+      user_data          = ""
     }
     suse12 = {
       os_family          = "suse"
@@ -353,30 +300,24 @@ EOF
     # Redhat Distribution
     redhat8 = {
       os_family          = "redhat"
-      ami_search_pattern = "RHEL-8.6.0_HVM*"
-      ami_owner          = "amazon"
+      ami_search_pattern = "cloudwatch-agent-integration-test-rhel8-base*"
+      ami_owner          = "506463145083"
       ami_product_code   = []
       family             = "linux"
       arch               = "amd64"
-      user_data          = <<EOF
-#! /bin/bash
-sudo dnf install -y python3
-sudo dnf install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
-EOF
+      login_user         = "ec2-user"
+      user_data          = ""
     }
     arm_redhat8 = {
       os_family          = "redhat"
-      ami_search_pattern = "RHEL-8.6.0_HVM*"
-      ami_owner          = "amazon"
+      ami_search_pattern = "cloudwatch-agent-integration-test-rhel8-arm64*"
+      ami_owner          = "506463145083"
       ami_product_code   = []
       family             = "linux"
       arch               = "arm64"
       instance_type      = "c6g.large"
-      user_data          = <<EOF
-#! /bin/bash
-sudo yum install -y python3
-sudo yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_arm64/amazon-ssm-agent.rpm
-EOF
+      login_user         = "ec2-user"
+      user_data          = ""
     }
   }
 }

--- a/terraform/ec2/main.tf
+++ b/terraform/ec2/main.tf
@@ -49,7 +49,7 @@ module "basic_components" {
 
   cortex_instance_endpoint = var.cortex_instance_endpoint
 
-  sample_app_listen_address_host = aws_instance.sidecar.public_ip
+  sample_app_listen_address_host = aws_instance.sidecar.public_dns
 
   sample_app_listen_address_port = module.common.sample_app_lb_port
 
@@ -62,6 +62,55 @@ provider "aws" {
 }
 
 data "aws_caller_identity" "current" {
+}
+
+resource "aws_security_group" "runner_access" {
+  count       = var.runner_ip != "" ? 1 : 0
+  name_prefix = "runner-${module.common.testing_id}-"
+  vpc_id      = module.basic_components.aoc_vpc_id
+  description = "Runner access for test ${module.common.testing_id}"
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = [var.runner_ip]
+  }
+
+  ingress {
+    from_port   = 5985
+    to_port     = 5985
+    protocol    = "tcp"
+    cidr_blocks = [var.runner_ip]
+  }
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = [var.runner_ip]
+  }
+
+  ingress {
+    from_port   = 8080
+    to_port     = 8080
+    protocol    = "tcp"
+    cidr_blocks = [var.runner_ip]
+  }
+
+  tags = {
+    Name      = "runner-${module.common.testing_id}"
+    TestID    = module.common.testing_id
+    ephemeral = "true"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+locals {
+  runner_sg_ids = var.runner_ip != "" ? [aws_security_group.runner_access[0].id] : (var.runner_sg_id != "" ? [var.runner_sg_id] : [])
 }
 
 data "aws_ecr_repository" "sample_app" {
@@ -97,7 +146,7 @@ resource "aws_instance" "sidecar" {
   ami                         = data.aws_ami.amazonlinux2.id
   instance_type               = var.sidecar_instance_type
   subnet_id                   = module.basic_components.random_subnet_instance_id
-  vpc_security_group_ids      = [module.basic_components.aoc_security_group_id]
+  vpc_security_group_ids      = concat([module.basic_components.aoc_security_group_id], local.runner_sg_ids)
   associate_public_ip_address = true
   iam_instance_profile        = module.common.aoc_iam_role_name
   key_name                    = local.ssh_key_name
@@ -126,7 +175,7 @@ resource "aws_instance" "aoc" {
   ami                         = local.ami_id
   instance_type               = local.instance_type
   subnet_id                   = module.basic_components.random_subnet_instance_id
-  vpc_security_group_ids      = [module.basic_components.aoc_security_group_id]
+  vpc_security_group_ids      = concat([module.basic_components.aoc_security_group_id], local.runner_sg_ids)
   associate_public_ip_address = true
   iam_instance_profile        = module.common.aoc_iam_role_name
   key_name                    = local.ssh_key_name
@@ -162,8 +211,8 @@ resource "null_resource" "check_patch" {
 
   provisioner "local-exec" {
     command = <<-EOT
-     "${self.triggers.aotutil}" ssm wait-patch "${self.triggers.sidecar_id}" --ignore-error
-     "${self.triggers.aotutil}" ssm wait-patch "${self.triggers.aoc_id}" --ignore-error
+     "${self.triggers.aotutil}" ssm wait-patch "${self.triggers.sidecar_id}" --ignore-error --timeout 15m
+     "${self.triggers.aotutil}" ssm wait-patch "${self.triggers.aoc_id}" --ignore-error --timeout 15m
     EOT
   }
 }
@@ -181,9 +230,10 @@ resource "null_resource" "setup_mocked_server_cert_for_windows" {
 
     connection {
       type     = local.connection_type
+      timeout  = "10m"
       user     = local.login_user
       password = rsadecrypt(aws_instance.aoc.password_data, local.private_key_content)
-      host     = aws_instance.aoc.public_ip
+      host     = aws_instance.aoc.public_dns
     }
   }
 
@@ -195,9 +245,10 @@ resource "null_resource" "setup_mocked_server_cert_for_windows" {
 
     connection {
       type     = local.connection_type
+      timeout  = "10m"
       user     = local.login_user
       password = rsadecrypt(aws_instance.aoc.password_data, local.private_key_content)
-      host     = aws_instance.aoc.public_ip
+      host     = aws_instance.aoc.public_dns
     }
   }
 }
@@ -211,10 +262,11 @@ resource "null_resource" "setup_mocked_server_cert_for_linux" {
 
     connection {
       type        = local.connection_type
+      timeout     = "10m"
       user        = local.login_user
       private_key = local.connection_type == "ssh" ? local.private_key_content : null
       password    = local.connection_type == "winrm" ? rsadecrypt(aws_instance.aoc.password_data, local.private_key_content) : null
-      host        = aws_instance.aoc.public_ip
+      host     = aws_instance.aoc.public_dns
     }
   }
 
@@ -229,9 +281,10 @@ resource "null_resource" "setup_mocked_server_cert_for_linux" {
 
     connection {
       type        = local.connection_type
+      timeout     = "10m"
       user        = local.login_user
       private_key = local.private_key_content
-      host        = aws_instance.aoc.public_ip
+      host     = aws_instance.aoc.public_dns
     }
   }
 }
@@ -249,10 +302,11 @@ resource "null_resource" "download_collector_from_local" {
 
     connection {
       type        = local.connection_type
+      timeout     = "10m"
       user        = local.login_user
       private_key = local.connection_type == "ssh" ? local.private_key_content : null
       password    = local.connection_type == "winrm" ? rsadecrypt(aws_instance.aoc.password_data, local.private_key_content) : null
-      host        = aws_instance.aoc.public_ip
+      host     = aws_instance.aoc.public_dns
     }
   }
 }
@@ -268,10 +322,11 @@ resource "null_resource" "download_collector_from_s3" {
 
     connection {
       type        = local.connection_type
+      timeout     = "10m"
       user        = local.login_user
       private_key = local.connection_type == "ssh" ? local.private_key_content : null
       password    = local.connection_type == "winrm" ? rsadecrypt(aws_instance.aoc.password_data, local.private_key_content) : null
-      host        = aws_instance.aoc.public_ip
+      host     = aws_instance.aoc.public_dns
     }
   }
 }
@@ -294,10 +349,11 @@ resource "null_resource" "collector_file_configuration" {
 
     connection {
       type        = local.connection_type
+      timeout     = "10m"
       user        = local.login_user
       private_key = local.connection_type == "ssh" ? local.private_key_content : null
       password    = local.connection_type == "winrm" ? rsadecrypt(aws_instance.aoc.password_data, local.private_key_content) : null
-      host        = aws_instance.aoc.public_ip
+      host     = aws_instance.aoc.public_dns
     }
   }
 }
@@ -335,10 +391,11 @@ resource "null_resource" "start_collector" {
 
     connection {
       type        = local.connection_type
+      timeout     = "10m"
       user        = local.login_user
       private_key = local.connection_type == "ssh" ? local.private_key_content : null
       password    = local.connection_type == "winrm" ? rsadecrypt(aws_instance.aoc.password_data, local.private_key_content) : null
-      host        = aws_instance.aoc.public_ip
+      host     = aws_instance.aoc.public_dns
     }
   }
 }
@@ -361,10 +418,11 @@ resource "null_resource" "install_collector_from_ssm" {
 
     connection {
       type        = local.connection_type
+      timeout     = "10m"
       user        = local.login_user
       private_key = local.connection_type == "ssh" ? local.private_key_content : null
       password    = local.connection_type == "winrm" ? rsadecrypt(aws_instance.aoc.password_data, local.private_key_content) : null
-      host        = aws_instance.aoc.public_ip
+      host     = aws_instance.aoc.public_dns
     }
   }
 
@@ -405,7 +463,7 @@ resource "null_resource" "setup_sample_app_and_mock_server" {
       type        = "ssh"
       user        = "ec2-user"
       private_key = local.private_key_content
-      host        = aws_instance.sidecar.public_ip
+      host        = aws_instance.sidecar.public_dns
     }
   }
   provisioner "remote-exec" {
@@ -425,7 +483,7 @@ resource "null_resource" "setup_sample_app_and_mock_server" {
       type        = "ssh"
       user        = "ec2-user"
       private_key = local.private_key_content
-      host        = aws_instance.sidecar.public_ip
+      host        = aws_instance.sidecar.public_dns
     }
   }
 }
@@ -452,10 +510,11 @@ resource "null_resource" "install_cwagent" {
 
     connection {
       type        = local.connection_type
+      timeout     = "10m"
       user        = local.login_user
       private_key = local.connection_type == "ssh" ? local.private_key_content : null
       password    = local.connection_type == "winrm" ? rsadecrypt(aws_instance.aoc.password_data, local.private_key_content) : null
-      host        = aws_instance.aoc.public_ip
+      host     = aws_instance.aoc.public_dns
     }
   }
 
@@ -468,10 +527,11 @@ resource "null_resource" "install_cwagent" {
 
     connection {
       type        = local.connection_type
+      timeout     = "10m"
       user        = local.login_user
       private_key = local.connection_type == "ssh" ? local.private_key_content : null
       password    = local.connection_type == "winrm" ? rsadecrypt(aws_instance.aoc.password_data, local.private_key_content) : null
-      host        = aws_instance.aoc.public_ip
+      host     = aws_instance.aoc.public_dns
     }
   }
 }
@@ -518,10 +578,11 @@ resource "null_resource" "ssm_validation" {
 
     connection {
       type        = local.connection_type
+      timeout     = "10m"
       user        = local.login_user
       private_key = local.connection_type == "ssh" ? local.private_key_content : null
       password    = local.connection_type == "winrm" ? rsadecrypt(aws_instance.aoc.password_data, local.private_key_content) : null
-      host        = aws_instance.aoc.public_ip
+      host     = aws_instance.aoc.public_dns
     }
   }
 }

--- a/terraform/ec2/variables.tf
+++ b/terraform/ec2/variables.tf
@@ -102,7 +102,7 @@ variable "canary" {
 # also set a patch tag onto the instance so that the instance get picked by the ssm patching process.
 # and then start the installation of collector.
 variable "patch" {
-  default = true
+  default = false
 }
 
 ######################

--- a/terraform/eks/container-insights-agent/config_map_fargate.yml
+++ b/terraform/eks/container-insights-agent/config_map_fargate.yml
@@ -12,8 +12,8 @@ data:
       prometheus:
         config:
           global:
-            scrape_interval: 1m
-            scrape_timeout: 50s
+            scrape_interval: 15s
+            scrape_timeout: 10s
 
           scrape_configs:
           - job_name: 'kubelets-cadvisor-metrics'
@@ -287,6 +287,7 @@ data:
 
       # converts cumulative sum to delta
       cumulativetodelta:
+        initial_value: keep
         include:
             metrics:
                 - new_container_cpu_usage_seconds_total
@@ -401,12 +402,14 @@ data:
             action: update
             new_name: container_$$1
 
-      # add cluster name from env variable and EKS metadata
+      # add cluster name from env variable (OTEL_RESOURCE_ATTRIBUTES)
+      # Note: the eks detector fatally fails on Fargate because IMDS
+      # is unavailable and K8S_NODE_NAME is not set.
       resourcedetection:
-        detectors: [env, eks]
+        detectors: [env]
 
       batch:
-        timeout: 60s
+        timeout: 15s
 
     exporters:
       awsemf:

--- a/terraform/eks/container-insights-agent/stateful_set_fargate.yml
+++ b/terraform/eks/container-insights-agent/stateful_set_fargate.yml
@@ -28,7 +28,6 @@ spec:
           command:
             - "/awscollector"
             - "--config=/conf/adot-collector-config.yaml"
-            - "--feature-gates=-processor.resourcedetection.propagateerrors"
           env:
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: "ClusterName=${ClusterName}"

--- a/terraform/eks/main.tf
+++ b/terraform/eks/main.tf
@@ -194,20 +194,49 @@ module "adot_operator" {
 
 
 ##########################################
+# Port-forward for ClusterIP services
+##########################################
+resource "null_resource" "port_forward" {
+  count = local.is_otlp_base_scenario ? 1 : 0
+
+  depends_on = [
+    kubernetes_service.mocked_server_service,
+    kubernetes_service.sample_app_service,
+    kubernetes_deployment.aoc_deployment,
+  ]
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      export KUBECONFIG=${abspath("./${local_file.kubeconfig.filename}")}
+      NS="${var.deployment_type == "fargate" ? kubernetes_namespace.aoc_fargate_ns.metadata[0].name : kubernetes_namespace.aoc_ns.metadata[0].name}"
+      kubectl -n "$NS" wait --for=condition=ready pod -l app=${local.aoc_label_selector} --timeout=300s || true
+      nohup kubectl -n "$NS" port-forward svc/mocked-server 18081:80 > /dev/null 2>&1 &
+      echo $! > /tmp/pf_mocked.pid
+      nohup kubectl -n "$NS" port-forward svc/sample-app 18080:${module.common.sample_app_lb_port} > /dev/null 2>&1 &
+      echo $! > /tmp/pf_sample.pid
+      sleep 2
+      curl -sf http://localhost:18081/ > /dev/null || echo "WARN: mocked-server port-forward not ready"
+    EOT
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = "kill $(cat /tmp/pf_mocked.pid 2>/dev/null) $(cat /tmp/pf_sample.pid 2>/dev/null) 2>/dev/null || true"
+  }
+}
+
+##########################################
 # Validation
 ##########################################
 module "validator" {
   source = "../validation"
 
-  validation_config = var.validation_config
-  region            = var.region
-  testing_id        = module.common.testing_id
-  metric_namespace  = "${module.common.otel_service_namespace}/${module.common.otel_service_name}"
-  sample_app_endpoint = (length(kubernetes_ingress.app) > 0 && var.deployment_type == "fargate" ? "http://${kubernetes_ingress.app[0].status[0].load_balancer[0].ingress[0].hostname}:${var.fargate_sample_app_lb_port}" : (
-    length(kubernetes_service.sample_app_service) > 0 ? "http://${kubernetes_service.sample_app_service[0].status[0].load_balancer[0].ingress[0].hostname}:${module.common.sample_app_lb_port}" : ""
-    )
-  )
-  mocked_server_validating_url = length(kubernetes_service.mocked_server_service) > 0 ? "http://${kubernetes_service.mocked_server_service[0].status[0].load_balancer[0].ingress[0].hostname}/check-data" : ""
+  validation_config            = var.validation_config
+  region                       = var.region
+  testing_id                   = module.common.testing_id
+  metric_namespace             = "${module.common.otel_service_namespace}/${module.common.otel_service_name}"
+  sample_app_endpoint          = length(kubernetes_service.sample_app_service) > 0 ? "http://localhost:18080" : ""
+  mocked_server_validating_url = length(kubernetes_service.mocked_server_service) > 0 ? "http://localhost:18081/check-data" : ""
   cloudwatch_context_json = var.aoc_base_scenario == "prometheus" ? jsonencode({
     clusterName : var.eks_cluster_name
     #    appMesh : {
@@ -247,5 +276,6 @@ module "validator" {
     null_resource.prom_base_ready_check,
     kubectl_manifest.aoc_deployment_adot_operator,
     kubernetes_deployment.aoc_deployment,
+    null_resource.port_forward,
   ]
 }

--- a/terraform/eks/nginx/get-service-external-ip.sh
+++ b/terraform/eks/nginx/get-service-external-ip.sh
@@ -20,12 +20,12 @@ NAMESPACE=${NAMESPACE:-""}
 SERVICE_NAME=${SERVICE_NAME:-""}
 
 service_wait() {
-  timeout=60
+  timeout=300
   until [[ $timeout -eq 0 ]]; do
     external_ip=$(kubectl --kubeconfig=$KUBECONFIG get service -n$NAMESPACE $SERVICE_NAME --no-headers | awk {'print $4'})
-    if [ -z "$external_ip" ]; then
-      sleep 1
-      timeout=$(( timeout - 1 ))
+    if [ -z "$external_ip" ] || [ "$external_ip" = "<pending>" ] || [ "$external_ip" = "<none>" ]; then
+      sleep 2
+      timeout=$(( timeout - 2 ))
     else
       echo "get external ip $external_ip"
       return 0

--- a/terraform/eks/nginx/nginx.tf
+++ b/terraform/eks/nginx/nginx.tf
@@ -71,32 +71,28 @@ resource "helm_release" "nginx_ingress" {
   }
 }
 
-data "kubernetes_service" "nginx_ingress_sample" {
-  metadata {
-    name      = "${helm_release.nginx_ingress.name}-ingress-nginx-controller"
-    namespace = kubernetes_namespace.nginx_ns.metadata[0].name
-  }
-  depends_on = [helm_release.nginx_ingress]
-}
-
-data "template_file" "traffic_deployment_file" {
-  template = file("./nginx/nginx_traffic_sample.tpl")
-  vars = {
-    NAMESPACE   = kubernetes_namespace.traffic_ns.metadata[0].name
-    EXTERNAL_IP = data.kubernetes_service.nginx_ingress_sample.status[0].load_balancer[0].ingress[0].hostname
-  }
-}
-
-resource "local_file" "traffic_deployment" {
-  filename = "nginx_traffic_sample_${var.testing_id}.yaml"
-  content  = data.template_file.traffic_deployment_file.rendered
-}
-
 resource "null_resource" "apply_traffic_deployment" {
-  triggers = {
-    config_contents = md5(local_file.traffic_deployment.content)
-  }
+  depends_on = [helm_release.nginx_ingress]
+
   provisioner "local-exec" {
-    command = "kubectl --kubeconfig=${var.kubeconfig} apply -f ${local_file.traffic_deployment.filename}"
+    command = <<-EOT
+      # Wait for LB hostname
+      for i in $(seq 1 150); do
+        EXTERNAL_IP=$(kubectl --kubeconfig=$KUBECONFIG get svc -n$NS $SVC -o jsonpath='{.status.loadBalancer.ingress[0].hostname}' 2>/dev/null)
+        if [ -n "$EXTERNAL_IP" ]; then break; fi
+        sleep 2
+      done
+      if [ -z "$EXTERNAL_IP" ]; then echo "ERROR: nginx LB hostname not available after 300s"; exit 1; fi
+      echo "Nginx LB: $EXTERNAL_IP"
+      export NAMESPACE EXTERNAL_IP
+      envsubst < ./nginx/nginx_traffic_sample.tpl | kubectl --kubeconfig=$KUBECONFIG apply -f -
+    EOT
+
+    environment = {
+      KUBECONFIG = var.kubeconfig
+      NS         = kubernetes_namespace.nginx_ns.metadata[0].name
+      SVC        = "${helm_release.nginx_ingress.name}-ingress-nginx-controller"
+      NAMESPACE  = kubernetes_namespace.traffic_ns.metadata[0].name
+    }
   }
 }

--- a/terraform/eks/otlp.tf
+++ b/terraform/eks/otlp.tf
@@ -37,7 +37,7 @@ module "basic_components" {
   sample_app                     = var.sample_app
   mocked_server                  = var.mocked_server
   cortex_instance_endpoint       = var.cortex_instance_endpoint
-  sample_app_listen_address_host = var.sample_app_mode == "pull" ? kubernetes_service.sample_app_service[0].status[0].load_balancer[0].ingress[0].hostname : ""
+  sample_app_listen_address_host = var.sample_app_mode == "pull" ? kubernetes_service.sample_app_service[0].spec[0].cluster_ip : ""
   sample_app_listen_address_port = module.common.sample_app_lb_port
 
   extra_data = { msk = module.aoc_msk_cluster.cluster_data }
@@ -266,14 +266,11 @@ resource "kubernetes_service" "mocked_server_service" {
     selector = {
       app = local.aoc_label_selector
     }
-    type = "LoadBalancer"
+    type = "ClusterIP"
     port {
       port        = 80
       target_port = 8080
     }
-  }
-  timeouts {
-    create = "20m"
   }
 }
 
@@ -331,48 +328,13 @@ resource "kubernetes_service" "sample_app_service" {
       app = "sample-app"
     }
 
-    type = var.deployment_type == "fargate" ? "NodePort" : "LoadBalancer"
+    type = "ClusterIP"
 
     port {
       port        = module.common.sample_app_lb_port
       target_port = module.common.sample_app_listen_address_port
     }
   }
-  timeouts {
-    create = "20m"
-  }
 }
 
-resource "kubernetes_ingress" "app" {
-  count                  = var.deployment_type == "fargate" && local.is_otlp_base_scenario ? 1 : 0
-  wait_for_load_balancer = true
-  metadata {
-    name      = "sample-app-ingress"
-    namespace = kubernetes_namespace.aoc_fargate_ns.metadata[0].name
-    annotations = {
-      "kubernetes.io/ingress.class"           = "alb"
-      "alb.ingress.kubernetes.io/scheme"      = "internet-facing"
-      "alb.ingress.kubernetes.io/target-type" = "ip"
-    }
-    labels = {
-      "app" = "sample-app"
-    }
-  }
-
-  spec {
-    rule {
-      http {
-        path {
-          path = "/*"
-          backend {
-            service_name = kubernetes_service.sample_app_service[count.index].metadata[0].name
-            service_port = kubernetes_service.sample_app_service[count.index].spec[0].port[0].port
-          }
-        }
-      }
-    }
-  }
-
-  depends_on = [kubernetes_service.sample_app_service]
-}
 

--- a/terraform/executeTerraformTest.sh
+++ b/terraform/executeTerraformTest.sh
@@ -73,31 +73,71 @@ case ${AWS_REGION} in
     ;;
 esac
 
+ts() { date -u +"%H:%M:%S"; }
+PROGRESS_FILE="${GITHUB_STEP_SUMMARY:-/dev/null}"
+echo "| Platform | Test | Result | Duration |" >> "$PROGRESS_FILE"
+echo "|----------|------|--------|----------|" >> "$PROGRESS_FILE"
 test_framework_shortsha=$(git rev-parse --short HEAD)
 # Used as a retry mechanic.
 ATTEMPTS_LEFT=2
 cd ${TEST_FOLDER};
+
+TEST_INDEX=${TEST_INDEX:-0}
+TEST_INDEX=$((TEST_INDEX + 1))
+export TEST_INDEX
+
 while [ $ATTEMPTS_LEFT -gt 0 ] && ! ../checkCacheHit.sh $SERVICE $TESTCASE $ADDTL_PARAMS; do
-    terraform init;
-    if timeout -k 5m --signal=SIGINT -v 45m terraform apply -auto-approve -lock=false $opts  -var="testcase=../testcases/$TESTCASE" ; then
+    TESTCASE_START=$(date -u +%s)
+    echo ""
+    echo "╔══════════════════════════════════════════════════════════════"
+    echo "║ TEST ${TEST_INDEX}: ${SERVICE} / ${TESTCASE} / ${ADDTL_PARAMS}"
+    echo "╚══════════════════════════════════════════════════════════════"
+    echo "::group::${SERVICE} ${TESTCASE} ${ADDTL_PARAMS}"
+
+    echo "[$(ts)] terraform init"
+    terraform init -no-color > /dev/null 2>&1;
+
+    echo "[$(ts)] terraform apply (30m timeout)"
+    export TF_IN_AUTOMATION=true
+
+    timeout -k 5m --signal=SIGINT -v 30m terraform apply -auto-approve -lock=false -compact-warnings $opts -var="testcase=../testcases/$TESTCASE" 2>&1 | tee /tmp/tf_apply.log | grep --line-buffered -E "Creation complete|Error:|Still creating.*[0-9]0s elapsed" || true
+    TF_EXIT=${PIPESTATUS[0]}
+    if [ $TF_EXIT -eq 0 ]; then
         APPLY_EXIT=$?
-        echo "Exit code: $?" 
+        DURATION=$(( $(date -u +%s) - TESTCASE_START ))
+        echo ""
+        DURATION=$(( $(date -u +%s) - TESTCASE_START ))
+        echo ""
+        echo "  ✅ PASS: ${SERVICE} / ${TESTCASE} / ${ADDTL_PARAMS} (${DURATION}s)"
+        echo ""
         aws dynamodb put-item --region=us-west-2 --table-name ${DDB_TABLE_NAME} --item {\"TestId\":{\"S\":\"$SERVICE$TESTCASE$ADDTL_PARAMS\"}\,\"aoc_version\":{\"S\":\"$DDB_SK_PREFIX$test_framework_shortsha\"}\,\"TimeToExist\":{\"N\":\"${TTL_DATE}\"}} --return-consumed-capacity TOTAL
+        echo "| $SERVICE | $TESTCASE | :white_check_mark: pass | ${DURATION}s |" >> "$PROGRESS_FILE"
     else
-        APPLY_EXIT=$?
-        echo "Terraform apply failed"
-        echo "Exit code: $?"
-        echo "AWS_service: $SERVICE"
-        echo "Testcase: $TESTCASE" 
+        APPLY_EXIT=$TF_EXIT
+        DURATION=$(( $(date -u +%s) - TESTCASE_START ))
+        echo ""
+        echo "  ❌ FAIL: ${SERVICE} / ${TESTCASE} / ${ADDTL_PARAMS} (exit=${APPLY_EXIT}, ${DURATION}s)"
+        echo ""
+        grep -E "Error:|validator" /tmp/tf_apply.log | tail -20
+        echo "| $SERVICE | $TESTCASE | :x: fail (exit=$APPLY_EXIT) | ${DURATION}s |" >> "$PROGRESS_FILE"
     fi
 
+    echo "[$(ts)] terraform destroy"
     case "$SERVICE" in
-        EKS*) terraform destroy --auto-approve $opts;
+        EKS*) terraform destroy --auto-approve -compact-warnings $opts > /dev/null 2>&1;
         ;;
     *)
-        terraform destroy --auto-approve;
+        terraform destroy --auto-approve -compact-warnings > /dev/null 2>&1;
     ;;
     esac
+
+    echo "[$(ts)] Destroy complete"
+    echo "::endgroup::"
+
+    if [ $APPLY_EXIT -ne 0 ]; then
+        echo "Waiting 60s before retry to allow resource cleanup..."
+        sleep 60
+    fi
 
     let ATTEMPTS_LEFT=ATTEMPTS_LEFT-1
 done

--- a/terraform/templates/defaults/validator_docker_compose.tpl
+++ b/terraform/templates/defaults/validator_docker_compose.tpl
@@ -4,6 +4,7 @@ services:
   validator:
     build:
       ../../validator
+    network_mode: host
     volumes:
       - ~/.aws:/root/.aws
       - ./output:/var/output

--- a/terraform/testcases/kafka_otlp_metric_2_8_1/otconfig.tpl
+++ b/terraform/testcases/kafka_otlp_metric_2_8_1/otconfig.tpl
@@ -15,7 +15,8 @@ receivers:
 %{ for broker in split(",", extra_data["msk"].bootstrap_brokers_tls) }      - ${broker}
 %{ endfor }
     metrics:
-      topic: ${extra_data.msk.topic}
+      topics:
+        - ${extra_data.msk.topic}
 
 processors:
   batch:

--- a/terraform/testcases/kafka_otlp_metric_3_2_0/otconfig.tpl
+++ b/terraform/testcases/kafka_otlp_metric_3_2_0/otconfig.tpl
@@ -15,7 +15,8 @@ receivers:
 %{ for broker in split(",", extra_data["msk"].bootstrap_brokers_tls) }      - ${broker}
 %{ endfor }
     metrics:
-      topic: ${extra_data.msk.topic}
+      topics:
+        - ${extra_data.msk.topic}
 
 processors:
   batch:

--- a/terraform/testcases/kafka_otlp_metric_mock_2_8_1/otconfig.tpl
+++ b/terraform/testcases/kafka_otlp_metric_mock_2_8_1/otconfig.tpl
@@ -15,7 +15,8 @@ receivers:
 %{ for broker in split(",", extra_data["msk"].bootstrap_brokers_tls) }      - ${broker}
 %{ endfor }
     metrics:
-      topic: ${extra_data.msk.topic}
+      topics:
+        - ${extra_data.msk.topic}
 
 processors:
   batch:

--- a/terraform/testcases/kafka_otlp_metric_mock_3_2_0/otconfig.tpl
+++ b/terraform/testcases/kafka_otlp_metric_mock_3_2_0/otconfig.tpl
@@ -15,7 +15,8 @@ receivers:
 %{ for broker in split(",", extra_data["msk"].bootstrap_brokers_tls) }      - ${broker}
 %{ endfor }
     metrics:
-      topic: ${extra_data.msk.topic}
+      topics:
+        - ${extra_data.msk.topic}
 
 processors:
   batch:

--- a/terraform/testcases/kafka_otlp_mock_2_8_1/otconfig.tpl
+++ b/terraform/testcases/kafka_otlp_mock_2_8_1/otconfig.tpl
@@ -15,7 +15,8 @@ receivers:
 %{ for broker in split(",", extra_data["msk"].bootstrap_brokers_tls) }      - ${broker}
 %{ endfor }
     traces:
-      topic: ${extra_data.msk.topic}
+      topics:
+        - ${extra_data.msk.topic}
 
 processors:
   batch:

--- a/terraform/testcases/kafka_otlp_mock_3_2_0/otconfig.tpl
+++ b/terraform/testcases/kafka_otlp_mock_3_2_0/otconfig.tpl
@@ -15,7 +15,8 @@ receivers:
 %{ for broker in split(",", extra_data["msk"].bootstrap_brokers_tls) }      - ${broker}
 %{ endfor }
     traces:
-      topic: ${extra_data.msk.topic}
+      topics:
+        - ${extra_data.msk.topic}
 
 processors:
   batch:

--- a/terraform/testcases/kafka_otlp_trace_2_8_1/otconfig.tpl
+++ b/terraform/testcases/kafka_otlp_trace_2_8_1/otconfig.tpl
@@ -15,7 +15,8 @@ receivers:
 %{ for broker in split(",", extra_data["msk"].bootstrap_brokers_tls) }      - ${broker}
 %{ endfor }
     traces:
-      topic: ${extra_data.msk.topic}
+      topics:
+        - ${extra_data.msk.topic}
 
 processors:
   batch:

--- a/terraform/testcases/kafka_otlp_trace_3_2_0/otconfig.tpl
+++ b/terraform/testcases/kafka_otlp_trace_3_2_0/otconfig.tpl
@@ -15,7 +15,8 @@ receivers:
 %{ for broker in split(",", extra_data["msk"].bootstrap_brokers_tls) }      - ${broker}
 %{ endfor }
     traces:
-      topic: ${extra_data.msk.topic}
+      topics:
+        - ${extra_data.msk.topic}
 
 processors:
   batch:

--- a/tools/batchTestGenerator/internal/githubGenerator.go
+++ b/tools/batchTestGenerator/internal/githubGenerator.go
@@ -1,10 +1,10 @@
 package internal
 
 import (
-	"container/ring"
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 )
 
 // generates the batch keys and value json for github action utilization
@@ -67,89 +67,68 @@ func GithubGenerator(config RunConfig) error {
 
 }
 
+func displayVariant(serviceType, additionalVar string) string {
+	if strings.Contains(additionalVar, "|") {
+		parts := strings.SplitN(additionalVar, "|", 2)
+		return strings.TrimPrefix(parts[1], "collector-ci-")
+	}
+	return additionalVar
+}
+
 func createBatchMap(maxBatches int, testCases []TestCaseInfo) (map[string][]string, error) {
-	var numBatches int
-	if len(testCases) <= maxBatches {
-		numBatches = len(testCases)
-	} else {
-		numBatches = maxBatches
-	}
-
-	nonParallelTestSet := map[string][]TestCaseInfo{
-		"EKS_ADOT_OPERATOR":       {},
-		"EKS_ADOT_OPERATOR_ARM64": {},
-		"EKS_FARGATE":             {},
-	}
-
-	if numBatches == 1 {
-		nonParallelTestSet = map[string][]TestCaseInfo{}
-	} else if numBatches-len(nonParallelTestSet) <= 0 {
-		numBatches = 1
-	} else {
-		numBatches -= len(nonParallelTestSet)
-	}
-
-	// circular linked list to distribute values
-	// we reach for a circular LL to evenly distrubute values since no
-	// weighting is being done during the batching process. We just want the
-	// easiest way to distribute test cases.
-	testContainers := ring.New(numBatches)
-	for i := 0; i < numBatches; i++ {
-		testContainers.Value = make([]TestCaseInfo, 0)
-		testContainers = testContainers.Next()
-	}
-
-	// distribute tests into containers
+	// Group tests by platform + variant (AMI for EC2, cluster for EKS, launch type for ECS)
+	subGroups := make(map[string][]TestCaseInfo)
 	for _, tc := range testCases {
-		if _, ok := nonParallelTestSet[tc.serviceType]; ok {
-			nonParallelTestSet[tc.serviceType] = append(nonParallelTestSet[tc.serviceType], tc)
-		} else {
-			testContainers.Value = append(testContainers.Value.([]TestCaseInfo), tc)
-			testContainers = testContainers.Next()
-		}
-
+		key := fmt.Sprintf("%s/%s", tc.serviceType, displayVariant(tc.serviceType, tc.additionalVar))
+		subGroups[key] = append(subGroups[key], tc)
 	}
 
-	// assign containers to a batch
+	// Allocate batch slots proportionally per sub-group
 	batchMap := make(map[string][]string)
+	totalTests := len(testCases)
 
-	batch := 0
-	// non-parallel tests
-	for _, npts := range nonParallelTestSet {
-		if len(npts) == 0 {
-			continue
+	for groupKey, tests := range subGroups {
+		// Separate kafka tests into their own batch (they share MSK connections)
+		var kafkaTests []TestCaseInfo
+		var otherTests []TestCaseInfo
+		for _, tc := range tests {
+			if strings.Contains(tc.testcaseName, "kafka") {
+				kafkaTests = append(kafkaTests, tc)
+			} else {
+				otherTests = append(otherTests, tc)
+			}
+		}
+		if len(kafkaTests) > 0 {
+			// Split kafka into batches of 2 (each test takes ~10min, 2 fits in 30m timeout)
+			for i, tc := range kafkaTests {
+				batchNum := i / 2
+				id := fmt.Sprintf("%s/kafka-%d", groupKey, batchNum)
+				val := fmt.Sprintf("%s %s %s", tc.serviceType, tc.testcaseName, tc.additionalVar)
+				batchMap[id] = append(batchMap[id], val)
+			}
+		}
+		tests = otherTests
+
+		share := (len(tests) * maxBatches) / totalTests
+		if share < 1 {
+			share = 1
 		}
 
-		nptsStringArray, err := generateBachValuesStringArray(npts)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create non parallel test set string array: %w", err)
-		}
-		id := fmt.Sprintf("batch%d", batch)
-		batchMap[id] = append(batchMap[id], nptsStringArray...)
-		if batch < maxBatches {
-			batch++
-		}
-	}
+		testsPerBatch := (len(tests) + share - 1) / share
 
-	//assign following batches
-	for i := 0; i < numBatches; i++ {
-		ts := testContainers.Value.([]TestCaseInfo)
-		if len(ts) == 0 {
-			testContainers = testContainers.Next()
-			continue
-		}
-
-		batchValueStringArray, err := generateBachValuesStringArray(ts)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create batchValueString: %w", err)
-		}
-		id := fmt.Sprintf("batch%d", batch)
-		batchMap[id] = append(batchMap[id], batchValueStringArray...)
-		testContainers = testContainers.Next()
-		if batch < maxBatches {
-			batch++
+		for i, tc := range tests {
+			batchNum := i / testsPerBatch
+			var id string
+			if testsPerBatch == 1 || len(tests) <= share {
+				id = fmt.Sprintf("%s/%s", groupKey, tc.testcaseName)
+			} else {
+				id = fmt.Sprintf("%s/batch-%d", groupKey, batchNum)
+			}
+			val := fmt.Sprintf("%s %s %s", tc.serviceType, tc.testcaseName, tc.additionalVar)
+			batchMap[id] = append(batchMap[id], val)
 		}
 	}
 
 	return batchMap, nil
 }
+

--- a/validator/src/main/java/com/amazon/aoc/enums/GenericConstants.java
+++ b/validator/src/main/java/com/amazon/aoc/enums/GenericConstants.java
@@ -20,9 +20,9 @@ import lombok.Getter;
 @Getter
 public enum GenericConstants {
   // retry
-  SLEEP_IN_MILLISECONDS("20000"), // ms
-  SLEEP_IN_SECONDS("30"),
-  MAX_RETRIES("10"),
+  SLEEP_IN_MILLISECONDS("10000"), // ms
+  SLEEP_IN_SECONDS("15"),
+  MAX_RETRIES("20"),
 
   // validator env vars
   ENV_VAR_AGENT_VERSION("AGENT_VERSION"),

--- a/validator/src/main/resources/expected-data-template/container-insight/eks/fargate/Pod.json
+++ b/validator/src/main/resources/expected-data-template/container-insight/eks/fargate/Pod.json
@@ -1,40 +1,39 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "structured log schema",
-  "description": "json schema for the cloudwatch agent k8s structured log",
+  "description": "json schema for the cloudwatch agent k8s structured log - Fargate Pod type",
   "type": "object",
   "properties": {
-    "ClusterName":{},
-    "LaunchType":{},
+    "ClusterName": {},
+    "LaunchType": {},
     "Namespace": {},
-    "PodName":{},
-    "Timestamp":{},
-    "kubernetes":{
+    "PodName": {},
+    "NodeName": {},
+    "Type": {},
+    "Version": {},
+    "OTelLib": {},
+    "pod_memory_working_set": {},
+    "pod_memory_cache": {},
+    "pod_memory_max_usage": {},
+    "pod_memory_rss": {},
+    "pod_memory_swap": {},
+    "pod_memory_usage": {},
+    "kubernetes": {
       "type": "object",
       "properties": {
         "host": {},
-        "namespace_name":{},
-        "pod_name":{}
-      }
+        "namespace_name": {},
+        "pod_name": {}
+      },
+      "required": ["host", "namespace_name", "pod_name"]
     },
     "_aws": {
+      "type": "object",
       "properties": {
         "CloudWatchMetrics": {},
         "Timestamp": {}
       },
-      "required": [
-        "CloudWatchMetrics",
-        "Timestamp"
-      ]},
-      "kubernetes": {
-        "type": "object",
-        "properties": {
-          "host": {},
-          "namespace_name":{},
-          "pod_name":{}
-        },
-        "required": ["namespace_name"],
-        "additionalProperties": false
+      "required": ["CloudWatchMetrics", "Timestamp"]
     }
   },
   "required": [
@@ -42,6 +41,7 @@
     "LaunchType",
     "Namespace",
     "PodName",
-    "kubernetes"
+    "kubernetes",
+    "_aws"
   ]
- }
+}


### PR DESCRIPTION
## Summary
- Fix Windows EC2 tests (powershell wrapper, firewall, MSI silent install)
- EKS: ClusterIP + port-forward replaces LoadBalancer services
- Batch generator groups by platform/variant with kafka-dedicated batches
- Suppress terraform plan noise, add live progress table
- Validator retry: 10s x 20, parallel cache checks
- Per-batch runner IP security group
- MSK protocol_version override for auto-upgraded clusters
- Nginx LB wait replaced with reliable local-exec loop
- EKS node groups scaled to 3 (max 4)

## Test plan
- [x] Verified on CI run 26074918282 (98/100 pass rate)