### PR TITLE
Resolve jmx app image from sample-apps repo

### DIFF
--- a/terraform/eks/jmx/jmx.tf
+++ b/terraform/eks/jmx/jmx.tf
@@ -34,8 +34,10 @@ output "metric_dimension_namespace" {
 
 locals {
   traffic_generator_image = "${var.sample_app_image_repo}:traffic-generator"
-  # :jmx-latest is built/pushed by terraform/imagebuild from sample-apps/jmx/Dockerfile.
-  jmx_sample_app_image = "${var.sample_app_image_repo}:jmx-latest"
+  # terraform/imagebuild pushes :jmx-latest to the otel-test/sample-apps repo, so resolve
+  # the jmx app image there (traffic-generator still lives in container-insight-samples).
+  jmx_app_image_repo   = replace(var.sample_app_image_repo, "/container-insight-samples", "/sample-apps")
+  jmx_sample_app_image = "${local.jmx_app_image_repo}:jmx-latest"
 }
 
 resource "kubernetes_namespace" "jmx_ns" {


### PR DESCRIPTION
**Description:**

Follow-up to #1841. That PR pointed the jmx EKS deployment at `:jmx-latest`, but the jmx module's default repo is `otel-test/container-insight-samples`, while `terraform/imagebuild` pushes `:jmx-latest` to `otel-test/sample-apps`. The tag therefore did not exist in the repo the deploy reads, so the jmx app image would fail to pull.

Resolve the jmx app image from the `sample-apps` repo (where the CI-built `:jmx-latest` lives). The traffic-generator image is unchanged and continues to resolve from `container-insight-samples`, where it exists.

**Testing:** Confirmed `otel-test/sample-apps:jmx-latest` exists (pushed by the imagebuild run on #1841 merge) and `otel-test/container-insight-samples:traffic-generator` exists. `terraform fmt` clean.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.