### PR TITLE
Update jmx test image

### DIFF
--- a/sample-apps/jmx/Dockerfile
+++ b/sample-apps/jmx/Dockerfile
@@ -1,16 +1,11 @@
 # Build the war file
-# Build with JDK 17 (source/target stays 1.8 via the pom) on a maintained base image.
 FROM --platform=$BUILDPLATFORM maven:3.9-eclipse-temurin-17 AS build
 
 WORKDIR /app
 COPY . .
 RUN mvn package
 
-# Tomcat w/ war
-# Stay on the Tomcat 9.0 line: the sample app targets javax.servlet (Servlet 4.0);
-# Tomcat 10+ moved to the jakarta namespace and would require an app migration.
-# Use a current, supported base (Ubuntu 24.04 "noble" + Temurin JRE 21) to clear the
-# Debian 10 (EOL) OS CVEs and pick up the latest Tomcat 9.0.x patch release.
+# Tomcat w/ war (stay on 9.0 line: app targets javax.servlet / Servlet 4.0)
 FROM tomcat:9.0-jre21-temurin-noble
 ARG AGENT_VER=0.12.0
 

--- a/sample-apps/jmx/Dockerfile
+++ b/sample-apps/jmx/Dockerfile
@@ -1,12 +1,17 @@
 # Build the war file
-FROM --platform=$BUILDPLATFORM maven:3.9-eclipse-temurin-8 AS build
+# Build with JDK 17 (source/target stays 1.8 via the pom) on a maintained base image.
+FROM --platform=$BUILDPLATFORM maven:3.9-eclipse-temurin-17 AS build
 
 WORKDIR /app
 COPY . .
 RUN mvn package
 
 # Tomcat w/ war
-FROM tomcat:9.0-jdk8-openjdk
+# Stay on the Tomcat 9.0 line: the sample app targets javax.servlet (Servlet 4.0);
+# Tomcat 10+ moved to the jakarta namespace and would require an app migration.
+# Use a current, supported base (Ubuntu 24.04 "noble" + Temurin JRE 21) to clear the
+# Debian 10 (EOL) OS CVEs and pick up the latest Tomcat 9.0.x patch release.
+FROM tomcat:9.0-jre21-temurin-noble
 ARG AGENT_VER=0.12.0
 
 # Download JMX exporter agent

--- a/terraform/eks/jmx/jmx.tf
+++ b/terraform/eks/jmx/jmx.tf
@@ -34,9 +34,7 @@ output "metric_dimension_namespace" {
 
 locals {
   traffic_generator_image = "${var.sample_app_image_repo}:traffic-generator"
-  # Use the :jmx-latest tag produced by terraform/imagebuild (built from
-  # sample-apps/jmx/Dockerfile) so the deployed image tracks the maintained,
-  # CI-rebuilt artifact instead of the stale hand-pushed :tomcatapp tag.
+  # :jmx-latest is built/pushed by terraform/imagebuild from sample-apps/jmx/Dockerfile.
   jmx_sample_app_image = "${var.sample_app_image_repo}:jmx-latest"
 }
 

--- a/terraform/eks/jmx/jmx.tf
+++ b/terraform/eks/jmx/jmx.tf
@@ -34,7 +34,10 @@ output "metric_dimension_namespace" {
 
 locals {
   traffic_generator_image = "${var.sample_app_image_repo}:traffic-generator"
-  jmx_sample_app_image    = "${var.sample_app_image_repo}:tomcatapp"
+  # Use the :jmx-latest tag produced by terraform/imagebuild (built from
+  # sample-apps/jmx/Dockerfile) so the deployed image tracks the maintained,
+  # CI-rebuilt artifact instead of the stale hand-pushed :tomcatapp tag.
+  jmx_sample_app_image = "${var.sample_app_image_repo}:jmx-latest"
 }
 
 resource "kubernetes_namespace" "jmx_ns" {

--- a/terraform/eks/variables.tf
+++ b/terraform/eks/variables.tf
@@ -25,6 +25,8 @@ variable "mock_endpoint" {
 // To rebuild images, please follow the documents:
 // appmesh: https://github.com/aws/aws-app-mesh-examples/tree/master/walkthroughs/howto-k8s-http-headers
 // jmx: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights-Prometheus-Sample-Workloads-javajmx.html
+// The :tomcatapp image is built from sample-apps/jmx/Dockerfile. Rebuild and re-push it
+// periodically to pick up base-image security patches (it is scanned by Inspector / CVM).
 // Don't forget to re-tag the images to ${sample_app_image_repo}:(feapp|colorapp|tomcatapp) before pushing to remote.
 variable "sample_app_image_repo" {
   default = "611364707713.dkr.ecr.us-west-2.amazonaws.com/otel-test/container-insight-samples"


### PR DESCRIPTION
**Description:**

The EKS jmx test deployed the `:tomcatapp` image tag, which was hand-pushed in 2021 (Debian 10 EOL / Tomcat 9.0.33) and never rebuilt. Two fixes:

- **Base image:** bump `sample-apps/jmx/Dockerfile` to `tomcat:9.0-jre21-temurin-noble` (Ubuntu 24.04) and build stage to `maven:3.9-eclipse-temurin-17`. Stays on the Tomcat 9.0 line since the app targets `javax.servlet` (Servlet 4.0).
- **Tag mismatch:** `terraform/imagebuild` builds and pushes `:jmx-latest`, but the test deployed `:tomcatapp`, so rebuilds never reached it. `terraform/eks/jmx/jmx.tf` now deploys `:jmx-latest`.

On merge, `update-test-images.yml` rebuilds `:jmx-latest` and subsequent test runs use it.

**Testing:** Built the Dockerfile locally (linux/amd64) — image reports Ubuntu 24.04, Tomcat 9.0.118, Temurin 21, war + JMX agent intact. `terraform fmt` clean. Full E2E via CI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.